### PR TITLE
Add Utilities and Bug/Runtime Fixes

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -26,7 +26,8 @@ def trim_wifi(string):
 
 
 def fan_to_percent(speed):
-    return round(int(speed) / 15) * 100
+    percentage = (int(speed) / 15) * 100
+    return math.ceil( percentage / 10) * 10
 
 
 # Temperature(bed_temp=14, target_bed_temp=0, chamber_temp=20, nozzle_temp=25, target_nozzle_temp=0)
@@ -108,7 +109,6 @@ SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         key="aux_fan_speed",
         name="Aux Fan Speed",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=SensorDeviceClass.SPEED,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:fan",
         value_fn=lambda device: device.fans.aux_fan_speed
@@ -117,7 +117,6 @@ SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         key="chamber_fan_speed",
         name="Chamber Fan Speed",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=SensorDeviceClass.SPEED,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:fan",
         value_fn=lambda device: device.fans.chamber_fan_speed
@@ -126,7 +125,6 @@ SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         key="cooling_fan_speed",
         name="Cooling Fan Speed",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=SensorDeviceClass.SPEED,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:fan",
         value_fn=lambda device: device.fans.cooling_fan_speed
@@ -135,9 +133,21 @@ SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         key="heatbreak_fan_speed",
         name="Heatbreak Fan Speed",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=SensorDeviceClass.SPEED,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:fan",
         value_fn=lambda device: device.fans.heatbreak_fan_speed
     ),
+    BambuLabSensorEntityDescription(
+        key="speed_profile",
+        name="Speed Profile",
+        icon="mdi:speedometer",
+        value_fn=lambda device: device.speed.name
+        #json attributes? lambda device: {"modifier": device.speed.modifier}
+    ),
+    BambuLabSensorEntityDescription(
+        key="stage",
+        name="Current Stage",
+        icon="mdi:file-tree",
+        value_fn=lambda device: device.stage.description
+    )
 )

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -57,7 +57,7 @@ class BambuClient:
 
             self._device.update_from_dict(data=json_data.get("print"))
 
-        return self._callback(self._device)
+        #return self._callback(self._device)
 
     def subscribe(self, serial):
         """Subscribe to report topic"""

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -1,3 +1,62 @@
 import logging
 
 LOGGER = logging.getLogger(__package__)
+
+ACTION_IDS = {
+    "default": "Unknown",
+    -1: "Idle",
+    0: "Printing",
+    1: "Auto Bed Leveling",
+    2: "Heatbed Preheating",
+    3: "Sweeping XY Mech Mode",
+    4: "Changing Filament",
+    5: "M400 Pause",
+    6: "Paused due to filament runout",
+    7: "Heating Hotend",
+    8: "Calibrating Extrusion",
+    9: "Scanning Bed Surface",
+    10: "Inspecting First Layer",
+    11: "Identifying Build Plate Type",
+    12: "Calibrating Micro Lidar",
+    13: "Homing Toolhead",
+    14: "Cleaning Nozzle Tip",
+    15: "Checking Extruder Temperature",
+    16: "Printing was paused by the user",
+    17: "Pause of front cover falling",
+    18: "Calibrating Micro Lidar",
+    19: "Calibrating Extrusion Flow",
+    20: "Paused due to nozzle temperature malfunction",
+    21: "Paused due to heat bed temperature malfunction"
+}
+
+SPEED_PROFILE = {
+    "default": "Unknown",
+    1: "Silent",
+    2: "Standard",
+    3: "Sport",
+    4: "Ludicrous"
+}
+
+FILAMENT_NAMES = {
+    "default": "Unknown",
+    "GFU99": "Generic TPU",
+    "GFS99": "Generic PVA",
+    "GFL98": "Generic PLA-CF",
+    "GFL99": "Generic PLA",
+    "GFG99": "Generic PETG",
+    "GFC99": "Generic PC",
+    "GFN98": "Generic PA-CF",
+    "GFN99": "Generic PA",
+    "GFB98": "Generic ASA",
+    "GFB99": "Generic ABS",
+    "GFU01": "Bambu TPU 95A",
+    "GFS00": "Bambu Support W",
+    "GFS01": "Bambu Support G",
+    "GFA01": "Bambu PLA Matte",
+    "GFA00": "Bambu PLA Basic",
+    "GFC00": "Bambu PC",
+    "GFN03": "Bambu PA-CF",
+    "GFB00": "Bambu ABS",
+    "GFL01": "PolyTerra PLA",
+    "GFL00": "PolyLite PLA"
+}

--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -1,4 +1,8 @@
-def search(lst, predicate, default=None):
+import math
+
+from .const import ACTION_IDS, SPEED_PROFILE, FILAMENT_NAMES
+
+def search(lst, predicate, default={}):
     """Search an array for a string"""
     for item in lst:
         if predicate(item):
@@ -8,10 +12,24 @@ def search(lst, predicate, default=None):
 
 def fan_percentage(speed):
     """Converts a fan speed to percentage"""
-    return round((int(speed) / 15) * 100)
-
+    if not speed:
+        return 0
+    percentage = (int(speed) / 15) * 100
+    return math.ceil( percentage / 10) * 10
 
 def to_whole(number):
     if not number:
         return 0
     return round(number)
+
+def get_filament_name(idx):
+    """Converts a filament idx to a human-readable name"""
+    return FILAMENT_NAMES.get(idx, "Unknown")
+
+def get_speed_name(_id):
+    """Return the human-readable name for a speed id"""
+    return SPEED_PROFILE.get(int(_id), "Unknown")
+
+def get_stage_action(_id):
+    """Return the human-readable description for a stage action"""
+    return ACTION_IDS.get(_id, "Unknown")


### PR DESCRIPTION
- Added utilities and sensors for speed profile and stage/action parsing
- Added translations for filament IDX's for future use
- Fixed math of fan percentages to reflect true percentage.
- Fixed issues with state-updates causing runtime errors. Wifi sensor and Light update_from_dict methods were not working when another state (such as speed profile) was updated.
- Fixed not-thread-safe code execution in mqtt client callback. This may also be a versioning issue if it didn't occur for you, but by commenting out/removing the return to callback in the on_message, I no longer got a Runtime error loading the component caused by a not-thread-safe execution.

Notes:

- It may be a good idea in the future to add translations for values such as speed profiles, filaments names, stages etc. 
- I'm not sure how the SensorEntityDescription works, but I do not see how to add json attributes to a sensor, so we can't enrich a sensor entity with additional details (such as speed percentage modifier on the speed profile, or multiple data points on a future AMS tray filament sensor).
- I added the Speed Profile as a sensor, however down the road if you want to implement controlling the printer such as toggling lights or changing speed profile, this would work well as a Select entity.

![image](https://user-images.githubusercontent.com/12175651/212522371-573c2cc9-2b7d-4eda-9a8f-366fd611c577.png)
