### PR TITLE
Don't the tell coordinator the data changed for the AMS/virtual trays if it didn't

### DIFF
--- a/custom_components/bambu_lab/__init__.py
+++ b/custom_components/bambu_lab/__init__.py
@@ -53,7 +53,7 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 async def async_migrate_entry(hass, config_entry: ConfigEntry):
     """Migrate old entry."""
-    LOGGER.debug(f"--------------------------- async_migrate_entry {config_entry.version}")
+    LOGGER.debug(f"async_migrate_entry {config_entry.version}")
     if config_entry.version > CONFIG_VERSION:
         # This means the user has downgraded from a future version
         return False

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -305,8 +305,9 @@ class BambuClient:
         """Return the payload when received"""
         try:
             # X1 mqtt payload is inconsistent. Adjust it for consistent logging.
-            clean_msg = re.sub(r"\\n *", "", str(message.payload))
-            LOGGER.debug(f"Received data from: {self._device.info.device_type}: {clean_msg}")
+            #clean_msg = re.sub(r"\\n *", "", str(message.payload))
+            #LOGGER.debug(f"Received data from: {self._device.info.device_type}: {clean_msg}")
+            LOGGER.debug(f"Received data from: {self._device.info.device_type}")
             json_data = json.loads(message.payload)
             if json_data.get("event"):
                 if json_data.get("event").get("event") == "client.connected":


### PR DESCRIPTION
We can do the same for print_update too but that's a lot more work due to the amount of code that needs to check for an actual delta. This gets the logging and home assistant updates down from 3 per mqtt payload to just 1. And I'll work on cleaning up the remainder separately.

Also turn off displaying the received payload by default since it's overwhelming with the X1 payload being a complete dump every second.