### PR TITLE
Added remaining filament amount to AMS trays.

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -322,6 +322,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_min": self.coordinator.get_model().get_active_tray().nozzle_temp_min,
             "nozzle_temp_max": self.coordinator.get_model().get_active_tray().nozzle_temp_max,
             "type": self.coordinator.get_model().get_active_tray().type,
+            "remain": self.coordinator.get_model().get_active_tray().remain,
         },
         available_fn=lambda self: self.coordinator.get_model().get_active_tray() is not None,
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.AMS) and not coordinator.get_model().supports_feature(Features.K_VALUE)
@@ -339,6 +340,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_min": self.coordinator.get_model().get_active_tray().nozzle_temp_min,
             "nozzle_temp_max": self.coordinator.get_model().get_active_tray().nozzle_temp_max,
             "type": self.coordinator.get_model().get_active_tray().type,
+            "remain": self.coordinator.get_model().get_active_tray().remain,
         },
         available_fn=lambda self: self.coordinator.get_model().get_active_tray() is not None,
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.AMS) and coordinator.get_model().supports_feature(Features.K_VALUE)
@@ -415,6 +417,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_min": self.coordinator.get_model().ams.data[self.index].tray[0].nozzle_temp_min,
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[0].nozzle_temp_max,
             "type": self.coordinator.get_model().ams.data[self.index].tray[0].type,
+            "remain": self.coordinator.get_model().ams.data[self.index].tray[0].remain,
         },
         exists_fn=lambda coordinator: not coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
@@ -433,6 +436,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_min": self.coordinator.get_model().ams.data[self.index].tray[1].nozzle_temp_min,
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[1].nozzle_temp_max,
             "type": self.coordinator.get_model().ams.data[self.index].tray[1].type,
+            "remain": self.coordinator.get_model().ams.data[self.index].tray[1].remain,
         },
         exists_fn=lambda coordinator: not coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
@@ -451,6 +455,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_min": self.coordinator.get_model().ams.data[self.index].tray[2].nozzle_temp_min,
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[2].nozzle_temp_max,
             "type": self.coordinator.get_model().ams.data[self.index].tray[2].type,
+            "remain": self.coordinator.get_model().ams.data[self.index].tray[2].remain,
         },
         exists_fn=lambda coordinator: not coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
@@ -469,6 +474,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_min": self.coordinator.get_model().ams.data[self.index].tray[3].nozzle_temp_min,
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[3].nozzle_temp_max,
             "type": self.coordinator.get_model().ams.data[self.index].tray[3].type,
+            "remain": self.coordinator.get_model().ams.data[self.index].tray[3].remain,
         },
         exists_fn=lambda coordinator: not coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
@@ -488,6 +494,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_min": self.coordinator.get_model().ams.data[self.index].tray[0].nozzle_temp_min,
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[0].nozzle_temp_max,
             "type": self.coordinator.get_model().ams.data[self.index].tray[0].type,
+            "remain": self.coordinator.get_model().ams.data[self.index].tray[0].remain,
         },
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
@@ -507,6 +514,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_min": self.coordinator.get_model().ams.data[self.index].tray[1].nozzle_temp_min,
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[1].nozzle_temp_max,
             "type": self.coordinator.get_model().ams.data[self.index].tray[1].type,
+            "remain": self.coordinator.get_model().ams.data[self.index].tray[1].remain,
         },
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
@@ -526,6 +534,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_min": self.coordinator.get_model().ams.data[self.index].tray[2].nozzle_temp_min,
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[2].nozzle_temp_max,
             "type": self.coordinator.get_model().ams.data[self.index].tray[2].type,
+            "remain": self.coordinator.get_model().ams.data[self.index].tray[2].remain,
         },
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
@@ -545,6 +554,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_min": self.coordinator.get_model().ams.data[self.index].tray[3].nozzle_temp_min,
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[3].nozzle_temp_max,
             "type": self.coordinator.get_model().ams.data[self.index].tray[3].type,
+            "remain": self.coordinator.get_model().ams.data[self.index].tray[3].remain,
         },
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.K_VALUE)
     ),

--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -323,6 +323,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_max": self.coordinator.get_model().get_active_tray().nozzle_temp_max,
             "type": self.coordinator.get_model().get_active_tray().type,
             "remain": self.coordinator.get_model().get_active_tray().remain,
+            "tag_uid": self.coordinator.get_model().get_active_tray().tag_uid,
         },
         available_fn=lambda self: self.coordinator.get_model().get_active_tray() is not None,
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.AMS) and not coordinator.get_model().supports_feature(Features.K_VALUE)
@@ -341,6 +342,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_max": self.coordinator.get_model().get_active_tray().nozzle_temp_max,
             "type": self.coordinator.get_model().get_active_tray().type,
             "remain": self.coordinator.get_model().get_active_tray().remain,
