### PR TITLE
A few small fixes

### DIFF
--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -93,6 +93,12 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
                 case "event_print_started":
                     self.PublishDeviceTriggerEvent(event)
 
+                case "event_printer_chamber_image_update":
+                    self._update_data()
+
+                case "event_printer_cover_image_update":
+                    self._update_data()
+
 
         async def listen():
             self.client.connect(callback=event_handler)

--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
     UnitOfTemperature,
     UnitOfMass,
     UnitOfLength,
-    TIME_MINUTES
+    UnitOfTime
 )
 
 from homeassistant.components.sensor import (
@@ -261,7 +261,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         key="remaining_time",
         translation_key="remaining_time",
         icon="mdi:timer-sand",
-        native_unit_of_measurement=TIME_MINUTES,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
         device_class=SensorDeviceClass.DURATION,
         value_fn=lambda self: self.coordinator.get_model().info.remaining_time
     ),

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -165,6 +165,12 @@ class ChamberImageThread(threading.Thread):
                             img = bytearray()
                             payload_size = int.from_bytes(dr[0:3], byteorder='little')
 
+                        elif len(dr) == 0:
+                            # This occurs if the wrong access code was provided.
+                            LOGGER.error("Chamber image connection rejected by the printer. Check provided access code and IP address.")
+                            LOGGER.info("Chamber image thread exited.")
+                            return
+
                         else:
                             LOGGER.error(f"{self._client._device.info.device_type}: UNEXPECTED DATA RECEIVED: {len(dr)}")
                             time.sleep(1)

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -1018,6 +1018,8 @@ class ChamberImage:
         LOGGER.debug(f"JPEG RECEIVED: {self.client._device.info.device_type}")
         self._bytes = bytes
         self._image_last_updated = datetime.now()
+        if self.client.callback is not None:
+            self.client.callback("event_printer_chamber_image_update")
     
     def get_jpeg(self) -> bytearray:
         return self._bytes
@@ -1033,6 +1035,8 @@ class CoverImage:
         self.client = client
         self._bytes = bytearray()
         self._image_last_updated = datetime.now()
+        if self.client.callback is not None:
+            self.client.callback("event_printer_cover_image_update")
 
     def set_jpeg(self, bytes):
         self._bytes = bytes


### PR DESCRIPTION
- Reduce latency of chamber/cover image update especially when not printing.
- Detect chamber image socket connection failure and log as error and stop trying to indefinitely read data since it will never succeed.
- Switch from deprecated TIME_MINUTES to UnitOfTime.MINUTES