### PR TITLE
Suppress remaining filament on AMS Lite

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -368,34 +368,16 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         extra_attributes=lambda self:
         {
             "color": f"#{self.coordinator.get_model().get_active_tray().color}",
+            **({"k_value": self.coordinator.get_model().get_active_tray().k} if self.coordinator.get_model().supports_feature(Features.K_VALUE) else {}),
             "name": self.coordinator.get_model().get_active_tray().name,
             "nozzle_temp_min": self.coordinator.get_model().get_active_tray().nozzle_temp_min,
             "nozzle_temp_max": self.coordinator.get_model().get_active_tray().nozzle_temp_max,
-            "remain": self.coordinator.get_model().get_active_tray().remain,
+            **({"remain": self.coordinator.get_model().get_active_tray().remain} if self.coordinator.get_model().supports_feature(Features.AMS_FILAMENT_REMAINING) else {}),
             "tray_uuid": self.coordinator.get_model().get_active_tray().tray_uuid,
             "type": self.coordinator.get_model().get_active_tray().type,
         },
         available_fn=lambda self: self.coordinator.get_model().get_active_tray() is not None,
-        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.AMS) and not coordinator.get_model().supports_feature(Features.K_VALUE)
-    ),
-    BambuLabSensorEntityDescription(
-        key="active_tray",
-        translation_key="active_tray",
-        icon="mdi:printer-3d-nozzle",
-        value_fn=lambda self: self.coordinator.get_model().get_active_tray().name,
-        extra_attributes=lambda self:
-        {
-            "color": f"#{self.coordinator.get_model().get_active_tray().color}",
-            "k_value": self.coordinator.get_model().get_active_tray().k,
-            "name": self.coordinator.get_model().get_active_tray().name,
-            "nozzle_temp_min": self.coordinator.get_model().get_active_tray().nozzle_temp_min,
-            "nozzle_temp_max": self.coordinator.get_model().get_active_tray().nozzle_temp_max,
-            "remain": self.coordinator.get_model().get_active_tray().remain,
-            "tray_uuid": self.coordinator.get_model().get_active_tray().tray_uuid,
-            "type": self.coordinator.get_model().get_active_tray().type,
-        },
-        available_fn=lambda self: self.coordinator.get_model().get_active_tray() is not None,
-        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.AMS) and coordinator.get_model().supports_feature(Features.K_VALUE)
+        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.AMS)
     ),
     BambuLabSensorEntityDescription(
         key="nozzle_diameter",
@@ -424,30 +406,12 @@ VIRTUAL_TRAY_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "active": not self.coordinator.get_model().supports_feature(Features.AMS) or (
                     self.coordinator.get_model().ams.tray_now == 254),
             "color": f"#{self.coordinator.get_model().external_spool.color}",
+            **({"k_value": self.coordinator.get_model().external_spool.k} if self.coordinator.get_model().supports_feature(Features.K_VALUE) else {}),
             "name": self.coordinator.get_model().external_spool.name,
             "nozzle_temp_min": self.coordinator.get_model().external_spool.nozzle_temp_min,
             "nozzle_temp_max": self.coordinator.get_model().external_spool.nozzle_temp_max,
             "type": self.coordinator.get_model().external_spool.type,
         },
-        exists_fn=lambda coordinator: not coordinator.get_model().supports_feature(Features.K_VALUE)
-    ),
-    BambuLabSensorEntityDescription(
-        key="external_spool",
-        translation_key="external_spool",
-        icon="mdi:printer-3d-nozzle",
-        value_fn=lambda self: self.coordinator.get_model().external_spool.name,
-        extra_attributes=lambda self:
-        {
-            "active": not self.coordinator.get_model().supports_feature(Features.AMS) or (
-                    self.coordinator.get_model().ams.tray_now == 254),
-            "color": f"#{self.coordinator.get_model().external_spool.color}",
-            "k_value": self.coordinator.get_model().external_spool.k,
-            "name": self.coordinator.get_model().external_spool.name,
-            "nozzle_temp_min": self.coordinator.get_model().external_spool.nozzle_temp_min,
-            "nozzle_temp_max": self.coordinator.get_model().external_spool.nozzle_temp_max,
-            "type": self.coordinator.get_model().external_spool.type,
-        },
-        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
 )
 
