### PR TITLE
Reapply camera URL fix

### DIFF
--- a/custom_components/bambu_lab/camera.py
+++ b/custom_components/bambu_lab/camera.py
@@ -68,8 +68,8 @@ class BambuLabCamera(BambuLabEntity, Camera):
 
             parsed_url = urlparse(self.coordinator.get_model().camera.rtsp_url)
             if self.coordinator.get_model().info.mqtt_mode == "local":
-                # For unknown reasons the returns rtsp URL sometimes has a completely incorrect IP address in it for the host.
-                # Since we know the correct IP (in local mqtt connection mode), rewrite the URL to have that.
+                # For unknown reasons the returned rtsp URL sometimes has a completely incorrect IP address in it for the host.
+                # Since we know the correct IP (but only in local mqtt connection mode), rewrite the URL to have that.
                 url = fr"{parsed_url.scheme}://bblp:{self._access_code}@{self._host}/{parsed_url.path}"
             else:
                 url = fr"{parsed_url.scheme}://bblp:{self._access_code}@{parsed_url.netloc}{parsed_url.path}"

--- a/custom_components/bambu_lab/camera.py
+++ b/custom_components/bambu_lab/camera.py
@@ -67,7 +67,10 @@ class BambuLabCamera(BambuLabEntity, Camera):
             # rtsps://192.168.1.1/streaming/live/1
 
             parsed_url = urlparse(self.coordinator.get_model().camera.rtsp_url)
-            url = fr"{parsed_url.scheme}://bblp:{self._access_code}@{parsed_url.netloc}{parsed_url.path}"
+            if self.coordinator.get_model().info.mqtt_mode == "local":
+                url = fr"{parsed_url.scheme}://bblp:{self._access_code}@{self._host}/{parsed_url.path}"
+            else:
+                url = fr"{parsed_url.scheme}://bblp:{self._access_code}@{parsed_url.netloc}{parsed_url.path}"
 
             LOGGER.debug(f"Camera RTSP Feed is {url}")
             return str(url)

--- a/custom_components/bambu_lab/camera.py
+++ b/custom_components/bambu_lab/camera.py
@@ -68,6 +68,8 @@ class BambuLabCamera(BambuLabEntity, Camera):
 
             parsed_url = urlparse(self.coordinator.get_model().camera.rtsp_url)
             if self.coordinator.get_model().info.mqtt_mode == "local":
+                # For unknown reasons the returns rtsp URL sometimes has a completely incorrect IP address in it for the host.
+                # Since we know the correct IP (in local mqtt connection mode), rewrite the URL to have that.
                 url = fr"{parsed_url.scheme}://bblp:{self._access_code}@{self._host}/{parsed_url.path}"
             else:
                 url = fr"{parsed_url.scheme}://bblp:{self._access_code}@{parsed_url.netloc}{parsed_url.path}"


### PR DESCRIPTION
The code changed slightly since the original fix and re-enabling cloud mqtt mode for connection means we don't necessarily have the right host name/IP to use so need to protect against that as well.