### PR TITLE
Adjust HMS attribute structure

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -208,7 +208,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         icon="mdi:alert",
         entity_category=EntityCategory.DIAGNOSTIC,
         available_fn = lambda self: True,
-        value_fn=lambda self: int(len(self.coordinator.get_model().hms.errors)/3),
+        value_fn=lambda self: int(len(self.coordinator.get_model().hms.errors)/2),
         extra_attributes=lambda self: self.coordinator.get_model().hms.errors
     ),
 )

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -530,6 +530,5 @@ class HMSList:
                 code = hms['code']
                 hms_error = f'{int(attr/0x10000):0>4X}_{attr&0xFFFF:0>4X}_{int(code/0x10000):0>4X}_{code&0xFFFF:0>4X}' # 0300_0100_0001_0007
                 LOGGER.warning(f"HMS ERROR: HMS_{hms_error} : {get_HMS_error_text(hms_error)}")
-                self.errors[f"{index} HMS code"] = f"HMS_{hms_error}"
-                self.errors[f"{index} URL"] = f"https://wiki.bambulab.com/en/x1/troubleshooting/hmscode/{hms_error}"
-                self.errors[f"{index} Text Description"] = f"{get_HMS_error_text(hms_error)}"
+                self.errors[f"{index}-Error"] = f"HMS_{hms_error}: {get_HMS_error_text(hms_error)}"
+                self.errors[f"{index}-Wiki"] = f"https://wiki.bambulab.com/en/x1/troubleshooting/hmscode/{hms_error}"

--- a/custom_components/bambu_lab/sensor.py
+++ b/custom_components/bambu_lab/sensor.py
@@ -54,7 +54,8 @@ class BambuLabSensor(BambuLabEntity, SensorEntity):
         """Initialize the sensor."""
         self.coordinator = coordinator
         self.entity_description = description
-        self._attr_unique_id = f"{config_entry.data['serial']}_{description.key}"
+        printer = coordinator.get_model().info
+        self._attr_unique_id = f"{printer.serial}_{description.key}"
         super().__init__(coordinator=coordinator)
 
     @property


### PR DESCRIPTION
Reduce to two entries per error to create a subjectively slightly cleaner appearance while still giving good access to both descriptive text and the wiki URL.