### PR TITLE
Fix integration rename and reload

### DIFF
--- a/custom_components/bambu_lab/__init__.py
+++ b/custom_components/bambu_lab/__init__.py
@@ -1,5 +1,7 @@
 """The Bambu Lab component."""
 
+import asyncio
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -27,20 +29,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Reload entry when its updated.
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+
     LOGGER.debug("Async Setup Entry Complete")
     return True
 
-
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload the Bambu Lab integration."""
-    # no data stored in hass.data
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        coordinator: BambuDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-        del hass.data[DOMAIN][entry.entry_id]
+    LOGGER.debug("async_unload_entry")
 
-    LOGGER.debug("Async Setup Unload")
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    # Unload the platforms
+    LOGGER.debug(f"async_unload_entry: {PLATFORMS}")
+    await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
+    # Halt the mqtt listener thread
+    coordinator: BambuDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.shutdown()
+
+    # Do this because the sample has us do it. Doesn't seem to do anything.
+    del hass.data[DOMAIN][entry.entry_id]
+
+    LOGGER.debug("Async Setup Unload Done")
+    return True
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload the config entry when it changed."""

--- a/custom_components/bambu_lab/__init__.py
+++ b/custom_components/bambu_lab/__init__.py
@@ -1,7 +1,5 @@
 """The Bambu Lab component."""
 
-import asyncio
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -63,6 +63,10 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
 
         asyncio.create_task(listen())
 
+    def shutdown(self) -> None:
+        """ Halt the MQTT listener thread """
+        self.client.disconnect()
+
     async def _publish(self, msg):
         return self.client.publish(msg)
 

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -48,10 +48,6 @@ def listen_thread(self):
                 time.sleep(1)
             self.client.disconnect()
 
-        if self._exitListenerThread:
-            LOGGER.debug("MQTT listener thread exiting.")
-            break
-
 @dataclass
 class BambuClient:
     """Initialize Bambu Client to connect to MQTT Broker"""
@@ -66,7 +62,6 @@ class BambuClient:
         self._device = Device(device_type)
         self._device.add_serial(self._serial)
         self._port = 1883
-        self._exitListenerThread = False
 
     @property
     def connected(self):
@@ -87,8 +82,6 @@ class BambuClient:
         self._port = 8883
         self.client.username_pw_set("bblp", password=self._access_code)
 
-        self._exitListenerThread = False
-        
         LOGGER.debug("Starting MQTT listener thread")
         thread = Thread(target=listen_thread, args=(self,))
         thread.start()
@@ -168,7 +161,6 @@ class BambuClient:
     def disconnect(self):
         """Disconnect the Bambu Client from server"""
         LOGGER.debug("Disconnect: Client Disconnecting")
-        self._exitListenerThread = True
         self.client.disconnect()
 
     async def try_connection(self):


### PR DESCRIPTION
The stock code was unloading the platforms twice which blew up with errors as a result. That was the main fix.

I also fixed the fact we leave the listener thread orphaned permanently so each rename would spin up a new listener thread and leave the old one(s) running. That didn't seem to cause any user visible misbehavior but it's inefficient so fixed that while I was here.

Fixes #57 