### PR TITLE
Blueprint: Lights off while calibrating_extrusion_flow

### DIFF
--- a/blueprints/wled_controller.yaml
+++ b/blueprints/wled_controller.yaml
@@ -68,6 +68,10 @@ action:
             state: calibrating_extrusion
             alias: Calibrating Extrusion
           - condition: state
+            entity_id: !input printer_stage
+            state: calibrating_extrusion_flow
+            alias: Calibrating Extrusion Flow
+          - condition: state
             entity_id: !input printer_status
             state: offline
             alias: Printer is off


### PR DESCRIPTION
Adds lights off while flow rate calibration with lidar to the blueprint.

