### PR TITLE
Suppress Bambu Cloud MQTT connection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,27 +12,10 @@ To install, add this Github Repo to the HACS Custom Repositories, or click the b
 
 For now, you will need the following information:
 
-Cloud Mode MQTT connection:
-- Registed Bambu email address & password.
-- Your full credentials will not be saved but an authentication token that's generated using them will be saved into the home assistant store.
-- The token expires after 360 days. You can re-auth using the configuration button on the integrations page.
-
-If you signed up using any OAuth method, you need to set a password for your Bambu Cloud account:
-- Login to the Bambu mobile app using OAuth.
-- Tap the person icon at the bottom right.
-- Tap Account Security > Change Password
-Now you can login to the HA integration using your Bambu username and that password.
-
-Lan mode MQTT connection:
 - Printer IP
 - LAN Access Code (Can be found on the Printer settings)
-
-Both:
 - Serial Number (Can be found in the printer settings or in Bambu Studio)
 
-### P1P Owners
-
-In the latest firmware update, Bambu Lab added back the ability to connect to the local MQTT server on the printer even in cloud mode. But the ability to use cloud MQTT will remain in case that changes again in a future update.
 
 ## Features
 

--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -41,8 +41,8 @@ PRINTER_SELECTOR = SelectSelector(
     )
 )
 SUPPORTED_MODES = [
-    SelectOptionDict(value="Bambu", label="Bambu Cloud"),
-    SelectOptionDict(value="Lan", label="Lan Mode"),
+    SelectOptionDict(value="Bambu", label="Bambu Cloud MQTT Connection"),
+    SelectOptionDict(value="Lan", label="Local MQTT Connection"),
 ]
 MODE_SELECTOR = SelectSelector(
     SelectSelectorConfig(
@@ -57,7 +57,9 @@ def get_authentication_token(username: str, password: str) -> dict:
     data = { 'account':username, 'password':password }
     response = requests.post(url, json=data, timeout=10)
     if not response.ok:
+        LOGGER.debug(f"Received error: {response.status_code}")
         raise ValueError(response.status_code)
+    LOGGER.debug(f"Success: {response.json()}")
     return response.json()
 
 class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -65,6 +67,7 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
     config_data: dict[str, Any] = {}
+    cloud_supported: bool = False
 
     @staticmethod
     @callback
@@ -83,16 +86,17 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             self.config_data = user_input
-            if (user_input["printer_mode"] == "Bambu"):
-                return await self.async_step_Bambu(None)
-            if (user_input["printer_mode"] == "Lan"):
+            if not self.cloud_supported or (user_input["printer_mode"] == "Lan"):
                 return await self.async_step_Lan(None)
+            if self.cloud_supported and (user_input["printer_mode"] == "Bambu"):
+                return await self.async_step_Bambu(None)
         
         # Build form
         fields: OrderedDict[vol.Marker, Any] = OrderedDict()
         fields[vol.Required("device_type")] = PRINTER_SELECTOR
         fields[vol.Required("serial")] = TEXT_SELECTOR
-        fields[vol.Required("printer_mode")] = MODE_SELECTOR
+        if self.cloud_supported:
+            fields[vol.Required("printer_mode")] = MODE_SELECTOR
 
         return self.async_show_form(
             step_id="user",
@@ -217,14 +221,15 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
             self.config_data = user_input
             self.config_data['device_type'] = self.config_entry.data['device_type']
             self.config_data['serial'] = self.config_entry.data['serial']
-            if (user_input["printer_mode"] == "Bambu"):
-                return await self.async_step_Bambu(None)
-            if (user_input["printer_mode"] == "Lan"):
+            if not self.cloud_supported or (user_input["printer_mode"] == "Lan"):
                 return await self.async_step_Lan(None)
+            if self.cloud_supported and (user_input["printer_mode"] == "Bambu"):
+                return await self.async_step_Bambu(None)
         
         # Build form
         fields: OrderedDict[vol.Marker, Any] = OrderedDict()
-        fields[vol.Required("printer_mode")] = MODE_SELECTOR
+        if self.cloud_supported:
+            fields[vol.Required("printer_mode")] = MODE_SELECTOR
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -68,7 +68,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
                 case "event_printer_data_update":
                     self._update_data()
 
-                case "event_ams_info_data":
+                case "event_ams_data_update":
                     self._update_data()
 
                 case "event_virtual_tray_data_update":

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -18,7 +18,7 @@
                 }
             },
             "Bambu": {
-                "title": "Bambu Cloud Connection",
+                "title": "Bambu Cloud MQTT Connection",
                 "description": "Please provide your Bambu Lab credentials to allow generation of an authentication token. Only the token will be saved, your Bambu credentials will not.",
                 "data": {
                     "username": "Email Address",
@@ -26,7 +26,7 @@
                 }
             },
             "Lan": {
-                "title": "Lan Mode Connection",
+                "title": "Local MQTT Connection",
                 "description": "Please provide your local printer IP address and access code. The access code can be found on the printer screen in the network settings.",
                 "data": {
                   "host": "Host IP",
@@ -50,7 +50,7 @@
                 }
             },
             "Bambu": {
-                "title": "Bambu Cloud Connection",
+                "title": "Bambu Cloud MQTT Connection",
                 "description": "Please provide your Bambu Lab credentials to allow generation of an authentication token. Only the token will be saved, your Bambu credentials will not.",
                 "data": {
                     "username": "Email Address",
@@ -58,7 +58,7 @@
                 }
             },
             "Lan": {
-                "title": "Lan Mode Connection",
+                "title": "Local MQTT Connection",
                 "description": "Please provide your local printer IP address and access code. The access code can be found on the printer screen in the network settings.",
                 "data": {
                   "host": "Host IP",


### PR DESCRIPTION
The Bambu Cloud MQTT connection options is currently broken. It is able to successfully retrieve the authentication token but attempting to authenticate using it is being consistently rejected. Something has changed server-side.

Until/if we can solve this the option is just confusing and harmful to the experience. Suppressing it for now.