### PR TITLE
Assume printer is X1C if device_type is unset

### DIFF
--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -26,7 +26,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         self._entry = entry
         self._hass = hass
         LOGGER.debug(f"ConfigEntry.Id: {entry.entry_id}")
-        self.client = BambuClient(device_type = entry.data["device_type"],
+        self.client = BambuClient(device_type = entry.data.get("device_type", "X1C"),
                                   serial = entry.data["serial"],
                                   host = entry.data["host"],
                                   access_code = entry.data["access_code"])


### PR DESCRIPTION
If device_type is unset, assume X1C to unblock upgrades. Will follow up with a fix to add the missing data separately with the correctly discovered printer model.

Should fix #71 