### PR TITLE
Fix firmware check on X1

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -89,7 +89,7 @@ PRINTER_BINARY_SENSORS: tuple[BambuLabBinarySensorEntityDescription, ...] = (
         translation_key="firmware_update",
         device_class=BinarySensorDeviceClass.UPDATE,
         entity_category=EntityCategory.DIAGNOSTIC,
-        is_on_fn=lambda self: len(self.coordinator.get_model().info.firmware_updates) != 0
+        is_on_fn=lambda self: self.coordinator.get_model().info.new_version_state == 1
     ),
 )
 

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -265,7 +265,7 @@ class Info:
     current_layer: int
     total_layers: int
     online: bool
-    firmware_updates: dict
+    new_version_state: int
 
     def __init__(self, client, device_type, serial):
         self.client = client
@@ -285,7 +285,7 @@ class Info:
         self.total_layers = 0
         self.online = False
         self.mqtt_mode = "local" if self.client._username == "bblp" else "bambu_cloud"
-        self.firmware_updates = {}
+        self.new_version_state = 0
 
     def set_online(self, online):
         if self.online != online:
@@ -360,7 +360,7 @@ class Info:
                 self.end_time = get_end_time(self.remaining_time)
         self.current_layer = data.get("layer_num", self.current_layer)
         self.total_layers = data.get("total_layer_num", self.total_layers)
-        self.firmware_updates = data.get("upgrade_state", {}).get("new_ver_list", self.firmware_updates)
+        self.new_version_state = data.get("upgrade_state", {}).get("new_version_state", self.new_version_state)
 
 
 @dataclass


### PR DESCRIPTION
The mqtt payload on the X1 is different to the P1P. There only shared value is the new_version_state value. Empirically:
1 == firmware update available
2 == not
Other values are unknown. Updated the sensor to consider '1' to mean there's a new firmware update available and anything else to mean there isn't.

Fixes #227 