### PR TITLE
Fix handling of HMS errors clearing

### DIFF
--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -183,9 +183,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
                 "device_id": hadevice.id,
                 "type": "event_printer_error_cleared",
             }
-            #LOGGER.debug(f"EVENT: print_error cleared: {event_data}")
-            if 'Code' in device.print_error.error:
-                event_data["Code"] = device.print_error.error['Code']
+            LOGGER.debug(f"EVENT: print_error cleared: {event_data}")
         else:
             event_data = {
                 "device_id": hadevice.id,


### PR DESCRIPTION
The code was trying to use an empty list (set to None) in the errors cleared case. Delete the errant line.