### PR TITLE
Gracefully handle print_status (gcode_state) being an empty string on printer power on

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -334,6 +334,8 @@ class Info:
         self.wifi_signal = int(data.get("wifi_signal", str(self.wifi_signal)).replace("dBm", ""))
         self.print_percentage = data.get("mc_percent", self.print_percentage)
         self.gcode_state = data.get("gcode_state", self.gcode_state)
+        if self.gcode_state == "":
+            self.gcode_state = "unknown"
         self.gcode_file = data.get("gcode_file", self.gcode_file)
         self.subtask_name = data.get("subtask_name", self.subtask_name)
         self.remaining_time = data.get("mc_remaining_time", self.remaining_time)

--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -46,8 +46,8 @@ def to_whole(number):
 def get_filament_name(idx):
     """Converts a filament idx to a human-readable name"""
     result = FILAMENT_NAMES.get(idx, "unknown")
-    if result == "unknown":
-        LOGGER.debug(f"UNKNOWN FILAMENT IDX: {idx}")
+    if result == "unknown" and idx != "":
+        LOGGER.debug(f"UNKNOWN FILAMENT IDX: '{idx}'")
     return result
 
 


### PR DESCRIPTION
This breaks the integration permanently.