### PR TITLE
Fix error when the printer is not configured for local mqtt access

### DIFF
--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -381,7 +381,7 @@ class BambuClient:
                 LOGGER.debug("Starting Chamber Image thread")
                 self._camera = ChamberImageThread(self)
                 self._camera.start()
-            elif (self._client.host == "") or (self._client._access_code == ""):
+            elif (self.client.host == "") or (self.client._access_code == ""):
                 LOGGER.debug("Skipping camera setup as local access details not provided.")
 
     def try_on_connect(self,


### PR DESCRIPTION
Regression in recent logging addition to help eliminate by design lack of camera access from unexpected lack of camera access.