### PR TITLE
Wiki link incorrect for non AMS related errors

### DIFF
--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -82,8 +82,14 @@ def get_generic_AMS_HMS_error_code(hms_code: str):
     code2 = int(hms_code[5:9], 16)
     code3 = int(hms_code[10:14], 16)
     code4 = int(hms_code[15:19], 16)
+
+    ams_code = f"{code1 & 0xFFF8:0>4X}_{code2 & 0xF8FF:0>4X}_{code3:0>4X}_{code4:0>4X}"
+    ams_error = HMS_AMS_ERRORS.get(ams_code, "")
+    if ams_error != "":
+        return ams_code
+
     # 070X_xYxx_xxxx_xxxx = AMS X (0 based index) Slot Y (0 based index) has the error
-    return f"{code1 & 0xFFF8:0>4X}_{code2 & 0xF8FF:0>4X}_{code3:0>4X}_{code4:0>4X}"
+    return f"{code1:0>4X}_{code2:0>4X}_{code3:0>4X}_{code4:0>4X}"
 
 
 def get_printer_type(modules, default):


### PR DESCRIPTION
HMS errors not related to the AMS are being regarded as being AMS related and thus were made generic.

Now the same method is followed as in get_HMS_error_text (check if error is part of HMS_AMS_ERRORS).