### PR TITLE
Re-enable Bambu cloud MQTT connection to printer.

### DIFF
--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -37,6 +37,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         self.client = BambuClient(device_type = entry.data.get("device_type", "X1C"),
                                   serial = entry.data["serial"],
                                   host = entry.data["host"],
+                                  username = entry.data.get("username", "bblp"),
                                   access_code = entry.data["access_code"])
 
         self._updatedDevice = False
@@ -148,6 +149,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
                             "device_type": device_type,
                             "serial": self._entry.data["serial"],
                             "host": self._entry.data["host"],
+                            "username": self._entry.data.get("username", "bblp"),
                             "access_code": self._entry.data["access_code"]
                         }
                     )

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -99,11 +99,12 @@ class BambuClient:
     """Initialize Bambu Client to connect to MQTT Broker"""
     _watchdog = None
 
-    def __init__(self, device_type: str, serial: str, host: str, access_code: str):
+    def __init__(self, device_type: str, serial: str, host: str, username: str, access_code: str):
         self.host = host
         self.client = mqtt.Client()
         self._serial = serial
         self._access_code = access_code
+        self._username = username
         self._connected = False
         self.callback = None
         self._device = Device(self, device_type, serial)
@@ -126,7 +127,7 @@ class BambuClient:
         self.client.tls_set(tls_version=ssl.PROTOCOL_TLS, cert_reqs=ssl.CERT_NONE)
         self.client.tls_insecure_set(True)
         self._port = 8883
-        self.client.username_pw_set("bblp", password=self._access_code)
+        self.client.username_pw_set(self._username, password=self._access_code)
 
         LOGGER.debug("Starting MQTT listener thread")
         thread = threading.Thread(target=listen_thread, args=(self,))
@@ -234,7 +235,7 @@ class BambuClient:
 
         self.client.tls_set(tls_version=ssl.PROTOCOL_TLS, cert_reqs=ssl.CERT_NONE)
         self.client.tls_insecure_set(True)
-        self.client.username_pw_set("bblp", password=self._access_code)
+        self.client.username_pw_set(self._username, password=self._access_code)
         self._port = 8883
 
         LOGGER.debug("Try Connection: Connecting to %s for connection test", self.host)

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -10,11 +10,11 @@
     },
     "step": {
       "user": {
-        "description": "Please select your printer and provide it's serial number.",
+        "description": "Please select your printer and provide it's serial number.\n\nNote that the latest P1P firmware (1.0.4.0) only correctly supports a single local connection. If you need a second (e.g. for P1Touch), you can use Bambu Cloud in this integration.\n\nUse local in all other cases.",
         "data": {
           "device_type": "Printer Model:",
           "serial": "Serial Number",
-          "printer_mode": "Connection Mode:"
+          "printer_mode": "Printer MQTT connection mode:"
         }
       },
       "Bambu": {
@@ -44,9 +44,9 @@
     "step": {
       "init": {
         "title": "Adjust connection settings",
-        "description": "Choose the new connection settings for this printer.",
+        "description": "Choose the new connection settings for this printer.\n\nNote that the latest P1P firmware (1.0.4.0) only correctly supports a single local connection. If you need a second (e.g. for P1Touch), you can use Bambu Cloud in this integration.\n\nUse local in all other cases.",
         "data": {
-          "printer_mode": "Connection Mode:"
+          "printer_mode": "Printer MQTT Connection Mode:"
         }
       },
       "Bambu": {


### PR DESCRIPTION
Added extraction of username from the authentication Token the disabled code was already getting and plumbed that through to the connection code. And then re-enabled the init and config flows to present the choice.