### PR TITLE
Add hysteresis to fan speed changes

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -27,7 +27,7 @@ from homeassistant.components.binary_sensor import (
 )
 
 from .const import LOGGER
-from .pybambu.const import SPEED_PROFILE, Features
+from .pybambu.const import SPEED_PROFILE, Features, FansEnum
 
 
 def fan_to_percent(speed):
@@ -161,7 +161,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:fan",
-        value_fn=lambda self: self.coordinator.get_model().fans.aux_fan_speed
+        value_fn=lambda self: self.coordinator.get_model().fans.get_fan_speed(FansEnum.AUXILIARY)
     ),
     BambuLabSensorEntityDescription(
         key="chamber_fan_speed",
@@ -169,7 +169,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:fan",
-        value_fn=lambda self: self.coordinator.get_model().fans.chamber_fan_speed,
+        value_fn=lambda self: self.coordinator.get_model().fans.get_fan_speed(FansEnum.CHAMBER),
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.CHAMBER_FAN)
     ),
     BambuLabSensorEntityDescription(
@@ -178,7 +178,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:fan",
-        value_fn=lambda self: self.coordinator.get_model().fans.cooling_fan_speed
+        value_fn=lambda self: self.coordinator.get_model().fans.get_fan_speed(FansEnum.PART_COOLING)
     ),
     BambuLabSensorEntityDescription(
         key="heatbreak_fan_speed",
@@ -186,7 +186,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:fan",
-        value_fn=lambda self: self.coordinator.get_model().fans.heatbreak_fan_speed
+        value_fn=lambda self: self.coordinator.get_model().fans.get_fan_speed(FansEnum.HEATBREAK)
     ),
     BambuLabSensorEntityDescription(
         key="speed_profile",

--- a/custom_components/bambu_lab/fan.py
+++ b/custom_components/bambu_lab/fan.py
@@ -33,17 +33,17 @@ FANS: tuple[FanEntityDescription, ...] = (
     BambuLabFanEntityDescription(
         key="cooling_fan",
         translation_key="cooling_fan",
-        value_fn=lambda device: device.fans.cooling_fan_speed,
+        value_fn=lambda device: device.fans.get_fan_speed(FansEnum.PART_COOLING)
     ),
     BambuLabFanEntityDescription(
         key="aux_fan",
         translation_key="aux_fan",
-        value_fn=lambda device: device.fans.aux_fan_speed
+        value_fn=lambda device: device.fans.get_fan_speed(FansEnum.AUXILIARY)
     ),
     BambuLabFanEntityDescription(
         key="chamber_fan",
         translation_key="chamber_fan",
-        value_fn=lambda device: device.fans.chamber_fan_speed,
+        value_fn=lambda device: device.fans.get_fan_speed(FansEnum.CHAMBER),
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.CHAMBER_FAN)
     )
 )
@@ -100,11 +100,11 @@ class BambuLabFan(BambuLabEntity, FanEntity):
         """Set the speed percentage of the fan."""
         match self.entity_description.key:
             case "cooling_fan":
-                self.coordinator.get_model().fans.SetFanSpeed(FansEnum.PART_COOLING, percentage)
+                self.coordinator.get_model().fans.set_fan_speed(FansEnum.PART_COOLING, percentage)
             case "aux_fan":
-                self.coordinator.get_model().fans.SetFanSpeed(FansEnum.AUXILIARY, percentage)
+                self.coordinator.get_model().fans.set_fan_speed(FansEnum.AUXILIARY, percentage)
             case "chamber_fan":
-                self.coordinator.get_model().fans.SetFanSpeed(FansEnum.CHAMBER, percentage)
+                self.coordinator.get_model().fans.set_fan_speed(FansEnum.CHAMBER, percentage)
 
     def set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -124,8 +124,10 @@ class ChamberImageThread(threading.Thread):
                     while not self._stop_event.is_set():
                         try:
                             dr = sslSock.recv(read_chunk_size)
+                            #LOGGER.debug(f"{self._client._device.info.device_type}: Received {len(dr)} bytes.")
 
                         except ssl.SSLWantReadError:
+                            #LOGGER.error(f"{self._client._device.info.device_type}: SSLWantReadError")
                             time.sleep(1)
                             continue
 
@@ -162,6 +164,11 @@ class ChamberImageThread(threading.Thread):
                             # We got the header bytes. Get the expected payload size from it and create the image buffer bytearray.
                             img = bytearray()
                             payload_size = int.from_bytes(dr[0:3], byteorder='little')
+
+                        else:
+                            LOGGER.error(f"{self._client._device.info.device_type}: UNEXPECTED DATA RECEIVED: {len(dr)}")
+                            time.sleep(1)
+                            continue
 
             except Exception as e:
                 LOGGER.error("A Chamber Image thread outer exception occurred:")

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -27,6 +27,7 @@ class FansEnum(Enum):
     PART_COOLING = 1,
     AUXILIARY = 2,
     CHAMBER = 3,
+    HEATBREAK = 4,
 
 
 ACTION_IDS = {

--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -18,7 +18,7 @@ def fan_percentage(speed):
     if not speed:
         return 0
     percentage = (int(speed) / 15) * 100
-    return math.ceil(percentage / 10) * 10
+    return round(percentage / 10) * 10
 
 
 def fan_percentage_to_gcode(fan: FansEnum, percentage: int):
@@ -31,7 +31,7 @@ def fan_percentage_to_gcode(fan: FansEnum, percentage: int):
         case FansEnum.CHAMBER:
             fanString = "P3"
 
-    percentage = math.ceil(percentage / 10) * 10
+    percentage = round(percentage / 10) * 10
     speed = math.ceil(255 * percentage / 100)
     command = SEND_GCODE_TEMPLATE
     command['print']['param'] = f"M106 {fanString} S{speed}\n"


### PR DESCRIPTION
Adjust fan logic to match Bambu's calculations / handy app.
Allow 5 second override of set value so that the reported value looks stable instead of showing incremental changes towards the user specified value. After 5 seconds we start reporting exactly what the printer told us again.
Trigger HA update immediately when we set the fan value so that it immediately changes to the rounded value and stays stable instead of showing the old stale value for a variable amount of time until we see the first update from the printer.