### PR TITLE
Alternative fix for start time

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -252,7 +252,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         key="start_time",
         translation_key="start_time",
         icon="mdi:clock",
-        available_fn=lambda self: self.coordinator.get_model().info.start_time != 0,
+        available_fn=lambda self: self.coordinator.get_model().info.start_time != "",
         value_fn=lambda self: self.coordinator.get_model().info.start_time,
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.START_TIME),
     ),
@@ -268,7 +268,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         key="end_time",
         translation_key="end_time",
         icon="mdi:clock",
-        available_fn=lambda self: self.coordinator.get_model().info.end_time != 0,
+        available_fn=lambda self: self.coordinator.get_model().info.end_time != "",
         value_fn=lambda self: self.coordinator.get_model().info.end_time,
     ),
     BambuLabSensorEntityDescription(

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -273,8 +273,8 @@ class Info:
         self.subtask_name = ""
         self.serial = serial
         self.remaining_time = 0
-        self.end_time = 0
-        self.start_time = 0
+        self.end_time = ""
+        self.start_time = ""
         self.current_layer = 0
         self.total_layers = 0
         self.online = False
@@ -342,12 +342,10 @@ class Info:
         self.remaining_time = data.get("mc_remaining_time", self.remaining_time)
         if data.get("gcode_start_time") is not None:
             self.start_time = start_time(int(data.get("gcode_start_time")))
-        if self.gcode_state == 'IDLE':
-            self.start_time = 0
-        # self.start_time = start_time(int(data.get("gcode_start_time", self.remaining_time)))
+        if self.remaining_time == 0:
+            self.start_time = ""
         if data.get("mc_remaining_time") is not None:
             self.end_time = end_time(data.get("mc_remaining_time"))
-        # self.end_time = end_time(data.get("mc_remaining_time", self.remaining_time))
         self.current_layer = data.get("layer_num", self.current_layer)
         self.total_layers = data.get("total_layer_num", self.total_layers)
         self.firmware_updates = data.get("upgrade_state", {}).get("new_ver_list", self.firmware_updates)

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -341,11 +341,11 @@ class Info:
         self.subtask_name = data.get("subtask_name", self.subtask_name)
         self.remaining_time = data.get("mc_remaining_time", self.remaining_time)
         if data.get("gcode_start_time") is not None:
-            self.start_time = start_time(int(data.get("gcode_start_time")))
+            self.start_time = get_start_time(int(data.get("gcode_start_time")))
         if self.remaining_time == 0:
             self.start_time = ""
         if data.get("mc_remaining_time") is not None:
-            self.end_time = end_time(data.get("mc_remaining_time"))
+            self.end_time = get_end_time(self.remaining_time)
         self.current_layer = data.get("layer_num", self.current_layer)
         self.total_layers = data.get("total_layer_num", self.total_layers)
         self.firmware_updates = data.get("upgrade_state", {}).get("new_ver_list", self.firmware_updates)

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -11,8 +11,8 @@ from .utils import \
     get_stage_action, \
     get_hw_version, \
     get_sw_version, \
-    start_time, \
-    end_time, \
+    get_start_time, \
+    get_end_time, \
     get_HMS_error_text
 from .const import LOGGER, Features, FansEnum, SPEED_PROFILE
 from .commands import CHAMBER_LIGHT_ON, CHAMBER_LIGHT_OFF, SPEED_PROFILE_TEMPLATE

--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -105,14 +105,14 @@ def get_sw_version(modules, default):
 def start_time(timestamp):
     """Return start time of a print"""
     if timestamp == 0:
-        return "N/A"
+        return ""
     return datetime.fromtimestamp(timestamp).strftime('%d %B %Y %H:%M:%S')
 
 
 def end_time(remaining_time):
     """Calculate the end time of a print"""
     if remaining_time <= 0:
-        return "N/A"
+        return ""
     endtime = datetime.now() + timedelta(minutes=remaining_time)
     return round_minute(endtime).strftime('%d %B %Y %H:%M:%S')
 

--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -102,14 +102,14 @@ def get_sw_version(modules, default):
     return default
 
 
-def start_time(timestamp):
+def get_start_time(timestamp):
     """Return start time of a print"""
     if timestamp == 0:
         return ""
     return datetime.fromtimestamp(timestamp).strftime('%d %B %Y %H:%M:%S')
 
 
-def end_time(remaining_time):
+def get_end_time(remaining_time):
     """Calculate the end time of a print"""
     if remaining_time <= 0:
         return ""


### PR DESCRIPTION
End time is already gated on remaining time != 0 (since it's calculated using that value. Start time and end time availability should be consistent. So if we reset start time when remaining time == 0 we both achieve the reset at an appropriate time and we get consistent availability. 

Also made consistency fixes since these values are stored as strings so set them to the empty string instead of 0 to indicate the unavailable state.