### PR TITLE
Various fixes

### DIFF
--- a/custom_components/bambu_lab/__init__.py
+++ b/custom_components/bambu_lab/__init__.py
@@ -82,7 +82,7 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
                 "region": "",
                 "email": "",
                 "username": old_data['username'] if (old_data.get('username', 'bblp') != "bblp") else "",
-                "name": "", # Device name
+                "name": old_data['device_type'], # Default device name to model name
                 "host": old_data['host'] if (old_data['host'] != "us.mqtt.bambulab.com") else "",
                 "local_mqtt": (old_data['host'] != "us.mqtt.bambulab.com"),
                 "auth_token": old_data['access_code'] if (old_data['host'] == "us.mqtt.bambulab.com") else "",

--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -449,7 +449,8 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
         # Build form
         fields: OrderedDict[vol.Marker, Any] = OrderedDict()
         fields[vol.Required('serial', default=self.config_entry.data['serial'])] = printer_selector
-        fields[vol.Optional('host')] = TEXT_SELECTOR
+        default_host = self.config_entry.options.get('host', '') if user_input is None else user_input['host']
+        fields[vol.Optional('host', default=default_host)] = TEXT_SELECTOR
         fields[vol.Optional('access_code', default=self.config_entry.options.get('access_code', access_code))] = TEXT_SELECTOR
         fields[vol.Optional('local_mqtt', default=self.config_entry.options.get('local_mqtt', True))] = BOOLEAN_SELECTOR
 

--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -310,6 +310,12 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         value_fn=lambda self: self.coordinator.get_model().info.subtask_name
     ),
     BambuLabSensorEntityDescription(
+        key="name",
+        translation_key="printer_name",
+        value_fn=lambda self: self.coordinator.config_entry.options.get('name', ''),
+        exists_fn=lambda coordinator: coordinator.config_entry.options.get('name', '') != ''
+    ),
+    BambuLabSensorEntityDescription(
         key="print_length",
         translation_key="print_length",
         native_unit_of_measurement=UnitOfLength.METERS,

--- a/custom_components/bambu_lab/pybambu/bambu_cloud.py
+++ b/custom_components/bambu_lab/pybambu/bambu_cloud.py
@@ -110,6 +110,7 @@ class BambuCloud:
         if not response.ok:
             LOGGER.debug(f"Received error: {response.status_code}")
             raise ValueError(response.status_code)
+        LOGGER.debug(f"DEVICE LIST: {response.json()}")
         return response.json()['devices']
 
     # The task list is of the following form with a 'hits' array with typical 20 entries.

--- a/custom_components/bambu_lab/translations/de.json
+++ b/custom_components/bambu_lab/translations/de.json
@@ -213,6 +213,9 @@
           }
         }
       },
+      "printer_name": {
+        "name": "Name des Druckers"
+      },
       "stage": {
         "name": "Aktuelle Schicht",
         "state": {

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -213,6 +213,9 @@
           }
         }
       },
+      "printer_name": {
+        "name": "Printer name"
+      },
       "stage": {
         "name": "Current stage",
         "state": {

--- a/custom_components/bambu_lab/translations/fr.json
+++ b/custom_components/bambu_lab/translations/fr.json
@@ -204,6 +204,9 @@
           }
         }
       },
+      "printer_name": {
+        "name": "Nom de l’imprimante"
+      },
       "stage": {
         "name": "Étape actuelle",
         "state": {

--- a/custom_components/bambu_lab/translations/it.json
+++ b/custom_components/bambu_lab/translations/it.json
@@ -213,6 +213,9 @@
           }
         }
       },
+      "printer_name": {
+        "name": "Nome della stampante"
+      },
       "stage": {
         "name": "Fase corrente",
         "state": {

--- a/custom_components/bambu_lab/translations/zh-Hans.json
+++ b/custom_components/bambu_lab/translations/zh-Hans.json
@@ -213,6 +213,9 @@
           }
         }
       },
+      "printer_name": {
+        "name": "打印机名称"
+      },
       "stage": {
         "name": "当前阶段",
         "state": {


### PR DESCRIPTION
Set device type as placeholder printer name in upgrade from pre-2.0 versions.
Add a new 'Printer name' sensor if name is present in config entry.
Add back setting the default host IP in the bambu cloud reconfigure flow. Not having it set by default is in annoying in the common case. Having it means it's impossible to unset but that should be an undesirable usage case anyway.
Add some extra logging for [TomN7](https://github.com/TomN7) to help me further investigate his connection issue.