### PR TITLE
Reuse authentication when possible during reconfigure

### DIFF
--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -296,7 +296,7 @@ class BambuClient:
         LOGGER.info("Watch dog fired")
         self._device.info.set_online(False)
         self.publish(START_PUSH)
-
+        
     def on_jpeg_received(self, bytes):
         #LOGGER.debug("JPEG received")
         self._device.p1p_camera.on_jpeg_received(bytes)

--- a/custom_components/bambu_lab/pybambu/bambu_cloud.py
+++ b/custom_components/bambu_lab/pybambu/bambu_cloud.py
@@ -74,6 +74,26 @@ class BambuCloud:
     #     ]
     # }
 
+    def _test_authentication_token(self) -> dict:
+        LOGGER.debug("Getting accessToken from Bambu Cloud")
+        url = 'https://api.bambulab.com/v1/user-service/user/login'
+        headers = {'Authorization': 'Bearer ' + self._auth_token}
+        response = requests.get(url, headers=headers, timeout=10)
+        if not response.ok:
+            LOGGER.debug(f"Received error: {response.status_code}")
+            raise ValueError(response.status_code)
+        LOGGER.debug(f"Success: {response.json()}")
+
+    def TestAuthentication(self, email: str, username: str, auth_token: str) -> bool:
+        self._email = email
+        self._username = username
+        self._auth_token = auth_token
+        try:
+            self.GetDeviceList()
+        except:
+            return False
+        return True
+
     def Login(self, email: str, password: str):
         self._email = email
         self._password = password
@@ -90,11 +110,32 @@ class BambuCloud:
             LOGGER.debug(f"Received error: {response.status_code}")
             raise ValueError(response.status_code)
         LOGGER.debug(f"Success: {response.json()}")
-        LOGGER.debug(f"{response.json()['devices']}")
         return response.json()['devices']
+
+    def GetTaskList(self) -> dict:
+        LOGGER.debug("Getting task list from Bambu Cloud")
+        url = 'https://api.bambulab.com/v1/user-service/my/tasks'
+        headers = {'Authorization': 'Bearer ' + self._auth_token}
+        response = requests.get(url, headers=headers, timeout=10)
+        if not response.ok:
+            LOGGER.debug(f"Received error: {response.status_code}")
+            raise ValueError(response.status_code)
+        #LOGGER.debug(f"Success: {response.json()}")
+        return response.json()
+    
+    def GetTaskListForPrinter(self, deviceId: str) -> dict:
+        LOGGER.debug(f"Getting task list from Bambu Cloud for Printer: {deviceId}")
+        data = self.GetTaskList()
+        for task in data['hits']:
+            if task['deviceId'] == deviceId:
+                LOGGER.debug(f"TASK: {task}")
+                return task
+        return {}
 
     def GetDeviceTypeFromDeviceProductName(self, device_product_name: str):
         match device_product_name:
+            case "X1E":
+                return "X1E"
             case "X1 Carbon":
                 return "X1C"
             case "X1":


### PR DESCRIPTION
During the options flow we have access to previously provided email, username and authToken (if previously configured via bambu cloud). If we have this we test if it still works and only if not do we prompt the user for their bambu credentials.

Also added a new bambu cloud API wrapper to retrieve the latest task assigned to a printer. Not used yet but will be used to populate further sensors and to download the image for the current/last print job when not in lan mode.