### PR TITLE
Various fixes

### DIFF
--- a/custom_components/bambu_lab/diagnostics.py
+++ b/custom_components/bambu_lab/diagnostics.py
@@ -13,8 +13,14 @@ from .pybambu.commands import PUSH_ALL, GET_VERSION
 
 
 TO_REDACT = [
+    "access_code",
+    "auth_token",
+    "email",
     "rtsp_url",
-    "sn"
+    "serial",
+    "sn",
+    "title",
+    "username"
 ]
 
 
@@ -24,10 +30,14 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     coordinator: BambuDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
+    # Must convert this to a dict for redaction to work correctly. Redaction leaves empty values as empty so we know if a value was present or not.
+    entry = coordinator._entry.as_dict()
+
     coordinator.client.publish(PUSH_ALL)
     coordinator.client.publish(GET_VERSION)
 
     diagnostics_data = {
+        "config_entry": async_redact_data(entry, TO_REDACT),
         "push_all": async_redact_data(coordinator.data.push_all_data, TO_REDACT),
         "get_version": async_redact_data(coordinator.data.get_version_data, TO_REDACT),
     }

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import queue
 import json
+import math
 import re
 import socket
 import ssl
@@ -51,7 +52,7 @@ class WatchdogThread(threading.Thread):
                 break
             interval = time.time() - self._last_received_data
             if not self._watchdog_fired and (interval > WATCHDOG_TIMER):
-                LOGGER.debug(f"Watchdog fired. No data received for {interval} seconds.")
+                LOGGER.debug(f"Watchdog fired. No data received for {math.floor(interval)} seconds for {self._client._device.info.device_type}/{self._client._serial}.")
                 self._watchdog_fired = True
                 self._client._on_watchdog_fired()
             elif interval < WATCHDOG_TIMER:

--- a/custom_components/bambu_lab/pybambu/bambu_cloud.py
+++ b/custom_components/bambu_lab/pybambu/bambu_cloud.py
@@ -156,7 +156,6 @@ class BambuCloud:
     #     },
 
     def get_tasklist(self) -> dict:
-        LOGGER.debug("Getting task list from Bambu Cloud")
         if self._region == "China":
             url = 'https://api.bambulab.cn/v1/user-service/my/tasks'
         else:

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -424,16 +424,6 @@ class Info:
             # Update task data if bambu cloud connected
             self._update_task_data()
 
-        # Handle print failed
-        if previous_gcode_state != "unknown" and previous_gcode_state != "FAILED" and self.gcode_state == "FAILED":
-            if self.client.callback is not None:
-               self.client.callback("event_print_failed")
-
-        # Handle print finish
-        if previous_gcode_state != "unknown" and previous_gcode_state != "FINISH" and self.gcode_state == "FINISH":
-            if self.client.callback is not None:
-               self.client.callback("event_print_finished")
-
         # When a print is canceled by the user, this is the payload that's sent. A couple of seconds later
         # print_error will be reset to zero.
         # {
@@ -441,10 +431,23 @@ class Info:
         #         "print_error": 50348044,
         #     }
         # }
+        isCanceledPrint = False
         if data.get("print_error") == 50348044 and self.print_error == 0:
+            isCanceledPrint = True
             if self.client.callback is not None:
                self.client.callback("event_print_canceled")
         self.print_error = data.get("print_error", self.print_error)
+
+        # Handle print failed
+        if previous_gcode_state != "unknown" and previous_gcode_state != "FAILED" and self.gcode_state == "FAILED":
+            if not isCanceledPrint:
+                if self.client.callback is not None:
+                   self.client.callback("event_print_failed")
+
+        # Handle print finish
+        if previous_gcode_state != "unknown" and previous_gcode_state != "FINISH" and self.gcode_state == "FINISH":
+            if self.client.callback is not None:
+               self.client.callback("event_print_finished")
 
         # Version data is provided differently for X1 and P1
         # P1P example:


### PR DESCRIPTION
Add the config_entry to the diagnosis log but heavily redacted. This at least lets us know if a value was populated or not as redaction leaves empty strings as empty strings.