### PR TITLE
Add ams weight data to weight sensor

### DIFF
--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -131,7 +131,12 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
     
     def _update_data(self):
         device = self.get_model()
-        self.async_set_updated_data(device)
+        try:
+            self.async_set_updated_data(device)
+        except Exception as e:
+            LOGGER.error("An exception occurred calling async_set_updated_data():")
+            LOGGER.error(f"Exception type: {type(e)}")
+            LOGGER.error(f"Exception data: {e}")
 
     def _update_hms(self):
         dev_reg = device_registry.async_get(self._hass)

--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -336,6 +336,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:file",
         value_fn=lambda self: self.coordinator.get_model().print_job.print_weight,
+        extra_attributes=lambda self: self.coordinator.get_model().print_job.get_ams_print_weights,
         exists_fn=lambda coordinator: coordinator.get_model().info.has_bambu_cloud_connection
     ),
     BambuLabSensorEntityDescription(

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -518,7 +518,7 @@ class PrintJob:
                 # self.end_time isn't updated if we hit an AMS retract at print end but the printer does count that entire
                 # paused time as usage hours. So we need to use the current time instead of the last recorded end time in
                 # our calculation here.
-                duration = get_end_time(0) - self.start_time
+                duration = datetime.now() - self.start_time
                 # Round usage hours to 2 decimal places (about 1/2 a minute accuracy)
                 new_hours = round((duration.seconds / 60 / 60) * 100) / 100
                 LOGGER.debug(f"NEW USAGE HOURS: {self._client._device.info.device_type} {new_hours}")

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -374,10 +374,19 @@ class PrintJob:
     current_layer: int
     total_layers: int
     print_error: int
-    print_weight: int
+    print_weight: float
     print_length: int
     print_bed_type: str
     print_type: str
+    _ams_print_weights: float
+
+    @property
+    def get_ams_print_weights(self) -> float:
+        values = {}
+        for i in range(16):
+            if self._ams_print_weights[i] != 0:
+                values[i] = self._ams_print_weights[i]
+        return values
 
     def __init__(self, client):
         self._client = client
@@ -392,6 +401,7 @@ class PrintJob:
         self.total_layers = 0
         self.print_error = 0
         self.print_weight = 0
+        self._ams_print_weights = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         self.print_length = 0
         self.print_bed_type = "unknown"
         self.file_type_icon = "mdi:file"
@@ -565,6 +575,7 @@ class PrintJob:
                 LOGGER.debug("No bambu cloud task data found for printer.")
                 self._client._device.cover_image.set_jpeg(None)
                 self.print_weight = 0
+                self._ams_print_weights = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                 self.print_length = 0
                 self.print_bed_type = "unknown"
                 self.start_time = None
@@ -576,9 +587,15 @@ class PrintJob:
                     data = self._client.bambu_cloud.download(url)
                     self._client._device.cover_image.set_jpeg(data)
 
-                self.print_weight = self._task_data.get('weight', self.print_weight)
                 self.print_length = self._task_data.get('length', self.print_length)
                 self.print_bed_type = self._task_data.get('bedType', self.print_bed_type)
+                self.print_weight = self._task_data.get('weight', self.print_weight)
+                ams_print_data = self._task_data.get('amsDetailMapping', [])
+                self._ams_print_weights = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+                for ams_data in ams_print_data:
+                    index = ams_data['ams']
+                    weight = ams_data['weight']
+                    self._ams_print_weights[index] = weight
 
                 status = self._task_data['status']
                 LOGGER.debug(f"CLOUD PRINT STATUS: {status}")

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -385,7 +385,7 @@ class PrintJob:
         values = {}
         for i in range(16):
             if self._ams_print_weights[i] != 0:
-                values[i] = self._ams_print_weights[i]
+                values[f"AMS Slot {i}"] = self._ams_print_weights[i]
         return values
 
     def __init__(self, client):


### PR DESCRIPTION
Adds the AMS weight data breakdown as extra attributes to the existing weight sensor.
Fixes an incorrect 24 hour jump in usage hours if you start and immediately cancel a print in < 30 seconds.
Add exception handling around data update call into HA as an extra safeguard.