### PR TITLE
Fix Chinese cloud mqtt host

### DIFF
--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -137,7 +137,7 @@ def mqtt_listen_thread(self):
     exceptionSeen = ""
     while True:
         try:
-            host = self.host if self._local_mqtt else self.client.bambu_cloud.get_mqtt_host()
+            host = self.host if self._local_mqtt else self.bambu_cloud.cloud_mqtt_host
             LOGGER.debug(f"Connect: Attempting Connection to {host}")
             self.client.connect(host, self._port, keepalive=5)
 

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -137,7 +137,7 @@ def mqtt_listen_thread(self):
     exceptionSeen = ""
     while True:
         try:
-            host = self.host if self._local_mqtt else "us.mqtt.bambulab.com"
+            host = self.host if self._local_mqtt else self.client.bambu_cloud.get_mqtt_host()
             LOGGER.debug(f"Connect: Attempting Connection to {host}")
             self.client.connect(host, self._port, keepalive=5)
 

--- a/custom_components/bambu_lab/pybambu/bambu_cloud.py
+++ b/custom_components/bambu_lab/pybambu/bambu_cloud.py
@@ -196,3 +196,7 @@ class BambuCloud:
     @property
     def auth_token(self):
         return self._auth_token
+    
+    @property
+    def cloud_mqtt_host(self):
+        return "us.mqtt.bambulab.com" if self.region != "China" else "cn.mqtt.bambulab.com"

--- a/custom_components/bambu_lab/pybambu/bambu_cloud.py
+++ b/custom_components/bambu_lab/pybambu/bambu_cloud.py
@@ -199,4 +199,4 @@ class BambuCloud:
     
     @property
     def cloud_mqtt_host(self):
-        return "us.mqtt.bambulab.com" if self.region != "China" else "cn.mqtt.bambulab.com"
+        return "us.mqtt.bambulab.com" if self._region != "China" else "cn.mqtt.bambulab.com"

--- a/custom_components/bambu_lab/pybambu/bambu_cloud.py
+++ b/custom_components/bambu_lab/pybambu/bambu_cloud.py
@@ -199,4 +199,4 @@ class BambuCloud:
     
     @property
     def cloud_mqtt_host(self):
-        return "us.mqtt.bambulab.com" if self._region != "China" else "cn.mqtt.bambulab.com"
+        return "cn.mqtt.bambulab.com" if self._region == "China" else "us.mqtt.bambulab.com"


### PR DESCRIPTION
The mqtt host was hard coded to the US one still. It needs to be dynamic based on region.