### PR TITLE
Simplify how we handle P1P optional hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,13 @@ instead of OAuth.
 
 ## Features
 
-(:heavy_check_mark: Optional accessory)
-
 ### Sensors
 
 | Sensor                    | X1C                | X1                 | P1P                | P1S                | A1 Mini            | 
 |---------------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
-| Aux Fan Speed             | :white_check_mark: | :white_check_mark: | :heavy_check_mark: | :white_check_mark: | :white_check_mark: |
+| Aux Fan Speed             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Bed Temperature           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Chamber Fan Speed         | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :x:                |
+| Chamber Fan Speed         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
 | Chamber Temperature       | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                |
 | Cooling Fan Speed         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Current Layer             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
@@ -74,7 +72,7 @@ Notes:
 
 | Light         | X1C                | X1                 | P1P                | P1S                | A1 Mini            |    
 |---------------|--------------------|--------------------|--------------------|--------------------|--------------------|
-| Chamber Light | :white_check_mark: | :white_check_mark: | :heavy_check_mark: | :white_check_mark: | :white_check_mark: |
+| Chamber Light | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 ### Buttons
 

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -69,7 +69,7 @@ class Device:
             case Features.CHAMBER_LIGHT:
                 return True
             case Features.CHAMBER_FAN:
-                return self.info.device_type == "X1" or self.info.device_type == "X1C" or self.info.device_type == "P1S"
+                return self.info.device_type == "X1" or self.info.device_type == "X1C" or self.info.device_type == "P1P" or self.info.device_type == "P1S"
             case Features.CHAMBER_TEMPERATURE:
                 return self.info.device_type == "X1" or self.info.device_type == "X1C"
             case Features.CURRENT_STAGE:


### PR DESCRIPTION
Remove the hardware distinctions for the P1P since it can have those added later by the upgrade kit. This matches how Bambu Studio/Handy handle it.