### PR TITLE
Cleanly handle an AMS being removed or moved to another printer.

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -817,6 +817,7 @@ class AMSList:
         self._client = client
         self.tray_now = 0
         self.data = [None] * 4
+        self._first_initialization_done = False
 
     def info_update(self, data):
         old_data = f"{self.__dict__}"
@@ -858,7 +859,7 @@ class AMSList:
             
             if index != -1:
                 # Sometimes we get incomplete version data. We have to skip if that occurs since the serial number is
-                # requires as part of the home assistant device identity.
+                # required as part of the home assistant device identity.
                 if not module['sn'] == '':
                     # May get data before info so create entries if necessary
                     if self.data[index] is None:
@@ -873,6 +874,9 @@ class AMSList:
                     if self.data[index].hw_version != module['hw_ver']:
                         data_changed = True
                         self.data[index].hw_version = module['hw_ver']
+            elif not self._first_initialization_done:
+                self._first_initialization_done = True
+                data_changed = True
 
         data_changed = data_changed or (old_data != f"{self.__dict__}")
 


### PR DESCRIPTION
This fixes two issues:
- When an AMS is first detected we manually added a device to HA. And we added it with the wrong identifiers - using the serial of the printer, not the AMS. This doesn't seem to have had any negative impact because when we later add the sensors we used device info with the correct serial and HA auto-added that device. So this entire section of code was removed.
- When an AMS is removed from a printer we never reacted to that. This happens in two cases - a literal removal or an addition of a new AMS that changes the indices that the printers assigns to the AMS's. I think that indexing starts with 0 being the AMS further along the connection chain from the printer and the highest number the AMS in the chain directly connect to the printer.

To handle the latter I updated the model to fire an event when the AMS list is first initialized even if the list was empty. Previously it only did that when the list changed and since it started as an empty list it didn't fire the event.

When receiving the event, instead of creating the incorrect device as before (now deleted) we enumerate the list of AMS devices attached to the printer from the model. And we enumerate the list of AMS devices attached to the printer in the home assistant device registry. And any that exist in the latter but not the former get removed from the HA device registry. This handles both removal and index re-order because in the latter, the 'dead' AMS at its old index no longer has an associated serial in it's identifiers in the device registry - presumably the new instance invalidated that somehow (it's 'N/A').

So if you previously had two printers each with 1 AMS attached and move one AMS to be daisy chained to the other, you would/could end up with:
Printer 1 -> 1 AMS attached
Printer 2 -> 3 AMS attached
With this fix you should now end up in the correct state of:
Printer 1 -> 0 AMS attached
Printer 2 -> 2 AMS attached