@@ -478,16 +442,16 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         {
             "active": (self.coordinator.get_model().ams.tray_now % 4 == 0) and (
                     math.floor(self.coordinator.get_model().ams.tray_now / 4) == self.index),
-            "empty": self.coordinator.get_model().ams.data[self.index].tray[0].empty,
             "color": f"#{self.coordinator.get_model().ams.data[self.index].tray[0].color}",
+            "empty": self.coordinator.get_model().ams.data[self.index].tray[0].empty,
+            **({"k_value": self.coordinator.get_model().ams.data[self.index].tray[0].k} if self.coordinator.get_model().supports_feature(Features.K_VALUE) else {}),
             "name": self.coordinator.get_model().ams.data[self.index].tray[0].name,
             "nozzle_temp_min": self.coordinator.get_model().ams.data[self.index].tray[0].nozzle_temp_min,
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[0].nozzle_temp_max,
-            "remain": self.coordinator.get_model().ams.data[self.index].tray[0].remain,
+            **({"remain": self.coordinator.get_model().ams.data[self.index].tray[0].remain} if self.coordinator.get_model().supports_feature(Features.AMS_FILAMENT_REMAINING) else {}),
             "tray_uuid": self.coordinator.get_model().ams.data[self.index].tray[0].tray_uuid,
             "type": self.coordinator.get_model().ams.data[self.index].tray[0].type,
         },
-        exists_fn=lambda coordinator: not coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
     BambuLabSensorEntityDescription(
         key="tray_2",
@@ -500,14 +464,14 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
                     math.floor(self.coordinator.get_model().ams.tray_now / 4) == self.index),
             "color": f"#{self.coordinator.get_model().ams.data[self.index].tray[1].color}",
             "empty": self.coordinator.get_model().ams.data[self.index].tray[1].empty,
+            **({"k_value": self.coordinator.get_model().ams.data[self.index].tray[1].k} if self.coordinator.get_model().supports_feature(Features.K_VALUE) else {}),
             "name": self.coordinator.get_model().ams.data[self.index].tray[1].name,
             "nozzle_temp_min": self.coordinator.get_model().ams.data[self.index].tray[1].nozzle_temp_min,
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[1].nozzle_temp_max,
-            "remain": self.coordinator.get_model().ams.data[self.index].tray[1].remain,
+            **({"remain": self.coordinator.get_model().ams.data[self.index].tray[1].remain} if self.coordinator.get_model().supports_feature(Features.AMS_FILAMENT_REMAINING) else {}),
             "tray_uuid": self.coordinator.get_model().ams.data[self.index].tray[1].tray_uuid,
             "type": self.coordinator.get_model().ams.data[self.index].tray[1].type,
         },
-        exists_fn=lambda coordinator: not coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
     BambuLabSensorEntityDescription(
         key="tray_3",
@@ -520,14 +484,14 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
                     math.floor(self.coordinator.get_model().ams.tray_now / 4) == self.index),
             "color": f"#{self.coordinator.get_model().ams.data[self.index].tray[2].color}",
             "empty": self.coordinator.get_model().ams.data[self.index].tray[2].empty,
+            **({"k_value": self.coordinator.get_model().ams.data[self.index].tray[2].k} if self.coordinator.get_model().supports_feature(Features.K_VALUE) else {}),
             "name": self.coordinator.get_model().ams.data[self.index].tray[2].name,
             "nozzle_temp_min": self.coordinator.get_model().ams.data[self.index].tray[2].nozzle_temp_min,
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[2].nozzle_temp_max,
-            "remain": self.coordinator.get_model().ams.data[self.index].tray[2].remain,
+            **({"remain": self.coordinator.get_model().ams.data[self.index].tray[2].remain} if self.coordinator.get_model().supports_feature(Features.AMS_FILAMENT_REMAINING) else {}),
             "tray_uuid": self.coordinator.get_model().ams.data[self.index].tray[2].tray_uuid,
             "type": self.coordinator.get_model().ams.data[self.index].tray[2].type,
         },
