### PR TITLE
Re-enable getting the slicer settings

### DIFF
--- a/custom_components/bambu_lab/manifest.json
+++ b/custom_components/bambu_lab/manifest.json
@@ -19,5 +19,5 @@
       "st": "urn:bambulab-com:device:3dprinter:1"
     }
   ],  
-  "version": "2.0.24"
+  "version": "2.0.25"
 }

--- a/custom_components/bambu_lab/pybambu/bambu_cloud.py
+++ b/custom_components/bambu_lab/pybambu/bambu_cloud.py
@@ -189,8 +189,8 @@ class BambuCloud:
         with httpx.Client(http2=True) as client:
             response = client.get(url, headers=headers, timeout=10)
         if response.status_code >= 400:
-            LOGGER.debug(f"Received error: {response.status_code}")
-            raise ValueError(response.status_code)
+            LOGGER.error(f"Slicer settings load failed: {response.status_code}")
+            return None
         return response.json()
         
     # The task list is of the following form with a 'hits' array with typical 20 entries.

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -1429,8 +1429,7 @@ class SlicerSettings:
 
     def update(self):
         self.custom_filaments = {}
-        # As of late 10/22 this is now return access denied (403) and breaking the integration. Disable it for now.
-        # if self._client.bambu_cloud.auth_token != "":
-        #     LOGGER.debug("Loading slicer settings")
-        #     slicer_settings = self._client.bambu_cloud.get_slicer_settings()
-        #     self._load_custom_filaments(slicer_settings)
+        if self._client.bambu_cloud.auth_token != "":
+            LOGGER.debug("Loading slicer settings")
+            slicer_settings = self._client.bambu_cloud.get_slicer_settings()
+            self._load_custom_filaments(slicer_settings)

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -1432,4 +1432,5 @@ class SlicerSettings:
         if self._client.bambu_cloud.auth_token != "":
             LOGGER.debug("Loading slicer settings")
             slicer_settings = self._client.bambu_cloud.get_slicer_settings()
-            self._load_custom_filaments(slicer_settings)
+            if slicer_settings is not None:
+                self._load_custom_filaments(slicer_settings)

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,6 @@
+### V2.0.25
+- Re-enable slicer settings with fix and improved resilience to http errors
+
 ### V2.0.24
 - Disable slicer settings retrieval as it is getting access denied and breaking the integration.
 


### PR DESCRIPTION
After the fix in #625, re-enable retrieving slicer settings and fix http error to not take out the integration and instead just log an error.