### PR TITLE
Improve setup clarity

### DIFF
--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -186,7 +186,7 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         errors = {}
-        LOGGER.debug("async_step_Bambu_Choose_Device")
+        LOGGER.debug("async_step_Bambu_Lan")
 
         device_list = await self.hass.async_add_executor_job(
             self._bambu_cloud.get_device_list)
@@ -380,7 +380,7 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
                 self.region = user_input['region']
                 self.email = user_input['email']
 
-                return await self.async_step_Bambu_Choose_Device(None)
+                return await self.async_step_Bambu_Lan(None)
 
             except Exception as e:
                 LOGGER.error(f"Failed to connect with error code {e.args}")
@@ -389,7 +389,7 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
         elif credentialsGood:
             self.region = self.config_entry.options['region']
             self.email = self.config_entry.options['email']
-            return await self.async_step_Bambu_Choose_Device(None)
+            return await self.async_step_Bambu_Lan(None)
 
         # Build form
         fields: OrderedDict[vol.Marker, Any] = OrderedDict()
@@ -407,11 +407,11 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
             last_step=False,
         )
 
-    async def async_step_Bambu_Choose_Device(
+    async def async_step_Bambu_Lan(
             self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         errors = {}
-        LOGGER.debug("async_step_Bambu_Choose_Device")
+        LOGGER.debug("async_step_Bambu_Lan")
 
         device_list = await self.hass.async_add_executor_job(
             self._bambu_cloud.get_device_list)
@@ -484,7 +484,7 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
         fields[vol.Optional('local_mqtt', default=self.config_entry.options.get('local_mqtt', True))] = BOOLEAN_SELECTOR
 
         return self.async_show_form(
-            step_id="Bambu_Choose_Device",
+            step_id="Bambu_Lan",
             data_schema=vol.Schema(fields),
             errors=errors or {},
             last_step=True,

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -124,10 +124,10 @@ class ChamberImageThread(threading.Thread):
                     while not self._stop_event.is_set():
                         try:
                             dr = sslSock.recv(read_chunk_size)
-                            #LOGGER.debug(f"{self._client._device.info.device_type}: Received {len(dr)} bytes.")
+                            LOGGER.debug(f"{self._client._device.info.device_type}: Received {len(dr)} bytes.")
 
                         except ssl.SSLWantReadError:
-                            #LOGGER.error(f"{self._client._device.info.device_type}: SSLWantReadError")
+                            LOGGER.error(f"{self._client._device.info.device_type}: SSLWantReadError")
                             time.sleep(1)
                             continue
 
@@ -307,7 +307,7 @@ class BambuClient:
         self._watchdog = WatchdogThread(self)
         self._watchdog.start()
 
-        if self._device.supports_feature(Features.CAMERA_IMAGE) and self.host != "":
+        if self._device.supports_feature(Features.CAMERA_IMAGE):
             LOGGER.debug("Starting Chamber Image thread")
             self._camera = ChamberImageThread(self)
             self._camera.start()

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -97,7 +97,7 @@ class Device:
             case Features.CAMERA_RTSP:
                 return self.info.device_type == "X1" or self.info.device_type == "X1C" or self.info.device_type == "X1E"
             case Features.CAMERA_IMAGE:
-                return (self.client.host != "us.mqtt.bambulab.com") and (self.info.device_type == "P1P" or self.info.device_type == "P1S" or self.info.device_type == "A1" or self.info.device_type == "A1Mini")
+                return (self.client.host != "") and (self.client._access_code != "") and (self.info.device_type == "P1P" or self.info.device_type == "P1S" or self.info.device_type == "A1" or self.info.device_type == "A1Mini")
             case Features.MANUAL_MODE:
                 return self.info.device_type == "P1P" or self.info.device_type == "P1S" or self.info.device_type == "A1" or self.info.device_type == "A1Mini"
 

--- a/custom_components/bambu_lab/translations/de.json
+++ b/custom_components/bambu_lab/translations/de.json
@@ -44,7 +44,7 @@
       },
       "Bambu_Lan": {
         "title": "Lokale Verbindung einrichten",
-        "description": "Optional können Sie die IP-Adresse des lokalen Druckers angeben. Dies wird empfohlen, da es den Kamerazugriff auf den P1/A1-Druckern ermöglicht und im Allgemeinen zuverlässiger ist.",
+        "description": "Sie können optional die IP-Adresse und den Zugriffscode des lokalen Druckers angeben. Dies ist für den Kamerazugriff auf die P1/A1 erforderlich. Oder um sich direkt mit dem Drucker verbinden zu können, anstatt über die Bambu Cloud.",
         "data": {
           "local_mqtt": "Verbinden Sie sich direkt mit dem Drucker statt über die Bambu Cloud:",
           "host": "IP-Adresse des lokalen Druckers:",
@@ -88,9 +88,9 @@
           "password": "Passwort"
         }
       },
-      "Bambu_Choose_Device": {
-        "title": "Drucker-Auswahl",
-        "description": "Anpassen der Einstellungen für diesen Drucker:",
+      "Bambu_Lan": {
+        "title": "Anpassen der Druckerkonfiguration",
+        "description": "Sie können optional die IP-Adresse und den Zugriffscode des lokalen Druckers angeben. Dies ist für den Kamerazugriff auf die P1/A1 erforderlich. Oder um sich direkt mit dem Drucker verbinden zu können, anstatt über die Bambu Cloud.",
         "data": {
           "printer": "Wählen Sie den hinzuzufügenden Drucker aus:",
           "host": "IP-Adresse des lokalen Druckers:",

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -45,7 +45,7 @@
       },
       "Bambu_Lan": {
         "title": "Setup Local Connection",
-        "description": "You can optionally provide the local printer IP address. This is recommended as it enables camera access on the P1/A1 printers and is generally more reliable.",
+        "description": "You can optionally provide the local printer IP address and access code. This is required for camera access on the P1/A1. Or to be able to connect directly to the printer instead of via Bambu Cloud.",
         "data": {
           "local_mqtt": "Connect locally to the printer:",
           "host": "Local Printer IP Address:",
@@ -88,9 +88,9 @@
           "password": "Password"
         }
       },
-      "Bambu_Choose_Device": {
-        "title": "Printer Selection",
-        "description": "Adjusting settings for this printer:",
+      "Bambu_Lan": {
+        "title": "Adjust Printer Configuration",
+        "description": "You can optionally provide the local printer IP address and access code. This is required for camera access on the P1/A1. Or to be able to connect directly to the printer instead of via Bambu Cloud.",
         "data": {
           "printer": "Choose Printer To Add:",
           "host": "Local Printer IP Address:",

--- a/custom_components/bambu_lab/translations/fr.json
+++ b/custom_components/bambu_lab/translations/fr.json
@@ -36,7 +36,7 @@
       },
       "Bambu_Lan": {
         "title": "Configurer la connexion locale",
-        "description": "Vous pouvez éventuellement fournir l’adresse IP de l’imprimante locale. Cette option est recommandée car elle permet l’accès à la caméra sur les imprimantes P1/A1 et est généralement plus fiable.",
+        "description": "Vous pouvez éventuellement fournir l’adresse IP et le code d’accès de l’imprimante locale. Ceci est nécessaire pour l’accès à la caméra sur le P1/A1. Ou de pouvoir se connecter directement à l’imprimante plutôt que via Bambu Cloud.",
         "data": {
           "local_mqtt": "Connectez-vous directement à l’imprimante au lieu de passer par Bambu Cloud :",
           "host": "Adresse IP de l’imprimante locale :",
@@ -79,9 +79,9 @@
           "password": "Mot de passe"
         }
       },
-      "Bambu_Choose_Device": {
-        "title": "Sélection de l’imprimante",
-        "description": "Réglage des paramètres de cette imprimante :",
+      "Bambu_Lan": {
+        "title": "Adjust Printer Configuration",
+        "description": "Vous pouvez éventuellement fournir l’adresse IP et le code d’accès de l’imprimante locale. Ceci est nécessaire pour l’accès à la caméra sur le P1/A1. Ou de pouvoir se connecter directement à l’imprimante plutôt que via Bambu Cloud.",
         "data": {
           "printer": "Choisissez l’imprimante à ajouter :",
           "host": "Adresse IP de l’imprimante locale :",

--- a/custom_components/bambu_lab/translations/it.json
+++ b/custom_components/bambu_lab/translations/it.json
@@ -45,7 +45,7 @@
       },
       "Bambu_Lan": {
         "title": "Configurare la connessione locale",
-        "description": "Facoltativamente, è possibile specificare l'indirizzo IP della stampante locale. Questa operazione è consigliata in quanto consente l'accesso alla fotocamera sulle stampanti P1/A1 ed è generalmente più affidabile.",
+        "description": "Facoltativamente, è possibile specificare l'indirizzo IP e il codice di accesso della stampante locale. Questa operazione è necessaria per l'accesso alla fotocamera sul P1/A1. O per potersi connettere direttamente alla stampante invece che tramite Bambu Cloud.",
         "data": {
           "local_mqtt": "Connettiti direttamente alla stampante invece che tramite Bambu Cloud:",
           "host": "Indirizzo IP della stampante locale:",
@@ -88,9 +88,9 @@
           "password": "Password"
         }
       },
-      "Bambu_Choose_Device": {
-        "title": "Selezione della stampante",
-        "description": "Regolazione delle impostazioni per questa stampante:",
+      "Bambu_Lan": {
+        "title": "Regolare la configurazione della stampante",
+        "description": "Facoltativamente, è possibile specificare l'indirizzo IP e il codice di accesso della stampante locale. Questa operazione è necessaria per l'accesso alla fotocamera sul P1/A1. O per potersi connettere direttamente alla stampante invece che tramite Bambu Cloud.",
         "data": {
           "printer": "Scegli la stampante da aggiungere:",
           "host": "Indirizzo IP della stampante locale:",

--- a/custom_components/bambu_lab/translations/zh-Hans.json
+++ b/custom_components/bambu_lab/translations/zh-Hans.json
@@ -45,7 +45,7 @@
       },
       "Bambu_Lan": {
         "title": "设置本地连接",
-        "description": "您可以选择提供本地打印机 IP 地址。建议这样做，因为它可以在 P1/A1 打印机上访问相机，并且通常更可靠。",
+        "description": "您可以选择提供本地打印机 IP 地址和访问代码。这是在 P1/A1 上访问相机所必需的。或者能够直接连接到打印机，而不是通过 Bambu Cloud。",
         "data": {
           "local_mqtt": "直接连接到打印机，而不是通过 Bambu Cloud：",
           "host": "本地打印机 IP 地址：",
@@ -88,9 +88,9 @@
           "password": "密码"
         }
       },
-      "Bambu_Choose_Device": {
-        "title": "打印机选择",
-        "description": "调整本打印机的设置：",
+      "Bambu_Lan": {
+        "title": "调整打印机配置",
+        "description": "您可以选择提供本地打印机 IP 地址和访问代码。这是在 P1/A1 上访问相机所必需的。或者能够直接连接到打印机，而不是通过 Bambu Cloud。",
         "data": {
           "printer": "选择要添加的打印机：",
           "host": "本地打印机 IP 地址：",

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,7 @@
 ### V2.0.5
 - Rework P1/A1 chamber image handling to be a lot more efficient and maybe fix broken tight loop bug
+- Make bambu cloud setup clearer w/ regards to camera and local connection.
+- Make P1/A1 camera unavailable if either host IP or access code has not been provided.
 
 ### V2.0.4
 - Change start/end time to datetime object and revert the date removal change.


### PR DESCRIPTION
Make it clearer that host IP + access code is required for camera.
Make camera unavailable if either host IP or access code is not set.