### PR TITLE
Make options more resilient

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -27,7 +27,7 @@ from homeassistant.components.binary_sensor import (
 )
 
 from .const import LOGGER
-from .pybambu.const import SPEED_PROFILE, Features, FansEnum
+from .pybambu.const import SPEED_PROFILE, Features, FansEnum, CURRENT_STAGE_OPTIONS, GCODE_STATE_OPTIONS
 
 
 def fan_to_percent(speed):
@@ -215,32 +215,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             self: "offline" if (not self.coordinator.get_model().info.online and not self.coordinator.client.manual_refresh_mode) else self.coordinator.get_model().stage.description,
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.CURRENT_STAGE),
         device_class=SensorDeviceClass.ENUM,
-        options=[
-            "offline",
-            "unknown",
-            "printing",
-            "auto_bed_leveling",
-            "heatbed_preheating",
-            "sweeping_xy_mech_mode",
-            "changing_filament",
-            "m400_pause",
-            "paused_filament_runout",
-            "heating_hotend",
-            "calibrating_extrusion",
-            "scanning_bed_surface",
-            "inspecting_first_layer",
-            "identifying_build_plate_type",
-            "calibrating_micro_lidar",
-            "homing_toolhead",
-            "cleaning_nozzle_tip",
-            "checking_extruder_temperature",
-            "paused_user",
-            "paused_front_cover_falling",
-            "calibrating_extrusion_flow",
-            "paused_nozzle_temperature_malfunction",
-            "paused_heat_bed_temperature_malfunction",
-            "idle"
-        ]
+        options=CURRENT_STAGE_OPTIONS + ["offline"]
     ),
     BambuLabSensorEntityDescription(
         key="print_progress",
@@ -257,7 +232,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         value_fn=lambda
             self: "offline" if (not self.coordinator.get_model().info.online and not self.coordinator.client.manual_refresh_mode) else self.coordinator.get_model().print_job.gcode_state.lower(),
         device_class=SensorDeviceClass.ENUM,
-        options=["failed", "finish", "idle", "init", "offline", "pause","prepare", "running", "slicing", "unknown"],
+        options=GCODE_STATE_OPTIONS + ["offline"]
     ),
     BambuLabSensorEntityDescription(
         key="start_time",

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -396,7 +396,6 @@ class BambuClient:
             if json_data.get("event"):
                 # These are events from the bambu cloud mqtt feed and allow us to detect when a local
                 # device has connected/disconnected (e.g. turned on/off)
-                LOGGER.debug(f"EVENT DATA: {message}")
                 if json_data.get("event").get("event") == "client.connected":
                     LOGGER.debug("Client connected event received.")
                     self._on_disconnect() # We aren't guaranteed to recieve a client.disconnected event.

--- a/custom_components/bambu_lab/pybambu/bambu_cloud.py
+++ b/custom_components/bambu_lab/pybambu/bambu_cloud.py
@@ -166,13 +166,21 @@ class BambuCloud:
             raise ValueError(response.status_code)
         return response.json()
     
+    def get_latest_task_for_printer(self, deviceId: str) -> dict:
+        LOGGER.debug(f"Getting latest task from Bambu Cloud for Printer: {deviceId}")
+        data = self.get_tasklist_for_printer(deviceId)
+        if len(data) != 0:
+            return data[0]
+        return {}
+
     def get_tasklist_for_printer(self, deviceId: str) -> dict:
         LOGGER.debug(f"Getting task list from Bambu Cloud for Printer: {deviceId}")
+        tasks = []
         data = self.get_tasklist()
         for task in data['hits']:
             if task['deviceId'] == deviceId:
-                return task
-        return {}
+                tasks.append(task)
+        return tasks
 
     def get_device_type_from_device_product_name(self, device_product_name: str):
         if device_product_name == "X1 Carbon":

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -31,7 +31,7 @@ class FansEnum(Enum):
     HEATBREAK = 4,
 
 
-ACTION_IDS = {
+CURRENT_STAGE_IDS = {
     "default": "unknown",
     0: "printing",
     1: "auto_bed_leveling",
@@ -45,13 +45,13 @@ ACTION_IDS = {
     9: "scanning_bed_surface",
     10: "inspecting_first_layer",
     11: "identifying_build_plate_type",
-    12: "calibrating_micro_lidar",
+    12: "calibrating_micro_lidar", # DUPLICATED?
     13: "homing_toolhead",
     14: "cleaning_nozzle_tip",
     15: "checking_extruder_temperature",
     16: "paused_user",
     17: "paused_front_cover_falling",
-    18: "calibrating_micro_lidar",
+    18: "calibrating_micro_lidar", # DUPLICATED?
     19: "calibrating_extrusion_flow",
     20: "paused_nozzle_temperature_malfunction",
     21: "paused_heat_bed_temperature_malfunction",
@@ -70,10 +70,25 @@ ACTION_IDS = {
     34: "paused_first_layer_error",
     35: "paused_nozzle_clog",
     # X1 returns -1 for idle
-    -1: "idle",
+    -1: "idle",  # DUPLICATED
     # P1 returns 255 for idle
-    255: "idle"
+    255: "idle", # DUPLICATED
 }
+
+CURRENT_STAGE_OPTIONS = list(set(CURRENT_STAGE_IDS.values())) # Conversion to set first removes the duplicates
+
+GCODE_STATE_OPTIONS = [
+    "failed",
+    "finish",
+    "idle",
+    "init",
+    "offline",
+    "pause",
+    "prepare",
+    "running",
+    "slicing",
+    "unknown"
+]
 
 SPEED_PROFILE = {
     1: "silent",
@@ -284,3 +299,4 @@ class Home_Flag_Values(IntEnum):
     INSTALLED_PLUS                      = 0x04000000,
     SUPPORTED_PLUS                      = 0x08000000,
     # Gap
+

--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -1,7 +1,7 @@
 import math
 from datetime import datetime, timedelta
 
-from .const import ACTION_IDS, SPEED_PROFILE, FILAMENT_NAMES, HMS_ERRORS, HMS_AMS_ERRORS, LOGGER, FansEnum
+from .const import CURRENT_STAGE_IDS, SPEED_PROFILE, FILAMENT_NAMES, HMS_ERRORS, HMS_AMS_ERRORS, LOGGER, FansEnum
 from .commands import SEND_GCODE_TEMPLATE
 
 
@@ -51,14 +51,14 @@ def get_filament_name(idx):
     return result
 
 
-def get_speed_name(_id):
+def get_speed_name(id):
     """Return the human-readable name for a speed id"""
-    return SPEED_PROFILE.get(int(_id), "standard")
+    return SPEED_PROFILE.get(int(id), "standard")
 
 
-def get_stage_action(_id):
+def get_current_stage(id) -> str:
     """Return the human-readable description for a stage action"""
-    return ACTION_IDS.get(_id, "unknown")
+    return CURRENT_STAGE_IDS.get(int(id), "unknown")
 
 
 def get_HMS_error_text(hms_code: str):
@@ -75,6 +75,7 @@ def get_HMS_error_text(hms_code: str):
         return ams_error
 
     return HMS_ERRORS.get(hms_code, "unknown")
+
 
 def get_generic_AMS_HMS_error_code(hms_code: str):
     code1 = int(hms_code[0:4], 16)


### PR DESCRIPTION
Create lists of the available options in pybambu so that the definition can reference those directly.
Update setting of the affected values so that they reliably set 'unknown' if we have a missing entry.
Tweak names to be more consistent with bambu terminology.