### PR TITLE
Fix X1 stopping updating

### DIFF
--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -39,7 +39,7 @@ class WatchdogThread(threading.Thread):
     def received_data(self):
         self._last_received_data = time.time()
 
-    async def run(self):
+    def run(self):
         LOGGER.info("Watchdog thread started.")
         WATCHDOG_TIMER = 20
         while True:
@@ -53,7 +53,7 @@ class WatchdogThread(threading.Thread):
             if not self._watchdog_fired and (interval > WATCHDOG_TIMER):
                 LOGGER.debug(f"Watchdog fired. No data received for {interval} seconds.")
                 self._watchdog_fired = True
-                await self._client.on_watchdog_fired()
+                self._client.on_watchdog_fired()
             elif interval < WATCHDOG_TIMER:
                 self._watchdog_fired = False
 
@@ -211,7 +211,7 @@ class BambuClient:
             # Reconnect normally
             await self.connect(self.callback)
 
-    async def connect(self, callback):
+    def connect(self, callback):
         """Connect to the MQTT Broker"""
         self.client = mqtt.Client()
         self.callback = callback
@@ -292,12 +292,12 @@ class BambuClient:
             self._camera.stop()
             self._camera.join()
 
-    async def on_watchdog_fired(self):
+    def on_watchdog_fired(self):
         LOGGER.info("Watch dog fired")
         # We can simply disconnect - the mqtt listener thread will detect this and immediately try to reconnect.
         self.disconnect()
         # Reconnect
-        await self.connect(self.callback)
+        self.connect(self.callback)
 
     def on_jpeg_received(self, bytes):
         #LOGGER.debug("JPEG received")


### PR DESCRIPTION
While I still don't understand the true root cause, the problem was the exception was being thrown in this method while the lock was acquired and the exception causes the release to be skipped:
![image](https://github.com/greghesp/ha-bambulab/assets/26147576/2f1f94e7-320b-4c88-b51c-4609a594cc1c)

The locking was added as an early attempt to fix a set of errors about duplicate (non-unique) AMS entries. It later turned out to not work and I found the real fix was to be more deliberate about initialization order - don't start the mqtt thread until the initial integration setup was complete otherwise the newly discovered AMSs could arrive while the integration was still mid-initialization as far as home assistant was concerned. So that locking is likely not helping and can be removed again. While that doesn't fix the exception, it will stop the X1 mqtt thread regularly hanging.

Also fixed a just introduced issue where the watchdog thread doesn't reliably run due to making the run thread async but that means it's not awaited by the underlying python threading functionality which means it doesn't run.