### PR TITLE
Improve german translation

### DIFF
--- a/custom_components/bambu_lab/translations/de.json
+++ b/custom_components/bambu_lab/translations/de.json
@@ -1,33 +1,33 @@
 {
   "device_automation": {
     "trigger_type": {
-      "event_print_canceled": "Druck abgebrochen",
-      "event_print_failed": "Druck fehlgeschlagen",
-      "event_print_finished": "Drucken beendet",
-      "event_print_started": "Drucken gestartet",
+      "event_print_canceled": "Druckauftrag abgebrochen",
+      "event_print_failed": "Druckauftrag fehlgeschlagen",
+      "event_print_finished": "Druckauftrag beendet",
+      "event_print_started": "Druckauftrag gestartet",
       "event_printer_error": "Druckerfehler erkannt"
     }
   },
   "config": {
     "abort": {
-      "already_configured": "Gerät ist bereits konfiguriert"
+      "already_configured": "Das Gerät ist bereits eingerichtet"
     },
     "error": {
       "cannot_connect": "Verbindung fehlgeschlagen",
-      "invalid_auth": "Ungültige Authentifizierung",
+      "invalid_auth": "Authentifizierung fehlgeschlagen",
       "unbekannt": "Unerwarteter Fehler"
     },
     "step": {
       "user": {
-        "description": "Bitte wählen Sie Ihren Drucker aus und geben Sie dessen Seriennummer an.\n\nBeachten Sie, dass die neueste P1P-Firmware (1.0.4.0) nur eine einzige lokale Verbindung korrekt unterstützt. Wenn Sie eine zweite benötigen (z.B. für P1Touch), können Sie Bambu Cloud in dieser Integration verwenden.\n\nBenutzen Sie in allen anderen Fällen lokal.",
+        "description": "Bitte wählen Sie Ihr Druckermodell aus und geben Sie dessen Seriennummer an.\n\nBeachten Sie, dass die neueste P1-Firmware (1.0.4.0) nur eine einzige lokale Verbindung zulässt. Wenn Sie eine weitere Verbindung benötigen (z.B. für xtouch), verwenden Sie die Bambu Cloud MQTT-Verbindung.\n\nIn allen anderen Fällen verwenden Sie die Lokale MQTT-Verbindung.",
         "data": {
-          "device_type": "Drucker-Modell:",
+          "device_type": "Druckermodell:",
           "serial": "Seriennummer",
-          "printer_mode": "Drucker MQTT-Verbindungsmodus:"
+          "printer_mode": "MQTT-Verbindungsmodus:"
         }
       },
       "Bambu": {
-        "title": "Bambu Cloud MQTT Verbindung",
+        "title": "Bambu Cloud MQTT-Verbindung",
         "description": "Bitte geben Sie Ihre Bambu-Lab-Anmeldedaten an, damit ein Authentifizierungs-Token generiert werden kann. Nur das Token wird gespeichert, Ihre Bambu-Anmeldedaten nicht.",
         "data": {
           "username": "E-Mail Adresse",
@@ -38,7 +38,7 @@
         "title": "Lokale MQTT-Verbindung",
         "Beschreibung": "Bitte geben Sie Ihre lokale Drucker-IP-Adresse und den Zugangscode an. Den Zugangscode finden Sie auf dem Bildschirm des Druckers in den Netzwerkeinstellungen.",
         "data": {
-          "host": "Host-IP",
+          "host": "Drucker-IP",
           "access_code": "Zugangscode"
         }
       }
@@ -47,19 +47,19 @@
   "options": {
     "error": {
       "cannot_connect": "Verbindung fehlgeschlagen",
-      "invalid_auth": "Ungültige Authentifizierung",
+      "invalid_auth": "Authentifizierung fehlgeschlagen",
       "unbekannt": "Unerwarteter Fehler"
     },
-    "Schritt": {
+    "step": {
       "init": {
         "title": "Verbindungseinstellungen anpassen",
-        "description": "Wählen Sie die neuen Verbindungseinstellungen für diesen Drucker.\n\nBeachten Sie, dass die neueste P1P-Firmware (1.0.4.0) nur eine einzige lokale Verbindung korrekt unterstützt. Wenn Sie eine zweite benötigen (z. B. für P1Touch), können Sie Bambu Cloud in dieser Integration verwenden.\n\nBenutzen Sie in allen anderen Fällen lokal.",
+        "description": "Wählen Sie die neuen Verbindungseinstellungen für diesen Drucker.\n\nBeachten Sie, dass die neueste P1-Firmware (1.0.4.0) nur eine einzige lokale Verbindung zulässt. Wenn Sie eine weitere Verbindung benötigen (z.B. für xtouch), verwenden Sie die Bambu Cloud MQTT-Verbindung.\n\nIn allen anderen Fällen verwenden Sie die Lokale MQTT-Verbindung.",
         "data": {
-          "printer_mode": "Drucker MQTT-Verbindungsmodus:"
+          "printer_mode": "MQTT-Verbindungsmodus:"
         }
       },
       "Bambu": {
-        "title": "Bambu Cloud MQTT Verbindung",
+        "title": "Bambu Cloud MQTT-Verbindung",
         "description": "Bitte geben Sie Ihre Bambu-Lab-Anmeldedaten an, damit ein Authentifizierungs-Token generiert werden kann. Nur das Token wird gespeichert, Ihre Bambu-Anmeldedaten nicht.",
         "data": {
           "username": "E-Mail Adresse",
@@ -70,7 +70,7 @@
         "title": "Lokale MQTT-Verbindung",
         "Beschreibung": "Bitte geben Sie Ihre lokale Drucker-IP-Adresse und den Zugangscode an. Den Zugangscode finden Sie auf dem Bildschirm des Druckers in den Netzwerkeinstellungen.",
         "data": {
-          "host": "Host-IP",
+          "host": "Drucker-IP",
           "access_code": "Zugangscode"
         }
       }
@@ -88,32 +88,32 @@
         "name": "Online"
       },
       "firmware_update": {
-        "name": "Aktualisierung der Firmware"
+        "name": "Firmware Status"
       }
     },
     "button": {
       "pause": {
-        "name": "Druck anhalten"
+        "name": "Druckvorgang anhalten"
       },
       "resume": {
-        "name": "Druck fortsetzen"
+        "name": "Druckvorgang fortsetzen"
       },
       "stop": {
-        "name": "Druck beenden"
+        "name": "Druckvorgang beenden"
       },
       "refresh": {
-        "name": "Aktualisieren der Daten erzwingen"
+        "name": "Aktualisierung erzwingen"
       }
     },
     "fan": {
       "cooling_fan": {
-        "name": "Kühlgebläse"
+        "name": "Druckkopflüfter"
       },
       "aux_fan": {
-        "name": "Hilfslüfter"
+        "name": "Bauteillüfter"
       },
       "chamber_fan": {
-        "name": "Kammerventilator"
+        "name": "Druckraumlüfter"
       }
     },
     "image": {
@@ -123,10 +123,10 @@
     },
     "light": {
       "chamber_light": {
-        "name": "Kammer LED"
+        "name": "Druckraumbeleuchtung"
       },
       "camera_light": {
-        "name": "Kamera Licht"
+        "name": "Kamerabeleuchtung"
       }
     },
     "select": {
@@ -142,34 +142,34 @@
     },
     "sensor": {
       "wifi_signal": {
-        "name": "Wi-Fi-Signal"
+        "name": "Wi-Fi-Signalquallität"
       },
       "bed_temp": {
-        "name": "Betttemperatur"
+        "name": "Druckbetttemperatur"
       },
       "target_bed_temp": {
-        "name": "Zielwert Betttemperatur"
+        "name": "Zieltemperatur des Druckbett"
       },
       "chamber_temp": {
-        "name": "Temperatur in der Kammer"
+        "name": "Temperatur im Druckraum"
       },
       "target_nozzle_temp": {
-        "name": "Düsensolltemperatur"
+        "name": "Zieltemperatur der Düse"
       },
       "nozzle_temp": {
-        "name": "Düsentemperatur"
+        "name": "Temperatur der Düse"
       },
       "aux_fan_speed": {
-        "name": "Gebläsedrehzahl"
+        "name": "Bauteillüfterdrehzahl"
       },
       "cooling_fan_speed": {
-        "name": "Drehzahl des Kühlgebläses"
+        "name": "Druckkopflüfterdrehzahl"
       },
       "chamber_fan_speed": {
-        "name": "Drehzahl des Kammerlüfters"
+        "name": "Druckraumlüfterdrehzahl"
       },
       "heatbreak_fan_speed": {
-        "name": "Geschwindigkeit des Heatbreak-Lüfters"
+        "name": "Hotendlüfterdrehzahl"
       },
       "speed_profile": {
         "name": "Geschwindigkeitsprofil",
@@ -194,8 +194,8 @@
           "heatbed_preheating": "Heizbettvorwärmung",
           "sweeping_xy_mech_mode": "Fegen im XY-Mechanik-Modus",
           "changing_filament": "Filament wechseln",
-          "m400_pause": "M400-Pause",
-          "paused_filament_runout": "Pausiert da das Filament leer gelaufe ist",
+          "m400_pause": "M400 Pause",
+          "paused_filament_runout": "Pausiert, weil das Filament leer ist",
           "heating_hotend": "Hotend wird erhitzt",
           "calibrating_extrusion": "Kalibrierung der Extrusion",
           "scanning_bed_surface": "Abtasten der Oberfläche des Bettes",
@@ -206,7 +206,7 @@
           "cleaning_nozzle_tip": "Reinigung der Düsenspitze",
           "checking_extruder_temperature": "Kontrolle der Extrudertemperatur",
           "paused_user": "Der Druckvorgang wurde vom Benutzer angehalten",
-          "paused_front_cover_falling": "Pause, da der Deckel vom Werkzeugkopf abgefallen ist",
+          "paused_front_cover_falling": "Pause, weil die Abdeckung des Druckkopf abgefallen ist",
           "calibrating_extrusion_flow": "Kalibrierung des Extrusionsflusses",
           "paused_nozzle_temperature_malfunction": "Pausiert aufgrund einer Störung der Düsentemperatur",
           "paused_heat_bed_temperature_malfunction": "Pausiert aufgrund einer Störung der Wärmebetttemperatur",
@@ -219,7 +219,7 @@
       "print_status": {
         "name": "Druckstatus",
         "state": {
-          "failed": "Gescheitert",
+          "failed": "Fehlgeschlagen",
           "finish": "Fertig",
           "idle": "Leerlauf",
           "offline": "Offline",
@@ -250,7 +250,7 @@
         "name": "Verbleibende Zeit"
       },
       "end_time": {
-        "name": "Endzeit"
+        "name": "Vrs. Fertigstellung"
       },
       "current_layer": {
         "name": "Aktuelle Schicht"
@@ -335,7 +335,7 @@
         }
       },
       "tray_2": {
-        "name": "Tablett 2",
+        "name": "Fach 2",
         "state_attributes": {
           "active": {
             "name": "Aktiv"
@@ -370,7 +370,7 @@
         }
       },
       "tray_3": {
-        "name": "Tablett 3",
+        "name": "Fach 3",
         "state_attributes": {
           "active": {
             "name": "Aktiv"
@@ -405,7 +405,7 @@
         }
       },
       "tray_4": {
-        "name": "Tablett 4",
+        "name": "Fach 4",
         "state_attributes": {
           "active": {
             "name": "Aktiv"


### PR DESCRIPTION
Improve translation.
change "schritt" should be "step" (otherwise the after Konfiguration is still English).
change "Tablett 2-4" to "Fach 2-4"
Rename Fans, to match with correct naming