### PR TITLE
Fix corrupted speed string

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -200,8 +200,8 @@ class Speed:
     def __init__(self):
         """Load from dict"""
         self._id = 0
-        self.name = get_speed_name(0),
-        self.modifier = 0
+        self.name = get_speed_name(2)
+        self.modifier = 100
 
     def update(self, data):
         """Update from dict"""


### PR DESCRIPTION
The trailing comma:
self.name = get_speed_name(0),
when initializing the default value for Speed was the cause of the text sometimes briefly showing as:
('Unknown',)

Fixed by removing the comma. And changed the default to 'Standard' since that's a more pleasing thing to show and almost certainly correct. If not it'll be fixed up a few seconds later.

Fixes #18 