### PR TITLE
Fix extra backslash in URL

### DIFF
--- a/custom_components/bambu_lab/camera.py
+++ b/custom_components/bambu_lab/camera.py
@@ -70,7 +70,7 @@ class BambuLabCamera(BambuLabEntity, Camera):
             if self.coordinator.get_model().info.mqtt_mode == "local":
                 # For unknown reasons the returned rtsp URL sometimes has a completely incorrect IP address in it for the host.
                 # Since we know the correct IP (but only in local mqtt connection mode), rewrite the URL to have that.
-                url = fr"{parsed_url.scheme}://bblp:{self._access_code}@{self._host}/{parsed_url.path}"
+                url = fr"{parsed_url.scheme}://bblp:{self._access_code}@{self._host}{parsed_url.path}"
             else:
                 url = fr"{parsed_url.scheme}://bblp:{self._access_code}@{parsed_url.netloc}{parsed_url.path}"
 


### PR DESCRIPTION
parsed_url.path already has the leading backslash in it.