### PR TITLE
Merge develop->main

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,6 @@
+### V2.0.9
+- Fix mishandling of printer power off/on when connected to bambu cloud mqtt.
+
 ### V2.0.8
 - Fix missing chamber image on A1 Mini
 


### PR DESCRIPTION
Fix mishandling of printer power off when bambu cloud mqtt connected.
The chamber image thread and watchdog threads never got restarted after the printer came back online.