### PR TITLE
Delete missed error initialization line from earlier incorrect change.

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -1193,7 +1193,6 @@ class PrintErrorList:
     def __init__(self, client):
         self._error = None
         self._client = client
-        self._error = {}
         
     def print_update(self, data) -> bool:
         # Example payload:


### PR DESCRIPTION
Should be benign but also shouldn't be there.