### PR TITLE
Add print weight, length and bed type sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ instead of OAuth.
 | Current Stage |                   |
 | Print Status  |                   |
 | Cover Image   |                   |
+| Print Weight  |                   |
 
 ### Miscellaneous
 

--- a/README.md
+++ b/README.md
@@ -62,14 +62,17 @@ instead of OAuth.
 
 ### Print Progress
 
-| Sensor            | Notes                |
-|-------------------|----------------------|
-| Current Layer     |                      |
-| Total Layer Count |                      |
-| Print Progress    |                      |
-| Start Time        | Simulated on P1*/A1* |
-| Remainining Time  |                      |
-| End Time          |                      |
+| Sensor            | Notes                    |
+|-------------------|--------------------------|
+| Current Layer     |                          |
+| Total Layer Count |                          |
+| Print Progress    |                          |
+| Print Weight      |                          |
+| Print Length      |                          |
+| Print Bed Type    | Not the current bed type |
+| Start Time        | Simulated on P1*/A1*     |
+| Remainining Time  |                          |
+| End Time          |                          |
 
 ### Status
 

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -46,7 +46,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
             
         self._updatedDevice = False
         self.data = self.get_model()
-        self.P1PCamera = None
+        self.ChamberImage = None
         super().__init__(
             hass,
             LOGGER,
@@ -99,8 +99,8 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
                 case "event_print_started":
                     self.PublishDeviceTriggerEvent(event)
 
-                case "p1p_jpeg_received":
-                    self._p1p_camera_jpeg_updated()
+                case "chamber_image_received":
+                    self._chamber_image_updated()
 
 
         async def listen():
@@ -148,8 +148,8 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
                 LOGGER.debug(f"EVENT: HMS errors: {event_data}")
                 self._hass.bus.async_fire(f"{DOMAIN}_event", event_data)
 
-    def _p1p_camera_jpeg_updated(self):
-        self.P1PCamera.jpeg_updated()
+    def _chamber_image_updated(self):
+        self.ChamberImage.image_updated()
 
     def _update_device_info(self):
         if not self._updatedDevice:

--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -8,9 +8,10 @@ from dataclasses import dataclass
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.const import (
     PERCENTAGE,
-    TEMPERATURE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     UnitOfTemperature,
+    UnitOfMass,
+    UnitOfLength,
     TIME_MINUTES
 )
 
@@ -307,6 +308,30 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         icon="mdi:file",
         available_fn=lambda self: self.coordinator.get_model().info.subtask_name != "",
         value_fn=lambda self: self.coordinator.get_model().info.subtask_name
+    ),
+    BambuLabSensorEntityDescription(
+        key="print_length",
+        translation_key="print_length",
+        native_unit_of_measurement=UnitOfLength.METERS,
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:file",
+        value_fn=lambda self: self.coordinator.get_model().info.print_length / 100
+    ),
+    BambuLabSensorEntityDescription(
+        key="print_bed_type",
+        translation_key="print_bed_type",
+        icon="mdi:file",
+        value_fn=lambda self: self.coordinator.get_model().info.print_bed_type
+    ),
+    BambuLabSensorEntityDescription(
+        key="print_weight",
+        translation_key="print_weight",
+        native_unit_of_measurement=UnitOfMass.GRAMS,
+        device_class=SensorDeviceClass.WEIGHT,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:file",
+        value_fn=lambda self: self.coordinator.get_model().info.print_weight
     ),
     BambuLabSensorEntityDescription(
         key="active_tray",

--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -568,7 +568,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
     ),
 )
 
