### PR TITLE
Update README.md with revised P1S support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)
+![image](https://github.com/ianschmitz/ha-bambulab/assets/6355370/c4b9527c-ad9c-4a6a-a09e-b47bddbde5ce)[![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)
 
 # Bambu Lab
 
@@ -51,7 +51,7 @@ If AMS(s) are present, an additional 'Current Tray' sensor is present on the Pri
 
 | Sensor                    | X1C                | X1                 | P1P                | P1S                |  
 |---------------------------|--------------------|--------------------|--------------------|--------------------|
-| Chamber Light             | :white_check_mark: | :white_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Chamber Light             | :white_check_mark: | :white_check_mark: | :heavy_check_mark: | :white_check_mark: |
 
 ### Buttons
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For now, you will need the following information:
 
 | Sensor                    | X1C                | X1                 | P1P                | P1S                | 
 |---------------------------|--------------------|--------------------|--------------------|--------------------|
-| Aux Fan Speed             | :white_check_mark: | :white_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Aux Fan Speed             | :white_check_mark: | :white_check_mark: | :heavy_check_mark: | :white_check_mark: |
 | Bed Temperature           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Chamber Fan Speed         | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
 | Chamber Temperature       | :white_check_mark: | :white_check_mark: | :x:                | :x:                |


### PR DESCRIPTION
The P1S includes the aux cooling fan by default. It also includes a chamber light.

![image](https://github.com/greghesp/ha-bambulab/assets/6355370/b58efcc5-860a-4c8f-9d0b-85f7a7509ad9)
![image](https://github.com/greghesp/ha-bambulab/assets/6355370/b915be2b-f45d-469a-9934-86e0f44a1238)


Let me know if you'd like to check anything else 😃 