### PR TITLE
Fix for 'AttributeError' no attribute 'errors'

### DIFF
--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -191,8 +191,8 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
                 "type": "event_printer_error_cleared",
             }
             #LOGGER.debug(f"EVENT: print_error cleared: {event_data}")
-            if 'Code' in device.print_error.errors:
-                event_data["Code"] = device.print_error.errors['Code']
+            if 'Code' in device.print_error.error:
+                event_data["Code"] = device.print_error.error['Code']
         else:
             event_data = {
                 "device_id": hadevice.id,


### PR DESCRIPTION
When an error occurs, Home Assistant throws an AttributeError. It seems that the current code uses the wrong attribute 'errors'. The surrounding code suggest also, the the attribute should be 'error'.

This closes #592.