### PR TITLE
Generate start time for P1P/S

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -254,7 +254,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         icon="mdi:clock",
         available_fn=lambda self: self.coordinator.get_model().info.start_time != "",
         value_fn=lambda self: self.coordinator.get_model().info.start_time,
-        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.START_TIME),
+        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.START_TIME) or coordinator.get_model().supports_feature(Features.START_TIME_GENERATED),
     ),
     BambuLabSensorEntityDescription(
         key="remaining_time",

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -18,7 +18,8 @@ class Features(Enum):
     START_TIME = 10,
     AMS_TEMPERATURE = 11,
     AMS_RAW_HUMIDITY = 12,
-    CAMERA_RTSP = 13
+    CAMERA_RTSP = 13,
+    START_TIME_GENERATED = 14
 
 
 class FansEnum(Enum):

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -281,7 +281,7 @@ class Info:
         self.gcode_file = ""
         self.subtask_name = ""
         self.serial = serial
-        self.remaining_time = 0
+        self.remaining_time = -1
         self.end_time = ""
         self.start_time = ""
         self.current_layer = 0

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -1,6 +1,7 @@
 import math
 
 from dataclasses import dataclass
+from datetime import datetime
 
 from .utils import \
     search, \
@@ -37,7 +38,7 @@ class Device:
 
     def print_update(self, data):
         """Update from dict"""
-        self.info.print_update(data)
+        self.info.print_update(self, data)
         self.temperature.print_update(data)
         self.lights.print_update(data)
         self.fans.print_update(data)
@@ -85,6 +86,8 @@ class Device:
                 return self.info.device_type == "P1P" or self.info.device_type == "P1S"
             case Features.START_TIME:
                 return self.info.device_type == "X1" or self.info.device_type == "X1C"
+            case Features.START_TIME_GENERATED:
+                return self.info.device_type == "P1P" or self.info.device_type == "P1S"
             case Features.AMS_TEMPERATURE:
                 return self.info.device_type == "X1" or self.info.device_type == "X1C"
             case Features.AMS_RAW_HUMIDITY:
@@ -322,7 +325,7 @@ class Info:
         if self.client.callback is not None:
             self.client.callback("event_printer_info_update")
 
-    def print_update(self, data):
+    def print_update(self, device, data):
         """Update from dict"""
 
         # Example payload:
@@ -351,6 +354,8 @@ class Info:
             self.gcode_state = "unknown"
         self.gcode_file = data.get("gcode_file", self.gcode_file)
         self.subtask_name = data.get("subtask_name", self.subtask_name)
+
+        # Generate the end_time from the remaining_time mqtt payload value.
         if data.get("gcode_start_time") is not None:
             self.start_time = get_start_time(int(data.get("gcode_start_time")))
         if data.get("mc_remaining_time") is not None:
@@ -358,6 +363,13 @@ class Info:
             self.remaining_time = data.get("mc_remaining_time")
             if existing_remaining_time != self.remaining_time:
                 self.end_time = get_end_time(self.remaining_time)
+
+                # Generate the start_time for P1P/S when remaining_time changes from 0 to non-zero. We already know the value changed.
+                LOGGER.debug(f"WTF: {existing_remaining_time} {self.remaining_time}")
+                if device.supports_feature(Features.START_TIME_GENERATED) and existing_remaining_time == 0:
+                    # We can use the existing get_end_time helper to format date.now() as desired by passing 0.
+                    self.start_time = get_end_time(0)
+
         self.current_layer = data.get("layer_num", self.current_layer)
         self.total_layers = data.get("total_layer_num", self.total_layers)
 

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -365,7 +365,6 @@ class Info:
                 self.end_time = get_end_time(self.remaining_time)
 
                 # Generate the start_time for P1P/S when remaining_time changes from 0 to non-zero. We already know the value changed.
-                LOGGER.debug(f"WTF: {existing_remaining_time} {self.remaining_time}")
                 if device.supports_feature(Features.START_TIME_GENERATED) and existing_remaining_time == 0:
                     # We can use the existing get_end_time helper to format date.now() as desired by passing 0.
                     self.start_time = get_end_time(0)


### PR DESCRIPTION
These don't generate the start_time mqtt payload natively. But we can simulate it by detecting remaining time changing from 0 to some value. The main limitation is that if the integration is started/restarted mid-print it won't be able to generate a correct value so the start time will remain unavailable in that case.