-        exists_fn=lambda coordinator: not coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
     BambuLabSensorEntityDescription(
         key="tray_4",
@@ -540,98 +504,14 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
                     math.floor(self.coordinator.get_model().ams.tray_now / 4) == self.index),
             "color": f"#{self.coordinator.get_model().ams.data[self.index].tray[3].color}",
             "empty": self.coordinator.get_model().ams.data[self.index].tray[3].empty,
+            **({"k_value": self.coordinator.get_model().ams.data[self.index].tray[3].k} if self.coordinator.get_model().supports_feature(Features.K_VALUE) else {}),
             "name": self.coordinator.get_model().ams.data[self.index].tray[3].name,
             "nozzle_temp_min": self.coordinator.get_model().ams.data[self.index].tray[3].nozzle_temp_min,
             "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[3].nozzle_temp_max,
-            "remain": self.coordinator.get_model().ams.data[self.index].tray[3].remain,
+            **({"remain": self.coordinator.get_model().ams.data[self.index].tray[3].remain} if self.coordinator.get_model().supports_feature(Features.AMS_FILAMENT_REMAINING) else {}),
             "tray_uuid": self.coordinator.get_model().ams.data[self.index].tray[3].tray_uuid,
             "type": self.coordinator.get_model().ams.data[self.index].tray[3].type,
         },
