### PR TITLE
Support for adding LED chamber lights via the WLED integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For now, you will need the following information:
 
 ### Sensors
 
-| Sensor                    | X1C                | X1                 | P1P                | P1S                | 
+| Sensor                    | X1C                | X1                 | P1P                | P1S                |
 |---------------------------|--------------------|--------------------|--------------------|--------------------|
 | Aux Fan Speed             | :white_check_mark: | :white_check_mark: | :heavy_check_mark: | :white_check_mark: |
 | Bed Temperature           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
@@ -49,7 +49,7 @@ If AMS(s) are present, an additional 'Current Tray' sensor is present on the Pri
 
 ### Lights
 
-| Sensor                    | X1C                | X1                 | P1P                | P1S                |  
+| Sensor                    | X1C                | X1                 | P1P                | P1S                |
 |---------------------------|--------------------|--------------------|--------------------|--------------------|
 | Chamber Light             | :white_check_mark: | :white_check_mark: | :heavy_check_mark: | :white_check_mark: |
 
@@ -111,6 +111,22 @@ This currently exposes the following Diagnostic Sensors:
 | 2-Error                   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | 2-Wiki                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | ... and so on             |                    |                    |                    |                    |
+
+### WLED Lights
+
+Support for adding LED chamber lights via the [WLED](https://kno.wled.ge/).
+
+- Requires the [WLED Home Assistant Integration](https://www.home-assistant.io/integrations/wled/) and the requiste LED lights and ESP device.
+- Clink the link below to import the WLED blueprint
+
+ [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fgreghesp%2Fha-bambulab%2Fblob%2Fmain%2Fblueprints%2Fwled_controller.yaml)
+
+#### WLED Features
+
+- LED lights automatically turn off when Bambu Lida is in use so as to not interfere
+- LED lights turn red when there is an error in the printer
+- LED lights turn blue when bed is auto leveling
+- LED lights turn green when print is finished
 
 ### Cameras
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ This currently exposes the following Diagnostic Sensors:
 
 Support for adding LED chamber lights via the [WLED](https://kno.wled.ge/).
 
-- Requires the [WLED Home Assistant Integration](https://www.home-assistant.io/integrations/wled/) and the requiste LED lights and ESP device.
+- Requires the [WLED Home Assistant Integration](https://www.home-assistant.io/integrations/wled/) and the requisite LED lights and ESP device.
 - Clink the link below to import the WLED blueprint
 
  [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fgreghesp%2Fha-bambulab%2Fblob%2Fmain%2Fblueprints%2Fwled_controller.yaml)

--- a/blueprints/wled_controller.yaml
+++ b/blueprints/wled_controller.yaml
@@ -34,6 +34,7 @@ blueprint:
         device:
           filter:
             integration: wled
+          multiple: true
 alias: Bambu Wled Controller
 description: ""
 
@@ -73,10 +74,12 @@ action:
             - 255
             - 255
             - 255
-          brightness: 255
-        target:
-          device_id: !input wled_lights
+          brightness_pct: 100
+          effect: Solid
         alias: Turn WLED light on white
+        target:
+          device_id:
+            !input wled_lights
       - choose:
           - conditions:
               - condition: or
@@ -101,8 +104,10 @@ action:
                     - 0
                     - 0
                   brightness: 255
+                  effect: Blink
                 target:
-                  device_id: !input wled_lights
+                  device_id:
+                    !input wled_lights
                 alias: Turn on Wled to red
         alias: Do we need to set color to red?
       - choose:
@@ -113,10 +118,10 @@ action:
                     entity_id: !input printer_stage
                     state: Idle
                   - condition: state
-                    entity_id: !input printer_status
+                    entity_id: sensor.x1c_printer_print_status
                     state: Finish
                   - condition: state
-                    entity_id: !input printer_status
+                    entity_id: sensor.x1c_printer_print_status
                     state: Offlilne
             sequence:
               - service: light.turn_on
@@ -126,8 +131,10 @@ action:
                     - 255
                     - 0
                   brightness: 255
+                  effect: Solid
                 target:
-                  device_id: !input wled_lights
+                  device_id:
+                    !input wled_lights
                 alias: Turn on Wled to green
         alias: Do we need to set color to green?
       - choose:
@@ -145,10 +152,36 @@ action:
                     - 0
                     - 255
                   brightness: 255
+                  effect: Blink
                 target:
-                  device_id: !input wled_lights
+                  device_id:
+                    !input wled_lights
                 alias: Turn on Wled to blue
         alias: Do we need to set color to blue?
+      - choose:
+          - conditions:
+              - condition: or
+                conditions:
+                  - condition: state
+                    entity_id: !input printer_stage
+                    state: Heatbed Preheating
+                  - condition: state
+                    entity_id: !input printer_stage
+                    state: Heating Hotend
+            sequence:
+              - service: light.turn_on
+                data:
+                  rgb_color:
+                    - 255
+                    - 169
+                    - 0
+                  brightness: 255
+                  effect: Blink
+                target:
+                  device_id:
+                    !input wled_lights
+                alias: Turn on Wled to yellow
+        alias: Do we need to set color to yellow?
     else:
       - service: light.turn_off
         data: {}

--- a/blueprints/wled_controller.yaml
+++ b/blueprints/wled_controller.yaml
@@ -1,0 +1,158 @@
+blueprint:
+  name: Bambu Wled Controller
+  description: Control Wled lights with Bambu 3d printer
+  domain: automation
+  input:
+    printer_status:
+      name: Bambu Lab Printer Status entity
+      description: "Select the printer status entity."
+      selector:
+        entity:
+          filter:
+            domain: sensor
+            integration: bambu_lab
+    printer_stage:
+      name: Bambu Lab Printer Stage entity
+      description: "Select the printer stage entity."
+      selector:
+        entity:
+          filter:
+            domain: sensor
+            integration: bambu_lab
+    chamber_light:
+      name: Bambu Lab Printer Chamber Light entity
+      description: "Select the printer chamber light entity."
+      selector:
+        entity:
+          filter:
+            domain: light
+            integration: bambu_lab
+    wled_lights:
+      name: Wled Light device
+      description: "Select the Wled light device."
+      selector:
+        device:
+          filter:
+            integration: wled
+alias: Bambu Wled Controller
+description: ""
+
+trigger:
+  - platform: state
+    entity_id:
+      - !input printer_stage
+      - !input chamber_light
+      - !input printer_status
+    alias: When printer stage,status or chamber light state changes
+condition: []
+action:
+  - if:
+      - condition: state
+        entity_id: !input chamber_light
+        state: "on"
+        alias: chamber light is on
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: !input printer_stage
+            state: Scanning Bed Surface
+            alias: Scanning Bed Surface
+          - condition: state
+            entity_id: !input printer_stage
+            state: Cleaning Nozzle Tip
+            alias: Cleaning Nozzle Tip
+          - condition: state
+            entity_id: !input printer_stage
+            state: Calibrating Extrusion
+            alias: Calibrating Extrusion
+        alias: And Lidar is NOT on
+    then:
+      - service: light.turn_on
+        data:
+          rgb_color:
+            - 255
+            - 255
+            - 255
+          brightness: 255
+        target:
+          device_id: !input wled_lights
+        alias: Turn WLED light on white
+      - choose:
+          - conditions:
+              - condition: or
+                conditions:
+                  - condition: state
+                    entity_id: !input printer_stage
+                    state: Paused due to filament runout
+                  - condition: state
+                    entity_id: !input printer_stage
+                    state: Pause of front cover falling
+                  - condition: state
+                    entity_id: !input printer_stage
+                    state: Paused due to nozzle temperature malfunction
+                  - condition: state
+                    entity_id: !input printer_stage
+                    state: Paused due to heat bed temperature malfunction
+            sequence:
+              - service: light.turn_on
+                data:
+                  rgb_color:
+                    - 255
+                    - 0
+                    - 0
+                  brightness: 255
+                target:
+                  device_id: !input wled_lights
+                alias: Turn on Wled to red
+        alias: Do we need to set color to red?
+      - choose:
+          - conditions:
+              - condition: or
+                conditions:
+                  - condition: state
+                    entity_id: !input printer_stage
+                    state: Idle
+                  - condition: state
+                    entity_id: !input printer_status
+                    state: Finish
+                  - condition: state
+                    entity_id: !input printer_status
+                    state: Offlilne
+            sequence:
+              - service: light.turn_on
+                data:
+                  rgb_color:
+                    - 0
+                    - 255
+                    - 0
+                  brightness: 255
+                target:
+                  device_id: !input wled_lights
+                alias: Turn on Wled to green
+        alias: Do we need to set color to green?
+      - choose:
+          - conditions:
+              - condition: or
+                conditions:
+                  - condition: state
+                    entity_id: !input printer_stage
+                    state: Auto Bed Leveling
+            sequence:
+              - service: light.turn_on
+                data:
+                  rgb_color:
+                    - 0
+                    - 0
+                    - 255
+                  brightness: 255
+                target:
+                  device_id: !input wled_lights
+                alias: Turn on Wled to blue
+        alias: Do we need to set color to blue?
+    else:
+      - service: light.turn_off
+        data: {}
+        target:
+          device_id: !input wled_lights
+        alias: Turn WLED light off
+mode: restart

--- a/blueprints/wled_controller.yaml
+++ b/blueprints/wled_controller.yaml
@@ -1,26 +1,26 @@
 blueprint:
-  name: Bambu Wled Controller
-  description: Control Wled lights with Bambu 3d printer
+  name: Bambu Lab WLED Controller
+  description: Control one or more WLED lights with Bambu 3d printer
   domain: automation
   input:
     printer_status:
-      name: Bambu Lab Printer Status entity
-      description: "Select the printer status entity."
+      name: Print Status of your Bambu Lab printer
+      description: "Select the print status entity."
       selector:
         entity:
           filter:
             domain: sensor
             integration: bambu_lab
     printer_stage:
-      name: Bambu Lab Printer Stage entity
-      description: "Select the printer stage entity."
+      name: Current Stage of your Bambu Lab Printer
+      description: "Select the printer current stage entity."
       selector:
         entity:
           filter:
             domain: sensor
             integration: bambu_lab
     chamber_light:
-      name: Bambu Lab Printer Chamber Light entity
+      name: Chamber Light of your Bambu Lab Printer
       description: "Select the printer chamber light entity."
       selector:
         entity:
@@ -28,30 +28,31 @@ blueprint:
             domain: light
             integration: bambu_lab
     wled_lights:
-      name: Wled Light device
-      description: "Select the Wled light device."
+      name: WLED Light devices
+      description: "Select the WLED light devices you wish to control."
       selector:
         device:
           filter:
             integration: wled
           multiple: true
-alias: Bambu Wled Controller
-description: ""
 
+alias: Bambu Lab WLED Controller
+description: ""
 trigger:
   - platform: state
     entity_id:
-      - !input printer_stage
       - !input chamber_light
       - !input printer_status
+      - !input printer_stage
     alias: When printer stage,status or chamber light state changes
+    #not_to: Unknown
 condition: []
 action:
   - if:
       - condition: state
-        entity_id: !input chamber_light
         state: "on"
         alias: chamber light is on
+        entity_id: !input chamber_light
       - condition: not
         conditions:
           - condition: state
@@ -66,6 +67,10 @@ action:
             entity_id: !input printer_stage
             state: Calibrating Extrusion
             alias: Calibrating Extrusion
+          - condition: state
+            entity_id: !input printer_status
+            state: Offline
+            alias: Printer is off
         alias: And Lidar is NOT on
     then:
       - service: light.turn_on
@@ -118,11 +123,11 @@ action:
                     entity_id: !input printer_stage
                     state: Idle
                   - condition: state
-                    entity_id: sensor.x1c_printer_print_status
+                    entity_id: !input printer_status
                     state: Finish
                   - condition: state
-                    entity_id: sensor.x1c_printer_print_status
-                    state: Offlilne
+                    entity_id: !input printer_status
+                    state: Offline
             sequence:
               - service: light.turn_on
                 data:
@@ -186,6 +191,7 @@ action:
       - service: light.turn_off
         data: {}
         target:
-          device_id: !input wled_lights
+          device_id:
+            !input wled_lights
         alias: Turn WLED light off
-mode: restart
+mode: single


### PR DESCRIPTION
Added a blueprint and changes to readme

- LED lights automatically turn off when Bambu Lida is in use so as to not interfere
- LED lights turn red when there is an error in the printer
- LED lights turn blue when bed is auto leveling
- LED lights turn green when print is finished