-P1P_IMAGE_SENSOR = BambuLabSensorEntityDescription(
+CHAMBER_IMAGE_SENSOR = BambuLabSensorEntityDescription(
         key="p1p_camera",
         translation_key="p1p_camera",
         value_fn=lambda self: self.coordinator.get_model().get_camera_image(),

--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -316,13 +316,15 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:file",
-        value_fn=lambda self: self.coordinator.get_model().info.print_length / 100
+        value_fn=lambda self: self.coordinator.get_model().info.print_length / 100,
+        exists_fn=lambda coordinator: coordinator.get_model().info.has_bambu_cloud_connection
     ),
     BambuLabSensorEntityDescription(
         key="print_bed_type",
         translation_key="print_bed_type",
         icon="mdi:file",
-        value_fn=lambda self: self.coordinator.get_model().info.print_bed_type
+        value_fn=lambda self: self.coordinator.get_model().info.print_bed_type,
+        exists_fn=lambda coordinator: coordinator.get_model().info.has_bambu_cloud_connection
     ),
     BambuLabSensorEntityDescription(
         key="print_weight",
@@ -331,7 +333,8 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.WEIGHT,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:file",
-        value_fn=lambda self: self.coordinator.get_model().info.print_weight
+        value_fn=lambda self: self.coordinator.get_model().info.print_weight,
+        exists_fn=lambda coordinator: coordinator.get_model().info.has_bambu_cloud_connection
     ),
     BambuLabSensorEntityDescription(
         key="active_tray",

--- a/custom_components/bambu_lab/image.py
+++ b/custom_components/bambu_lab/image.py
@@ -10,7 +10,7 @@ from homeassistant.util import dt as dt_util
 from .const import DOMAIN, LOGGER
 from .coordinator import BambuDataUpdateCoordinator
 from .models import BambuLabEntity
-from .definitions import P1P_IMAGE_SENSOR, COVER_IMAGE_SENSOR, BambuLabSensorEntityDescription
+from .definitions import CHAMBER_IMAGE_SENSOR, COVER_IMAGE_SENSOR, BambuLabSensorEntityDescription
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -22,10 +22,10 @@ async def async_setup_entry(
     LOGGER.debug("IMAGE::async_setup_entry")
     coordinator: BambuDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    if P1P_IMAGE_SENSOR.exists_fn(coordinator):
-        P1PCamera = P1PImage(hass, coordinator, P1P_IMAGE_SENSOR)
-        async_add_entities([P1PCamera])
-        coordinator.P1PCamera = P1PCamera
+    if CHAMBER_IMAGE_SENSOR.exists_fn(coordinator):
+        chamber_image = ChamberImage(hass, coordinator, CHAMBER_IMAGE_SENSOR)
+        async_add_entities([chamber_image])
+        coordinator.ChamberImage = chamber_image
 
     if COVER_IMAGE_SENSOR.exists_fn(coordinator):
         cover_image = CoverImage(hass, coordinator, COVER_IMAGE_SENSOR)
@@ -33,7 +33,7 @@ async def async_setup_entry(
         #coordinator.CoverImage = cover_image
 
 
-class P1PImage(ImageEntity, BambuLabEntity):
+class ChamberImage(ImageEntity, BambuLabEntity):
     """Representation of an image entity."""
 
     def __init__(
@@ -54,9 +54,9 @@ class P1PImage(ImageEntity, BambuLabEntity):
     def image(self) -> bytes | None:
         """Return bytes of image."""
 
-        return self.coordinator.get_model().p1p_camera.get_jpeg()
+        return self.coordinator.get_model().chamber_image.get_jpeg()
 
-    def jpeg_updated(self):
+    def image_updated(self):
         self._attr_image_last_updated = dt_util.utcnow()
 
 class CoverImage(ImageEntity, BambuLabEntity):
@@ -82,5 +82,5 @@ class CoverImage(ImageEntity, BambuLabEntity):
 
         return self.coordinator.get_model().cover_image.get_jpeg()
 
-    def jpeg_updated(self):
+    def image_updated(self):
         self._attr_image_last_updated = dt_util.utcnow()

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -60,7 +60,7 @@ class WatchdogThread(threading.Thread):
         LOGGER.info("Watchdog thread exited.")
 
 
-class P1PCameraThread(threading.Thread):
+class ImageCameraThread(threading.Thread):
     def __init__(self, client):
         self._client = client
         self._stop_event = threading.Event()
@@ -70,7 +70,7 @@ class P1PCameraThread(threading.Thread):
         self._stop_event.set()
 
     def run(self):
-        LOGGER.debug("P1P Camera thread started.")
+        LOGGER.debug("Image Camera thread started.")
 
         d = bytearray()
 
@@ -129,7 +129,7 @@ class P1PCameraThread(threading.Thread):
 
                     self._client.on_jpeg_received(img)
 
-        LOGGER.info("P1P Camera thread exited.")
+        LOGGER.info("Image Camera thread exited.")
 
 
 def mqtt_listen_thread(self):
@@ -258,8 +258,8 @@ class BambuClient:
         self._watchdog.start()
 
         if self._device.supports_feature(Features.CAMERA_IMAGE) and self.host != "":
-            LOGGER.debug("Starting P1P camera thread")
-            self._camera = P1PCameraThread(self)
+            LOGGER.debug("Starting Image Camera thread")
+            self._camera = ImageCameraThread(self)
             self._camera.start()
 
 
@@ -299,7 +299,7 @@ class BambuClient:
         self.publish(START_PUSH)
         
     def on_jpeg_received(self, bytes):
-        self._device.p1p_camera.set_jpeg(bytes)
+        self._device.chamber_image.set_jpeg(bytes)
 
     def on_message(self, client, userdata, message):
         """Return the payload when received"""

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -37,7 +37,7 @@ class Device:
         self.push_all_data = None
         self.get_version_data = None
         if self.supports_feature(Features.CAMERA_IMAGE):
-            self.p1p_camera = P1PCamera(client)
+            self.chamber_image = ChamberImage(client)
         self.cover_image = CoverImage(client)
 
     def print_update(self, data):
@@ -475,6 +475,7 @@ class Info:
         # And the P1P lists it's versions in new_ver_list as a structured set of data with old
         # and new versions provided for each component. While the X1 lists only the new version
         # in separate string properties.
+
         self.new_version_state = data.get("upgrade_state", {}).get("new_version_state", self.new_version_state)
 
     def _update_task_data(self):
@@ -859,7 +860,7 @@ class HMSList:
                     self.client.callback("event_hms_errors")
 
 @dataclass
-class P1PCamera:
+class ChamberImage:
     """Returns the latest jpeg data from the P1P camera"""
     def __init__(self, client):
         self.client = client
@@ -867,7 +868,7 @@ class P1PCamera:
 
     def set_jpeg(self, bytes):
         self._bytes = bytes
-        self.client.callback("p1p_jpeg_received")
+        self.client.callback("camera_jpeg_received")
     
     def get_jpeg(self) -> bytearray:
         return self._bytes
@@ -882,7 +883,7 @@ class CoverImage:
 
     def set_jpeg(self, bytes):
         self._bytes = bytes
-        #self.client.callback("p1p_jpeg_received")
+        #self.client.callback("cover_image_jpeg_received")
     
     def get_jpeg(self) -> bytearray:
         return self._bytes

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -305,6 +305,9 @@ class Info:
         self.new_version_state = 0
         self.print_error = 0
         self._cover_url = ""
+        self.print_weight = 0
+        self.print_length = 0
+        self.print_bed_type = "unknown"
 
     def set_online(self, online):
         if self.online != online:
@@ -478,6 +481,48 @@ class Info:
 
         self.new_version_state = data.get("upgrade_state", {}).get("new_version_state", self.new_version_state)
 
+    # The task list is of the following form with a 'hits' array with typical 20 entries.
+    #
+    # "total": 531,
+    # "hits": [
+    #     {
+    #     "id": 35237965,
+    #     "designId": 0,
+    #     "designTitle": "",
+    #     "instanceId": 0,
+    #     "modelId": "REDACTED",
+    #     "title": "REDACTED",
+    #     "cover": "REDACTED",
+    #     "status": 4,
+    #     "feedbackStatus": 0,
+    #     "startTime": "2023-12-21T19:02:16Z",
+    #     "endTime": "2023-12-21T19:02:35Z",
+    #     "weight": 34.62,
+    #     "length": 1161,
+    #     "costTime": 10346,
+    #     "profileId": 35276233,
+    #     "plateIndex": 1,
+    #     "plateName": "",
+    #     "deviceId": "REDACTED",
+    #     "amsDetailMapping": [
+    #         {
+    #         "ams": 4,
+    #         "sourceColor": "F4D976FF",
+    #         "targetColor": "F4D976FF",
+    #         "filamentId": "GFL99",
+    #         "filamentType": "PLA",
+    #         "targetFilamentType": "",
+    #         "weight": 34.62
+    #         }
+    #     ],
+    #     "mode": "cloud_file",
+    #     "isPublicProfile": false,
+    #     "isPrintable": true,
+    #     "deviceModel": "P1P",
+    #     "deviceName": "Bambu P1P",
+    #     "bedType": "textured_plate"
+    #     },
+
     def _update_task_data(self):
         if self.has_bambu_cloud_connection:
             LOGGER.debug("Updating cloud task data")
@@ -486,6 +531,10 @@ class Info:
             if url != "":
                 data = self.client.bambu_cloud.download(url)
                 self.device.cover_image.set_jpeg(data)
+
+            self.print_weight = self._task_data.get('weight', self.print_weight)
+            self.print_length = self._task_data.get('length', self.print_length)
+            self.print_bed_type = self._task_data.get('bedType', self.print_bed_type)
 
     @property
     def has_bambu_cloud_connection(self) -> bool:

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -261,6 +261,15 @@
       "gcode_file": {
         "name": "Gcode filename"
       },
+      "print_bed_type": {
+        "name": "Print bed type"
+      },
+      "print_length": {
+        "name": "Print length"
+      },
+      "print_weight": {
+        "name": "Print weight"
+      },
       "subtask_name": {
         "name": "Task name"
       },


### PR DESCRIPTION
The new sensors are only available when we have a working bambu cloud connection for the printer.

Cleanup P1PCamera references to be more generically name 'Chamber Image Camera'