### PR TITLE
Detect offline with bambu cloud mqtt mode connection

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -281,6 +281,11 @@ class Info:
         self.mqtt_mode = "local" if self.client._username == "bblp" else "bambu_cloud"
         self.firmware_updates = {}
 
+    def set_online(self, online):
+        self.online = online
+        if self.client.callback is not None:
+            self.client.callback("event_printer_data_update")
+
     def info_update(self, data):
         """Update from dict"""
 


### PR DESCRIPTION
The watchdog timer is used to trigger a more aggressive (20 second) detection than waiting for the client.disconnected event (> 3.5 minutes) would allow. But we use the client.connect event to subscribe and request version info / push_all data to get back into an up to date state.