### PR TITLE
Enable External Spool for X1

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,19 +99,19 @@ This currently exposes the following Buttons:
 | Name                      | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Type                      | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
-### External Spool (P1P only)
+### External Spool
 
 | Sensor                    | X1C                | X1                 | P1P                |
 |---------------------------|--------------------|--------------------|--------------------|
-| External Spool            | :x:                | :x:                | :white_check_mark: |
+| External Spool            | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Attributes:               |                    |                    |                    |
-| Active                    | :x:                | :x:                | :white_check_mark: |
-| Color                     | :x:                | :x:                | :white_check_mark: |
+| Active                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Color                     | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | K Value                   | :x:                | :x:                | :white_check_mark: |
-| Max Nozzle Temp           | :x:                | :x:                | :white_check_mark: |
-| Min Nozzle Temp           | :x:                | :x:                | :white_check_mark: |
-| Name                      | :x:                | :x:                | :white_check_mark: |
-| Type                      | :x:                | :x:                | :white_check_mark: |
+| Max Nozzle Temp           | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Min Nozzle Temp           | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Name                      | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Type                      | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 ### Diagnostics
 

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -59,7 +59,7 @@ class Device:
         if feature == Features.AMS:
             return len(self.ams.data) != 0
         if feature == Features.EXTERNAL_SPOOL:
-            return self.info.device_type == "P1P"
+            return self.info.device_type == "X1" or self.info.device_type == "X1C" or self.info.device_type == "P1P"
         if feature == Features.K_VALUE:
             return self.info.device_type == "P1P"
         if feature == Features.START_TIME:


### PR DESCRIPTION
The latest firmware update enabled the same virtual tray data in the mqtt payload on the X1 as the P1P already had. This release enables the support for that for the X1 printers.