### PR TITLE
Fix finished and failed events firing at restart of integration

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -377,12 +377,12 @@ class Info:
                 self.start_time = get_end_time(0)
 
         # Handle print failed
-        if previous_gcode_state != "FAILED" and self.gcode_state == "FAILED":
+        if previous_gcode_state != "unknown" and previous_gcode_state != "FAILED" and self.gcode_state == "FAILED":
             if self.client.callback is not None:
                self.client.callback("event_print_failed")
 
         # Handle print finish
-        if previous_gcode_state != "FINISH" and self.gcode_state == "FINISH":
+        if previous_gcode_state != "unknown" and previous_gcode_state != "FINISH" and self.gcode_state == "FINISH":
             if self.client.callback is not None:
                self.client.callback("event_print_finished")
 


### PR DESCRIPTION
The 'unknown' -> 'FINISHED'/'FAILED' transition for gcode_state was triggering the event incorrectly when the integration was restarted with the printer in a finished (very common) or failed (uncommon) state. Ignore transitions from the starting state of 'unknown' for these events. 

For print started, the same issue applies but for that case I decided to let the event fire since it's somewhat more accurate and the same logic triggers setting the print started timestamp sensor.