+            "tag_uid": self.coordinator.get_model().get_active_tray().tag_uid,
         },
         available_fn=lambda self: self.coordinator.get_model().get_active_tray() is not None,
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.AMS) and coordinator.get_model().supports_feature(Features.K_VALUE)
@@ -418,6 +420,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[0].nozzle_temp_max,
             "type": self.coordinator.get_model().ams.data[self.index].tray[0].type,
             "remain": self.coordinator.get_model().ams.data[self.index].tray[0].remain,
+            "tag_uid": self.coordinator.get_model().ams.data[self.index].tray[0].tag_uid,
         },
         exists_fn=lambda coordinator: not coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
@@ -437,6 +440,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[1].nozzle_temp_max,
             "type": self.coordinator.get_model().ams.data[self.index].tray[1].type,
             "remain": self.coordinator.get_model().ams.data[self.index].tray[1].remain,
+            "tag_uid": self.coordinator.get_model().ams.data[self.index].tray[1].tag_uid,
         },
         exists_fn=lambda coordinator: not coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
@@ -456,6 +460,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[2].nozzle_temp_max,
             "type": self.coordinator.get_model().ams.data[self.index].tray[2].type,
             "remain": self.coordinator.get_model().ams.data[self.index].tray[2].remain,
+            "tag_uid": self.coordinator.get_model().ams.data[self.index].tray[2].tag_uid,
         },
         exists_fn=lambda coordinator: not coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
@@ -475,6 +480,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[3].nozzle_temp_max,
             "type": self.coordinator.get_model().ams.data[self.index].tray[3].type,
             "remain": self.coordinator.get_model().ams.data[self.index].tray[3].remain,
+            "tag_uid": self.coordinator.get_model().ams.data[self.index].tray[3].tag_uid,
         },
         exists_fn=lambda coordinator: not coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
@@ -495,6 +501,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[0].nozzle_temp_max,
             "type": self.coordinator.get_model().ams.data[self.index].tray[0].type,
             "remain": self.coordinator.get_model().ams.data[self.index].tray[0].remain,
+            "tag_uid": self.coordinator.get_model().ams.data[self.index].tray[0].tag_uid,
         },
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
@@ -515,6 +522,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[1].nozzle_temp_max,
             "type": self.coordinator.get_model().ams.data[self.index].tray[1].type,
             "remain": self.coordinator.get_model().ams.data[self.index].tray[1].remain,
+            "tag_uid": self.coordinator.get_model().ams.data[self.index].tray[1].tag_uid,
         },
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
@@ -535,6 +543,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[2].nozzle_temp_max,
             "type": self.coordinator.get_model().ams.data[self.index].tray[2].type,
             "remain": self.coordinator.get_model().ams.data[self.index].tray[2].remain,
+            "tag_uid": self.coordinator.get_model().ams.data[self.index].tray[2].tag_uid,
         },
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
@@ -555,6 +564,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[3].nozzle_temp_max,
             "type": self.coordinator.get_model().ams.data[self.index].tray[3].type,
             "remain": self.coordinator.get_model().ams.data[self.index].tray[3].remain,
+            "tag_uid": self.coordinator.get_model().ams.data[self.index].tray[3].tag_uid,
         },
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.K_VALUE)
     ),

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -554,6 +554,7 @@ class AMSList:
         #                     "bed_temp": "0",
         #                     "nozzle_temp_max": "240",
         #                     "nozzle_temp_min": "190",
+        #                     "remain": 100,
         #                     "xcam_info": "000000000000000000000000",
         #                     "tray_uuid": "00000000000000000000000000000000"
         #                 },
@@ -622,6 +623,7 @@ class AMSTray:
         self.color = "00000000"  # RRGGBBAA
         self.nozzle_temp_min = 0
         self.nozzle_temp_max = 0
+        self.remain = 0
         self.k = 0
 
     def print_update(self, data):
@@ -635,6 +637,7 @@ class AMSTray:
             self.color = "00000000"  # RRGGBBAA
             self.nozzle_temp_min = 0
             self.nozzle_temp_max = 0
+            self.remain = 0
             self.k = 0
         else:
             self.empty = False
@@ -645,6 +648,7 @@ class AMSTray:
             self.color = data.get('tray_color', self.color)
             self.nozzle_temp_min = data.get('nozzle_temp_min', self.nozzle_temp_min)
             self.nozzle_temp_max = data.get('nozzle_temp_max', self.nozzle_temp_max)
+            self.remain = data.get('remain', self.remain)
             self.k = data.get('k', self.k)
 
 
