### PR TITLE
Allow incorrect access code override during initial cloud setup.

### DIFF
--- a/custom_components/bambu_lab/translations/de.json
+++ b/custom_components/bambu_lab/translations/de.json
@@ -37,13 +37,20 @@
       },
       "Bambu_Choose_Device": {
         "title": "Drucker-Auswahl",
-        "description": "Wählen Sie den Drucker aus, den Sie hinzufügen möchten. Wenn Sie die lokale IP-Adresse angeben, können Sie die Verbindung zum Drucker auch auf lokales mqtt einstellen.",
+        "description": "Wählen Sie den Drucker aus, den Sie hinzufügen möchten.",
         "data": {
-          "printer": "Wählen Sie den hinzuzufügenden Drucker aus:",
-          "host": "IP-Adresse des lokalen Druckers:",
-          "local_mqtt": "Verbinden Sie sich direkt mit dem Drucker statt über die Bambu Cloud:"
+          "printer": "Wählen Sie den hinzuzufügenden Drucker aus:"
         }
-      },      
+      },
+      "Bambu_Lan": {
+        "title": "Lokale Verbindung einrichten",
+        "description": "Optional können Sie die IP-Adresse des lokalen Druckers angeben. Dies wird empfohlen, da es den Kamerazugriff auf den P1/A1-Druckern ermöglicht und im Allgemeinen zuverlässiger ist.",
+        "data": {
+          "local_mqtt": "Verbinden Sie sich direkt mit dem Drucker statt über die Bambu Cloud:",
+          "host": "IP-Adresse des lokalen Druckers:",
+          "access_code": "Zugangscode"
+        }
+      },
       "Lan": {
         "title": "LAN-Modus-Verbindung",
         "Beschreibung": "Bitte geben Sie Ihren lokalen Druckertyp, Ihre IP-Adresse, die Seriennummer und den Zugangscode an. Den Zugangscode finden Sie auf dem Druckerbildschirm in den Netzwerkeinstellungen. Die Seriennummer finden Sie in den Geräteeinstellungen.",

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -38,11 +38,18 @@
       },
       "Bambu_Choose_Device": {
         "title": "Printer Selection",
-        "description": "Choose which printer you want to add. If you provide the local IP address you can also set the connection to the printer to be by local mqtt.",
+        "description": "Choose which printer you want to add.",
         "data": {
-          "printer": "Choose Printer To Add:",
+          "printer": "Choose Printer To Add:"
+        }
+      },
+      "Bambu_Lan": {
+        "title": "Setup Local Connection",
+        "description": "You can optionally provide the local printer IP address. This is recommended as it enables camera access on the P1/A1 printers and is generally more reliable.",
+        "data": {
+          "local_mqtt": "Connect locally to the printer:",
           "host": "Local Printer IP Address:",
-          "local_mqtt": "Connect directly to printer instead of by Bambu Cloud:"
+          "access_code": "Access Code:"
         }
       },
       "Lan": {

--- a/custom_components/bambu_lab/translations/fr.json
+++ b/custom_components/bambu_lab/translations/fr.json
@@ -29,12 +29,18 @@
       },
       "Bambu_Choose_Device": {
         "title": "Sélection de l’imprimante",
-        "description": "Choisissez l’imprimante que vous souhaitez ajouter. Si vous fournissez l’adresse IP locale, vous pouvez également définir la connexion à l’imprimante pour qu’elle se fasse par mqtt local.",
+        "description": "Choisissez l’imprimante que vous souhaitez ajouter.",
         "data": {
-          "printer": "Choisissez l’imprimante à ajouter :",
+          "printer": "Choisissez l’imprimante à ajouter :"
+        }
+      },
+      "Bambu_Lan": {
+        "title": "Configurer la connexion locale",
+        "description": "Vous pouvez éventuellement fournir l’adresse IP de l’imprimante locale. Cette option est recommandée car elle permet l’accès à la caméra sur les imprimantes P1/A1 et est généralement plus fiable.",
+        "data": {
+          "local_mqtt": "Connectez-vous directement à l’imprimante au lieu de passer par Bambu Cloud :",
           "host": "Adresse IP de l’imprimante locale :",
-          "access_code": "Code d'accès",
-          "local_mqtt": "Connectez-vous directement à l’imprimante au lieu de passer par Bambu Cloud :"
+          "access_code": "Code d'accès"
         }
       },
       "Lan": {

--- a/custom_components/bambu_lab/translations/it.json
+++ b/custom_components/bambu_lab/translations/it.json
@@ -38,12 +38,18 @@
       },
       "Bambu_Choose_Device": {
         "title": "Selezione della stampante",
-        "description": "Scegli la stampante che desideri aggiungere. Se si fornisce l'indirizzo IP locale, è anche possibile impostare la connessione alla stampante in modo che avvenga tramite mqtt locale.",
+        "description": "Scegli la stampante che desideri aggiungere.",
         "data": {
-          "printer": "Scegli la stampante da aggiungere:",
+          "printer": "Scegli la stampante da aggiungere:"
+        }
+      },
+      "Bambu_Lan": {
+        "title": "Configurare la connessione locale",
+        "description": "Facoltativamente, è possibile specificare l'indirizzo IP della stampante locale. Questa operazione è consigliata in quanto consente l'accesso alla fotocamera sulle stampanti P1/A1 ed è generalmente più affidabile.",
+        "data": {
+          "local_mqtt": "Connettiti direttamente alla stampante invece che tramite Bambu Cloud:",
           "host": "Indirizzo IP della stampante locale:",
-          "access_code": "Codice d'accesso",
-          "local_mqtt": "Connettiti direttamente alla stampante invece che tramite Bambu Cloud:"
+          "access_code": "Codice d'accesso"
         }
       },
       "Lan": {

--- a/custom_components/bambu_lab/translations/zh-Hans.json
+++ b/custom_components/bambu_lab/translations/zh-Hans.json
@@ -38,11 +38,18 @@
       },
       "Bambu_Choose_Device": {
         "title": "打印机选择",
-        "description": "选择要添加的打印机。如果提供本地 IP 地址，还可以将与打印机的连接设置为通过本地 mqtt。",
+        "description": "选择要添加的打印机。",
         "data": {
-          "printer": "选择要添加的打印机：",
+          "printer": "选择要添加的打印机："
+        }
+      },
+      "Bambu_Lan": {
+        "title": "设置本地连接",
+        "description": "您可以选择提供本地打印机 IP 地址。建议这样做，因为它可以在 P1/A1 打印机上访问相机，并且通常更可靠。",
+        "data": {
+          "local_mqtt": "直接连接到打印机，而不是通过 Bambu Cloud：",
           "host": "本地打印机 IP 地址：",
-          "local_mqtt": "直接连接到打印机，而不是通过 Bambu Cloud："
+          "access_code": "访问码"
         }
       },
       "Lan": {


### PR DESCRIPTION
Sometimes bambu cloud might have the wrong access code for your printer. This change allows the user to edit it during setup to be correct.