### PR TITLE
Switch to async_forward_entry_setups

### DIFF
--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -221,8 +221,8 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         LOGGER.debug("_reinitialize_sensors START")
         LOGGER.debug("async_forward_entry_unload")
         await self.hass.config_entries.async_forward_entry_unload(self.config_entry, Platform.SENSOR)
-        LOGGER.debug("async_forward_entry_setup")
-        await self.hass.config_entries.async_forward_entry_setup(self.config_entry, Platform.SENSOR)
+        LOGGER.debug("async_forward_entry_setups")
+        await self.hass.config_entries.async_forward_entry_setups(self.config_entry, [Platform.SENSOR])
         LOGGER.debug("_reinitialize_sensors DONE")
 
     def _update_ams_info(self):


### PR DESCRIPTION
[Calling `hass.config_entries.async_forward_entry_setup` is deprecated and will be removed in Home Assistant 2025.6](https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/).