### PR TITLE
Fixup missing device type

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -200,8 +200,8 @@ class Speed:
     def __init__(self):
         """Load from dict"""
         self._id = 0
-        self.name = get_speed_name(0),
-        self.modifier = 0
+        self.name = get_speed_name(2)
+        self.modifier = 100
 
     def update(self, data):
         """Update from dict"""


### PR DESCRIPTION
Detect missing or mis-matched device type once we we know what the printer is from the mqtt version info. And then fix up the HA ConfigEntry to match.

Fixes #78 