### PR TITLE
Add layer sensors for P1P

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For now, you will need the following information:
 | Chamber Fan Speed         | :white_check_mark: | :white_check_mark: | :x:                |
 | Chamber Temperature       | :white_check_mark: | :white_check_mark: | :x:                |
 | Cooling Fan Speed         | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Current Layer             | :white_check_mark: | :white_check_mark: | :x:                |
+| Current Layer             | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Current Stage             | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | End Time                  | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Heatbreak Fan Speed       | :white_check_mark: | :white_check_mark: | :white_check_mark: |
@@ -42,7 +42,7 @@ For now, you will need the following information:
 | Speed Profile             | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Start Time                | :white_check_mark: | :white_check_mark: | :x:                |
 | Target Bed Temperature    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Total Layer Count         | :white_check_mark: | :white_check_mark: | :x:                |
+| Total Layer Count         | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Timelapse Active          | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 If AMS(s) are present, an additional 'Current Tray' sensor is present on the Printer device.

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -64,7 +64,7 @@ class Device:
         if feature == Features.CURRENT_STAGE:
             return self.info.device_type == "X1" or self.info.device_type == "X1C" or self.info.device_type == "P1P"
         if feature == Features.PRINT_LAYERS:
-            return self.info.device_type == "X1" or self.info.device_type == "X1C"
+            return self.info.device_type == "X1" or self.info.device_type == "X1C" or self.info.device_type == "P1P"
         if feature == Features.AMS:
             return len(self.ams.data) != 0
         if feature == Features.EXTERNAL_SPOOL:


### PR DESCRIPTION
With the latest firmware update, P1P devices now support the layer count output.