### PR TITLE
Redo start/end time sensors as datetime objects

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -253,7 +253,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         key="start_time",
         translation_key="start_time",
         icon="mdi:clock",
-        available_fn=lambda self: self.coordinator.get_model().info.start_time != "",
+        available_fn=lambda self: self.coordinator.get_model().info.start_time != None,
         value_fn=lambda self: self.coordinator.get_model().info.start_time,
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.START_TIME) or coordinator.get_model().supports_feature(Features.START_TIME_GENERATED),
     ),

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -291,7 +291,7 @@ class Info:
     gcode_state: str
     remaining_time: int
     start_time: str
-    end_time: str
+    end_time: datetime
     current_layer: int
     total_layers: int
     online: bool
@@ -312,7 +312,7 @@ class Info:
         self.subtask_name = ""
         self.serial = serial
         self.remaining_time = -1
-        self.end_time = ""
+        self.end_time = None
         self.start_time = ""
         self.current_layer = 0
         self.total_layers = 0

--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -137,21 +137,14 @@ def get_sw_version(modules, default):
 def get_start_time(timestamp):
     """Return start time of a print"""
     if timestamp == 0:
-        return ""
-    start_time = datetime.fromtimestamp(timestamp)
-    if start_time.day == datetime.now().day:
-        return datetime.fromtimestamp(timestamp).strftime('%H:%M:%S')
-    else:
-        return datetime.fromtimestamp(timestamp).strftime('%d %B %Y %H:%M:%S')
+        return None
+    return datetime.fromtimestamp(timestamp)
 
 
 def get_end_time(remaining_time):
     """Calculate the end time of a print"""
     end_time = round_minute(datetime.now() + timedelta(minutes=remaining_time))
-    if end_time.day == datetime.now().day:
-        return end_time.strftime('%H:%M:%S')
-    else:
-        return end_time.strftime('%d %B %Y %H:%M:%S')
+    return end_time
 
 
 def round_minute(date: datetime = None, round_to: int = 1):


### PR DESCRIPTION
Reverting prior change to give a stable sensor and making it a true datetime object instead of a formatted string. Users can choose to format it in their dashboards with a template sensor while the unstable recent version of the sensor where it's a string that may or may note contained a date isn't reasonable to work with in automations.