### PR TITLE
Fix handling of gap in AMS indices

### DIFF
--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -412,7 +412,7 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
                         "serial": self.config_entry.data['serial']
                 }
                 options = {
-                        "email": self.config_entry.data['email'],
+                        "email": self.config_entry.options.get('email', ''),
                         "username": "",
                         "name": "",
                         "host": user_input['host'],

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -182,17 +182,18 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         device = self.get_model()
         dev_reg = device_registry.async_get(self._hass)
         for index in range (0, len(device.ams.data)):
-            LOGGER.debug(f"Initialize AMS {index+1}")
-            hadevice = dev_reg.async_get_or_create(config_entry_id=self._entry.entry_id,
-                                                   identifiers={(DOMAIN, device.ams.data[index].serial)})
-            serial = self._entry.data["serial"]
-            device_type = self._entry.data["device_type"]
-            dev_reg.async_update_device(hadevice.id,
-                                        name=f"{device_type}_{serial}_AMS_{index+1}",
-                                        model="AMS",
-                                        manufacturer=BRAND,
-                                        sw_version=device.ams.data[index].sw_version,
-                                        hw_version=device.ams.data[index].hw_version)
+            if device.ams.data[index] is not None:
+                LOGGER.debug(f"Initialize AMS {index+1}")
+                hadevice = dev_reg.async_get_or_create(config_entry_id=self._entry.entry_id,
+                                                    identifiers={(DOMAIN, device.ams.data[index].serial)})
+                serial = self._entry.data["serial"]
+                device_type = self._entry.data["device_type"]
+                dev_reg.async_update_device(hadevice.id,
+                                            name=f"{device_type}_{serial}_AMS_{index+1}",
+                                            model="AMS",
+                                            manufacturer=BRAND,
+                                            sw_version=device.ams.data[index].sw_version,
+                                            hw_version=device.ams.data[index].hw_version)
 
         self._lock.release()
         self.hass.async_create_task(self._reinitialize_sensors())

--- a/custom_components/bambu_lab/sensor.py
+++ b/custom_components/bambu_lab/sensor.py
@@ -30,7 +30,8 @@ async def async_setup_entry(
     for sensor in AMS_SENSORS:
         if sensor.exists_fn(coordinator):
             for index in range (0, len(coordinator.get_model().ams.data)):
-                async_add_entities([BambuLabAMSSensor(coordinator, sensor, index)])
+                if coordinator.get_model().ams.data[index] is not None:
+                    async_add_entities([BambuLabAMSSensor(coordinator, sensor, index)])
 
     for sensor in PRINTER_SENSORS:    
         if sensor.exists_fn(coordinator):


### PR DESCRIPTION
If you add two AMS's they get permanently assigned an index on that printer. So if they are 'A' and 'B' and you then later remove 'A', 'B' will remain at index 1 rather than becoming index 0. We didn't support a sparse list so mishandled that case. This fixes it.