### PR TITLE
Add binary sensor support. Use it for timelapse running

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ For now, you will need the following information:
 
 Cloud Mode MQTT connection:
 - Registed Bambu email address & password.
-  If you signed up using any OAuth method, you need to set a password for your Bambu Cloud account:
-  - Login to the Bambu mobile app using OAuth.
-  - Tap the person icon at the bottom right.
-  - Tap Account Security > Change Password
-  Now you can login to the HA integration using your Bambu username and that password.
 - Your full credentials will not be saved but an authentication token that's generated using them will be saved into the home assistant store.
 - The token expires after 360 days. You can re-auth using the configuration button on the integrations page.
+
+If you signed up using any OAuth method, you need to set a password for your Bambu Cloud account:
+- Login to the Bambu mobile app using OAuth.
+- Tap the person icon at the bottom right.
+- Tap Account Security > Change Password
+Now you can login to the HA integration using your Bambu username and that password.
 
 Lan mode MQTT connection:
 - Printer IP
@@ -59,6 +60,7 @@ In the latest firmware update, Bambu Lab added back the ability to connect to th
 | Start Time                | :white_check_mark: | :white_check_mark: | :x:                |
 | Target Bed Temperature    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Total Layer Count         | :white_check_mark: | :white_check_mark: | :x:                |
+| Timelapse Active          | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 If AMS(s) are present, an additional 'Current Tray' sensor is present on the Printer device.
 

--- a/custom_components/bambu_lab/binary_sensor.py
+++ b/custom_components/bambu_lab/binary_sensor.py
@@ -1,0 +1,53 @@
+"""Support for Bambu Lab through MQTT."""
+from __future__ import annotations
+import json
+from homeassistant.components import mqtt
+from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorDeviceClass
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.util import slugify
+from homeassistant.helpers.entity import DeviceInfo
+
+from .const import DOMAIN, LOGGER
+from .definitions import PRINTER_BINARY_SENSORS, BambuLabBinarySensorEntityDescription
+from .coordinator import BambuDataUpdateCoordinator
+from .models import BambuLabEntity
+from .pybambu.const import Features
+
+
+async def async_setup_entry(
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up BambuLab sensor based on a config entry."""
+    coordinator: BambuDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    for sensor in PRINTER_BINARY_SENSORS:    
+        if sensor.exists_fn(coordinator):
+            async_add_entities([BambuLabBinarySensor(coordinator, sensor, entry)])
+
+
+class BambuLabBinarySensor(BambuLabEntity, BinarySensorEntity):
+    """Representation of a BambuLab that is updated via MQTT."""
+
+    def __init__(
+            self,
+            coordinator: BambuDataUpdateCoordinator,
+            description: BambuLabBinarySensorEntityDescription,
+            config_entry: ConfigEntry
+    ) -> None:
+        """Initialize the sensor."""
+        self.coordinator = coordinator
+        self.entity_description = description
+        printer = coordinator.get_model().info
+        self._attr_unique_id = f"{printer.serial}_{description.key}"
+        super().__init__(coordinator=coordinator)
+    
+    @property
+    def is_on(self) -> bool:
+        """Return if binary sensor is on."""
+        return self.entity_description.is_on_fn(self)

--- a/custom_components/bambu_lab/const.py
+++ b/custom_components/bambu_lab/const.py
@@ -13,5 +13,6 @@ SCAN_INTERVAL = timedelta(seconds=60)
 PLATFORMS = (
     Platform.LIGHT,
     Platform.SENSOR,
+    Platform.BINARY_SENSOR,
     Platform.BUTTON
 )

--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -25,6 +25,10 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntityDescription
+)
 
 def fan_to_percent(speed):
     percentage = (int(speed) / 15) * 100
@@ -44,6 +48,28 @@ class BambuLabSensorEntityDescription(SensorEntityDescription, BambuLabSensorEnt
     exists_fn: Callable[..., bool] = lambda _: True
     extra_attributes: Callable[..., dict] = lambda _: {}
 
+
+@dataclass
+class BambuLabBinarySensorEntityDescriptionMixIn:
+    """Mixin for required keys."""
+    is_on_fn: Callable[..., bool]
+
+
+@dataclass
+class BambuLabBinarySensorEntityDescription(BinarySensorEntityDescription, BambuLabBinarySensorEntityDescriptionMixIn):
+    """Sensor entity description for Bambu Lab."""
+    exists_fn: Callable[..., bool] = lambda _: True
+
+
+PRINTER_BINARY_SENSORS: tuple[BambuLabBinarySensorEntityDescription, ...] = (
+    BambuLabBinarySensorEntityDescription(
+        key="timelapse",
+        name="Recording TimeLapse",
+        icon="mdi:camera",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        is_on_fn=lambda self: self.coordinator.get_model().info.timelapse == 'enabled'
+    ),
+)
 
 PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
     BambuLabSensorEntityDescription(
@@ -193,12 +219,6 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         icon="mdi:printer-3d-nozzle",
         value_fn=lambda self: self.coordinator.get_model().info.total_layers,
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.PRINT_LAYERS)
-    ),
-    BambuLabSensorEntityDescription(
-        key="timelapse",
-        name="TimeLapse",
-        icon="mdi:camera",
-        value_fn=lambda self: self.coordinator.get_model().info.timelapse,
     ),
     BambuLabSensorEntityDescription(
         key="tray_now",

--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -163,6 +163,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         key="start_time",
         name="Start Time",
         icon="mdi:clock",
+        available_fn = lambda self: self.coordinator.get_model().info.start_time != 0,
         value_fn=lambda self: self.coordinator.get_model().info.start_time,
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.START_TIME)
     ),
@@ -207,7 +208,6 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         name="HMS Errors",
         icon="mdi:alert",
         entity_category=EntityCategory.DIAGNOSTIC,
-        available_fn = lambda self: True,
         value_fn=lambda self: int(len(self.coordinator.get_model().hms.errors)/2),
         extra_attributes=lambda self: self.coordinator.get_model().hms.errors
     ),

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -383,7 +383,7 @@ class AMSList:
         # }
 
         data = data.get('param', '')
-        if data.startswith('[AMS][TASK]ams'):
+        if data.startswith('[AMS][TASK]ams') and data.find('humidity') != -1:
             LOGGER.debug(data)
             data = data[14:]
             LOGGER.debug(data)

--- a/custom_components/bambu_lab/sensor.py
+++ b/custom_components/bambu_lab/sensor.py
@@ -72,7 +72,7 @@ class BambuLabSensor(BambuLabEntity, SensorEntity):
     def available(self) -> bool:
         """Return if entity is available."""
         return self.entity_description.available_fn(self)
-
+    
 
 class BambuLabAMSSensor(AMSEntity, SensorEntity):
     """Representation of a BambuLab AMS that is updated via MQTT."""


### PR DESCRIPTION
Should also fix the exceptions for other mc_print events.
And fix the brief 1970 start time by making the sensor unavailable until the non-zero data arrives.
These are both X1 only fixes so untested.