-        exists_fn=lambda coordinator: not coordinator.get_model().supports_feature(Features.K_VALUE)
-    ),
-    BambuLabSensorEntityDescription(
-        key="tray_1",
-        translation_key="tray_1",
-        icon="mdi:printer-3d-nozzle",
-        value_fn=lambda self: self.coordinator.get_model().ams.data[self.index].tray[0].name,
-        extra_attributes=lambda self:
-        {
-            "active": (self.coordinator.get_model().ams.tray_now % 4 == 0) and (
-                    math.floor(self.coordinator.get_model().ams.tray_now / 4) == self.index),
-            "color": f"#{self.coordinator.get_model().ams.data[self.index].tray[0].color}",
-            "empty": self.coordinator.get_model().ams.data[self.index].tray[0].empty,
-            "k_value": self.coordinator.get_model().ams.data[self.index].tray[0].k,
-            "name": self.coordinator.get_model().ams.data[self.index].tray[0].name,
-            "nozzle_temp_min": self.coordinator.get_model().ams.data[self.index].tray[0].nozzle_temp_min,
-            "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[0].nozzle_temp_max,
-            "remain": self.coordinator.get_model().ams.data[self.index].tray[0].remain,
-            "tray_uuid": self.coordinator.get_model().ams.data[self.index].tray[0].tray_uuid,
-            "type": self.coordinator.get_model().ams.data[self.index].tray[0].type,
-        },
-        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.K_VALUE)
-    ),
-    BambuLabSensorEntityDescription(
-        key="tray_2",
-        translation_key="tray_2",
-        icon="mdi:printer-3d-nozzle",
-        value_fn=lambda self: self.coordinator.get_model().ams.data[self.index].tray[1].name,
-        extra_attributes=lambda self:
-        {
-            "active": (self.coordinator.get_model().ams.tray_now % 4 == 1) and (
-                    math.floor(self.coordinator.get_model().ams.tray_now / 4) == self.index),
-            "color": f"#{self.coordinator.get_model().ams.data[self.index].tray[1].color}",
-            "empty": self.coordinator.get_model().ams.data[self.index].tray[1].empty,
-            "k_value": self.coordinator.get_model().ams.data[self.index].tray[1].k,
-            "name": self.coordinator.get_model().ams.data[self.index].tray[1].name,
-            "nozzle_temp_min": self.coordinator.get_model().ams.data[self.index].tray[1].nozzle_temp_min,
-            "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[1].nozzle_temp_max,
-            "remain": self.coordinator.get_model().ams.data[self.index].tray[1].remain,
-            "tray_uuid": self.coordinator.get_model().ams.data[self.index].tray[1].tray_uuid,
-            "type": self.coordinator.get_model().ams.data[self.index].tray[1].type,
-        },
-        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.K_VALUE)
-    ),
-    BambuLabSensorEntityDescription(
-        key="tray_3",
-        translation_key="tray_3",
-        icon="mdi:printer-3d-nozzle",
-        value_fn=lambda self: self.coordinator.get_model().ams.data[self.index].tray[2].name,
-        extra_attributes=lambda self:
-        {
-            "active": (self.coordinator.get_model().ams.tray_now % 4 == 2) and (
-                    math.floor(self.coordinator.get_model().ams.tray_now / 4) == self.index),
-            "color": f"#{self.coordinator.get_model().ams.data[self.index].tray[2].color}",
-            "empty": self.coordinator.get_model().ams.data[self.index].tray[2].empty,
-            "k_value": self.coordinator.get_model().ams.data[self.index].tray[2].k,
-            "name": self.coordinator.get_model().ams.data[self.index].tray[2].name,
-            "nozzle_temp_min": self.coordinator.get_model().ams.data[self.index].tray[2].nozzle_temp_min,
-            "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[2].nozzle_temp_max,
-            "remain": self.coordinator.get_model().ams.data[self.index].tray[2].remain,
-            "tray_uuid": self.coordinator.get_model().ams.data[self.index].tray[2].tray_uuid,
-            "type": self.coordinator.get_model().ams.data[self.index].tray[2].type,
-        },
-        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.K_VALUE)
-    ),
-    BambuLabSensorEntityDescription(
-        key="tray_4",
-        translation_key="tray_4",
-        icon="mdi:printer-3d-nozzle",
-        value_fn=lambda self: self.coordinator.get_model().ams.data[self.index].tray[3].name,
-        extra_attributes=lambda self:
-        {
-            "active": (self.coordinator.get_model().ams.tray_now % 4 == 3) and (
-                    math.floor(self.coordinator.get_model().ams.tray_now / 4) == self.index),
-            "color": f"#{self.coordinator.get_model().ams.data[self.index].tray[3].color}",
-            "empty": self.coordinator.get_model().ams.data[self.index].tray[3].empty,
-            "k_value": self.coordinator.get_model().ams.data[self.index].tray[3].k,
-            "name": self.coordinator.get_model().ams.data[self.index].tray[3].name,
-            "nozzle_temp_min": self.coordinator.get_model().ams.data[self.index].tray[3].nozzle_temp_min,
-            "nozzle_temp_max": self.coordinator.get_model().ams.data[self.index].tray[3].nozzle_temp_max,
-            "remain": self.coordinator.get_model().ams.data[self.index].tray[3].remain,
-            "tray_uuid": self.coordinator.get_model().ams.data[self.index].tray[3].tray_uuid,
-            "type": self.coordinator.get_model().ams.data[self.index].tray[3].type,
-        },
-        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.K_VALUE)
     ),
 )
 

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -27,6 +27,7 @@ class Features(Enum):
     CAMERA_IMAGE = 15,
     DOOR_SENSOR = 16,
     MANUAL_MODE = 17,
+    AMS_FILAMENT_REMAINING = 18,
 
 
 class FansEnum(Enum):

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -124,6 +124,9 @@ class Device:
             return self.info.device_type == "X1" or self.info.device_type == "X1C" or self.info.device_type == "X1E"
         elif feature == Features.MANUAL_MODE:
             return self.info.device_type == "P1P" or self.info.device_type == "P1S" or self.info.device_type == "A1" or self.info.device_type == "A1MINI"
+        elif feature == Features.AMS_FILAMENT_REMAINING:
+            # Technically this is not the AMS Lite but that's currently tied to only these printer types.
+            return self.info.device_type != "A1" and self.info.device_type != "A1MINI"
 
         return False
     


### PR DESCRIPTION
The AMS Lite cannot track remaining filament so suppress that data point from the tray attributes.
Fixes #580

I also found a neat Python-y way to construct the dict with conditional entries and was able to use that to remove the high duplication currently used to have K value not present for X1 printers.