@@ -676,6 +680,7 @@ class ExternalSpool(AMSTray):
         #     "bed_temp": "0",
         #     "nozzle_temp_max": "280",
         #     "nozzle_temp_min": "240",
+        #     "remain": 100,
         #     "xcam_info": "000000000000000000000000",
         #     "tray_uuid": "00000000000000000000000000000000",
         #     "remain": 0,

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -625,6 +625,7 @@ class AMSTray:
         self.nozzle_temp_max = 0
         self.remain = 0
         self.k = 0
+        self.tag_uid = "0000000000000000"
 
     def print_update(self, data):
         if len(data) == 1:
@@ -638,6 +639,7 @@ class AMSTray:
             self.nozzle_temp_min = 0
             self.nozzle_temp_max = 0
             self.remain = 0
+            self.tag_uid = "0000000000000000"
             self.k = 0
         else:
             self.empty = False
@@ -649,6 +651,7 @@ class AMSTray:
             self.nozzle_temp_min = data.get('nozzle_temp_min', self.nozzle_temp_min)
             self.nozzle_temp_max = data.get('nozzle_temp_max', self.nozzle_temp_max)
             self.remain = data.get('remain', self.remain)
+            self.tag_uid = data.get('tag_uid', self.tag_uid)
             self.k = data.get('k', self.k)
 
 

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -325,6 +325,9 @@
           },
           "type": {
             "name": "Type"
+          },
+          "remain": {
+            "name": "Remaining filament"
           }
         }
       },
@@ -354,6 +357,9 @@
           },
           "type": {
             "name": "Type"
+          },
+          "remain": {
+            "name": "Remaining filament"
           }
         }
       },
@@ -383,6 +389,9 @@
           },
           "type": {
             "name": "Type"
+          },
+          "remain": {
+            "name": "Remaining filament"
           }
         }
       },
@@ -412,6 +421,9 @@
           },
           "type": {
             "name": "Type"
+          },
+          "remain": {
+            "name": "Remaining filament"
           }
         }
       }

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -328,6 +328,9 @@
           },
           "remain": {
             "name": "Remaining filament"
+          },
+          "tag_uid": {
+            "name": "Serial number of filament"
           }
         }
       },
@@ -360,6 +363,9 @@
           },
           "remain": {
             "name": "Remaining filament"
+          },
+          "tag_uid": {
+            "name": "Serial number of filament"
           }
         }
       },
@@ -392,6 +398,9 @@
           },
           "remain": {
             "name": "Remaining filament"
+          },
+          "tag_uid": {
+            "name": "Serial number of filament"
           }
         }
       },
@@ -424,6 +433,9 @@
           },
           "remain": {
             "name": "Remaining filament"
+          },
+          "tag_uid": {
+            "name": "Serial number of filament"
           }
         }
       }

--- a/custom_components/bambu_lab/translations/fr.json
+++ b/custom_components/bambu_lab/translations/fr.json
@@ -312,6 +312,9 @@
           },
           "remain": {
             "name": "Filament restant"
+          },
+          "tag_uid": {
+            "name": "Numéro de série du filament"
           }
         }
       },
@@ -344,6 +347,9 @@
           },
           "remain": {
             "name": "Filament restant"
+          },
+          "tag_uid": {
+            "name": "Numéro de série du filament"
           }
         }
       },
@@ -376,6 +382,9 @@
           },
           "remain": {
             "name": "Filament restant"
+          },
+          "tag_uid": {
+            "name": "Numéro de série du filament"
           }
         }
       },
@@ -408,6 +417,9 @@
           },
           "remain": {
             "name": "Filament restant"
+          },
+          "tag_uid": {
+            "name": "Numéro de série du filament"
           }
         }
       }

--- a/custom_components/bambu_lab/translations/fr.json
+++ b/custom_components/bambu_lab/translations/fr.json
@@ -309,6 +309,9 @@
           },
           "type": {
             "name": "Type"
+          },
+          "remain": {
+            "name": "Filament restant"
           }
         }
       },
@@ -338,6 +341,9 @@
           },
           "type": {
             "name": "Type"
+          },
+          "remain": {
+            "name": "Filament restant"
           }
         }
       },
@@ -367,6 +373,9 @@
           },
           "type": {
             "name": "Type"
+          },
+          "remain": {
+            "name": "Filament restant"
           }
         }
       },
@@ -396,6 +405,9 @@
           },
           "type": {
             "name": "Type"
+          },
+          "remain": {
+            "name": "Filament restant"
           }
         }
       }


### PR DESCRIPTION
To solve the open issue #249 I created a pull request which implements the reading of the filament. My solution is quite simple: I simply added the remain parameter as it is. For filaments that are not Bambulabs or when the reading is disabled in the printers settings the value will simply be -1 and otherwise represent a percentage from 0 - 100%