### PR TITLE
Avoid overlapping initialization and AMS reinitialization

### DIFF
--- a/custom_components/bambu_lab/__init__.py
+++ b/custom_components/bambu_lab/__init__.py
@@ -7,7 +7,7 @@ from .coordinator import BambuDataUpdateCoordinator
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the Bambu Lab integration."""
-    LOGGER.debug("async_setup_entry")
+    LOGGER.debug("async_setup_entry Start")
     coordinator = BambuDataUpdateCoordinator(hass, entry=entry)
     await coordinator.async_config_entry_first_refresh()
 
@@ -20,6 +20,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
     LOGGER.debug("async_setup_entry Complete")
+
+    # Now that we've finished initialization fully, start the MQTT connection so that any necessary
+    # sensor reinitialization happens entirely after the initial setup.
+    await coordinator.start_mqtt()
+    
     return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -42,7 +42,6 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
 
         self._updatedDevice = False
         self.data = self.get_model()
-        self._use_mqtt()
         self._lock = threading.Lock()
         super().__init__(
             hass,
@@ -52,8 +51,9 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         )
 
     @callback
-    def _use_mqtt(self) -> None:
+    async def start_mqtt(self) -> None:
         """Use MQTT for updates."""
+        LOGGER.debug("Starting MQTT")
 
         def event_handler(event):
             match event:


### PR DESCRIPTION
If we haven't finished the initial sensor setup by the time the MQTT payload that drives adding the AMS sensor reinitialization occurs we end up causing errors of the form:
2023-09-14 19:48:30.622 ERROR (MainThread) [homeassistant.components.sensor] Platform bambu_lab does not generate unique IDs. ID X1C_[REDACTED]_ExternalSpool_external_spool already exists - ignoring sensor.x1c_[REDACTED]_externalspool_external_spool
2023-09-14 19:48:30.624 ERROR (MainThread) [homeassistant.components.sensor] Platform bambu_lab does not generate unique IDs. ID X1C_[REDACTED]_AMS_[REDACTED]_humidity_index already exists - ignoring sensor.x1c_[REDACTED]_ams_1_humidity_index

As in #211 

This change is the attempt to avoid this by ensuring that we don't connect the MQTT until after the initial setup has fully completed.