### PR TITLE
Fix reconfigure error by returning expected result type

### DIFF
--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -131,7 +131,7 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     return self.async_create_entry(
                         title=self.config_data["serial"],
                         data={
-                            "device_type": "",
+                            "device_type": self.config_date["device_type"],
                             "serial": self.config_data["serial"],
                             "host": "us.mqtt.bambulab.com",
                             "access_code": authToken,

--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -131,7 +131,7 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     return self.async_create_entry(
                         title=self.config_data["serial"],
                         data={
-                            "device_type": self.config_date["device_type"],
+                            "device_type": self.config_data["device_type"],
                             "serial": self.config_data["serial"],
                             "host": "us.mqtt.bambulab.com",
                             "access_code": authToken,

--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -131,7 +131,7 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     return self.async_create_entry(
                         title=self.config_data["serial"],
                         data={
-                            "device_type": self.config_data["device_type"],
+                            "device_type": "",
                             "serial": self.config_data["serial"],
                             "host": "us.mqtt.bambulab.com",
                             "access_code": authToken,
@@ -257,7 +257,7 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
 
                 if success:
                     LOGGER.debug("Config Flow: Writing new entry")
-                    return self.hass.config_entries.async_update_entry(
+                    self.hass.config_entries.async_update_entry(
                         self.config_entry,
                         title=self.config_data["serial"],
                         data={
@@ -267,6 +267,7 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
                             "access_code": authToken,
                         }
                     )
+                    return self.async_create_entry(title="", data={})
             
             errors["base"] = "cannot_connect"
         
@@ -294,7 +295,7 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
 
             if success:
                 LOGGER.debug("Config Flow: Writing new entry")
-                return self.hass.config_entries.async_update_entry(
+                self.hass.config_entries.async_update_entry(
                     self.config_entry,
                     title=self.config_data["serial"],
                     data={
@@ -304,6 +305,7 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
                         "access_code": user_input["access_code"],
                     }
                 )
+                return self.async_create_entry(title="", data={})
             
             errors["base"] = "cannot_connect"
 

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -28,7 +28,6 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         self._hass = hass
         self._entry = entry
         LOGGER.debug(f"ConfigEntry.Id: {entry.entry_id}")
-        LOGGER.debug(f"ConfigEntry.data: {entry.data}")
         self.client = BambuClient(device_type = entry.data.get("device_type", "X1C"),
                                   serial = entry.data["serial"],
                                   host = entry.data["host"],

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -28,6 +28,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         self._hass = hass
         self._entry = entry
         LOGGER.debug(f"ConfigEntry.Id: {entry.entry_id}")
+        LOGGER.debug(f"ConfigEntry.data: {entry.data}")
         self.client = BambuClient(device_type = entry.data.get("device_type", "X1C"),
                                   serial = entry.data["serial"],
                                   host = entry.data["host"],


### PR DESCRIPTION
hass.config_entries.async_update_entry returns a bool not a FlowResult like async_create_entry. Because... of course it does. Copy the mqtt integrations way of dealing with this inconsistency.

Fixed #85 