### PR TITLE
Remove chamber fan for P1P

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -126,7 +126,8 @@ SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:fan",
-        value_fn=lambda device: device.fans.chamber_fan_speed
+        value_fn=lambda device: device.fans.chamber_fan_speed,
+        exists_fn=lambda device: device.supports_feature(Features.CHAMBER_FAN)
     ),
     BambuLabSensorEntityDescription(
         key="cooling_fan_speed",

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -6,9 +6,10 @@ LOGGER = logging.getLogger(__package__)
 class Features(Enum):
     AUX_FAN = 1,
     CHAMBER_LIGHT = 2,
-    CHAMBER_TEMPERATURE = 3,
-    CURRENT_STAGE = 3,
-    PRINT_LAYERS = 4
+    CHAMBER_FAN = 3,
+    CHAMBER_TEMPERATURE = 4,
+    CURRENT_STAGE = 5,
+    PRINT_LAYERS = 6
 
 ACTION_IDS = {
     "default": "Unknown",

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -33,6 +33,8 @@ class Device:
             return self.info.device_type == "X1" or self.info.device_type == "X1C" or self.info.device_type == "P1P"
         if feature == Features.CHAMBER_LIGHT:
             return self.info.device_type == "X1" or self.info.device_type == "X1C" or self.info.device_type == "P1P"
+        if feature == Features.CHAMBER_FAN:
+            return self.info.device_type == "X1" or self.info.device_type == "X1C"
         if feature == Features.CHAMBER_TEMPERATURE:
             return self.info.device_type == "X1" or self.info.device_type == "X1C"
         if feature == Features.CURRENT_STAGE:


### PR DESCRIPTION
P1P doesn't have a chamber fan so we shouldn't be creating that entity for it.

Fixes #72