### PR TITLE
Harden rtsp camera handling

### DIFF
--- a/custom_components/bambu_lab/camera.py
+++ b/custom_components/bambu_lab/camera.py
@@ -52,9 +52,7 @@ class BambuLabCamera(BambuLabEntity, Camera):
 
     @property
     def is_streaming(self) -> bool:
-        if self.coordinator.get_model().camera.rtsp_url == "disable" or None:
-            return False
-        return True
+        return self.available
 
     @property
     def is_recording(self) -> bool:
@@ -62,8 +60,12 @@ class BambuLabCamera(BambuLabEntity, Camera):
             return True
         return False
 
+    @property
+    def available(self) -> bool:
+        return self.coordinator.get_model().camera.rtsp_url is not None or "disable"
+
     async def stream_source(self) -> str | None:
-        if self.coordinator.get_model().camera.rtsp_url is not None:
+        if self.available:
             # rtsps://192.168.1.1/streaming/live/1
 
             parsed_url = urlparse(self.coordinator.get_model().camera.rtsp_url)

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -299,7 +299,6 @@ class BambuClient:
         self.publish(START_PUSH)
         
     def on_jpeg_received(self, bytes):
-        #LOGGER.debug("JPEG received")
         self._device.p1p_camera.set_jpeg(bytes)
 
     def on_message(self, client, userdata, message):


### PR DESCRIPTION
The Camera should not report itself as available or try to process the rtsp URL when disabled as there won't be an RTSP URL in the mqtt data.