### PR TITLE
The AMS lite has a different hardware identity in the version info block.

### DIFF
--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -196,30 +196,30 @@ HMS_ERRORS = {
     "0500_0400_0001_0004": "The print file is unauthorized.",
     "0500_0400_0001_0006": "Failed to resume previous print.",
     "0500_0400_0002_0007": "The bed temperature exceeds the filament's vitrification temperature, which may cause a nozzle clog.",
-    "0700_0100_0001_0001": "The AMS assist motor has slipped.The extrusion wheel may be worn down, or the filament may be too thin.",
-    "0700_0100_0001_0003": "The AMS assist motor torque control is malfunctioning. The current sensor may be faulty.",
-    "0700_0100_0001_0004": "The AMS assist motor speed control is malfunctioning.The speed sensor may be faulty.",
-    "0700_0100_0002_0002": "The AMS assist motor is overloaded.The filament may be tangled or stuck.",
-    "0700_0200_0001_0001": "AMS filament speed and length error.The filament odometry may be faulty.",
     "0700_4000_0002_0001": "The filament buffer signal lost, the cable or position sensor may be malfunctioning.",
     "0700_4000_0002_0002": "The filament buffer position signal error, the position sensor may be malfunctioning.",
     "0700_4000_0002_0003": "The AMS Hub communication is abnormal, the cable may be not well connected.",
     "0700_4000_0002_0004": "The filament buffer signal is abnormal, the spring may be stuck.",
-    "0700_4500_0002_0001": "The filament cutter sensor is malfunctioning.The sensor may be disconnected or damaged.",
-    "0700_4500_0002_0002": "The filament cutter's cutting distance is too large.The XY motor may lose steps.",
-    "0700_4500_0002_0003": "The filament cutter handle has not released.The handle or blade may be stuck.",
-    "0700_5100_0003_0001": "The AMS is disabled, please load filament from spool holder.",
+    "0700_4500_0002_0001": "The filament cutter sensor is malfunctioning. The sensor may be disconnected or damaged.",
+    "0700_4500_0002_0002": "The filament cutter's cutting distance is too large. The XY motor may lose steps.",
+    "0700_4500_0002_0003": "The filament cutter handle has not released. The handle or blade may be stuck.",
+    "0700_5100_0003_0001": "AMS is disabled, please load filament from spool holder.",
     "07FF_2000_0002_0001": "External filament has run out, please load a new filament.",
     "07FF_2000_0002_0002": "External filament is missing, please load a new filament.",
     "07FF_2000_0002_0004": "External filament is missing, please load a new filament.",
 }
 
-# These errors cover those that are AMS/slot specific
-# 070X_xYxx_xxxx_xxxx = AMS X (0 based index) Slot Y (0 based index) has the error
+# These errors cover those that are AMS and/or slot specific.
+# 070X_xYxx_xxxx_xxxx = AMS X (0 based index) Slot Y (0 based index) has the error.
 HMS_AMS_ERRORS = {
+    "0700_0100_0001_0001": "AMS1 assist motor has slipped. The extrusion wheel may be worn down, or the filament may be too thin.",
+    "0700_0100_0001_0003": "AMS1 assist motor torque control is malfunctioning. The current sensor may be faulty.",
+    "0700_0100_0001_0004": "AMS1 assist motor speed control is malfunctioning. The speed sensor may be faulty.",
+    "0700_0100_0002_0002": "AMS1 assist motor is overloaded. The filament may be tangled or stuck.",
+    "0700_0200_0001_0001": "AMS1 filament speed and length error. The filament odometry may be faulty.",
     "0700_1000_0001_0001": "AMS1 slot 1 motor has slipped. The extrusion wheel may be malfunctioning, or the filament may be too thin.",
-    "0700_1000_0001_0003": "AMS1 slot 1 motor torque control is malfunctioning.The current sensor may be faulty.",
-    "0700_1000_0002_0002": "AMS1 slot 1 motor is overloaded.The filament may be tangled or stuck.",
+    "0700_1000_0001_0003": "AMS1 slot 1 motor torque control is malfunctioning. The current sensor may be faulty.",
+    "0700_1000_0002_0002": "AMS1 slot 1 motor is overloaded. The filament may be tangled or stuck.",
     "0700_2000_0002_0001": "AMS1 slot 1 filament has been ran out.",
     "0700_2000_0002_0002": "AMS1 slot 1 is empty.",
     "0700_2000_0002_0003": "AMS1 slot 1 filament may be broken in AMS.",

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -488,7 +488,7 @@ class AMSList:
         # what devices to add to humidity_index assistant and add all the sensors as entities. And then then json payload data
         # to populate the values for all those entities.
 
-        # The module entries are of this form:
+        # The module entries are of this form (P1/X1):
         # {
         #     "name": "ams/0",
         #     "project_name": "",
@@ -498,13 +498,28 @@ class AMSList:
         #     "hw_ver": "AMS08",
         #     "sn": "<SERIAL>"
         # }
+        # AMS Lite of the form:
+        # {
+        #   "name": "ams_f1/0",
+        #   "project_name": "",
+        #   "sw_ver": "00.00.07.89",
+        #   "loader_ver": "00.00.00.00",
+        #   "ota_ver": "00.00.00.00",
+        #   "hw_ver": "AMS_F102",
+        #   "sn": "**REDACTED**"
+        # }
 
         received_ams_info = False
         module_list = data.get("module", [])
         for module in module_list:
             name = module["name"]
+            index = -1
             if name.startswith("ams/"):
                 index = int(name[4])
+            elif name.startswith("ams_f1/"):
+                index = int(name[7])
+            
+            if index != -1:
                 # Sometimes we get incomplete version data. We have to skip if that occurs since the serial number is
                 # requires as part of the home assistant device identity.
                 if not module['sn'] == '':


### PR DESCRIPTION
It named ams_f1/<n> instead of the ams/<n> we were previously only looking for.

Also moved a few more AMS-specific (I think!) over to the new AMS specific error list.