### PR TITLE
Starting the camera is optional, defaults to on

### DIFF
--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -283,7 +283,7 @@ class BambuClient:
     _usage_hours: float
 
     def __init__(self, device_type: str, serial: str, host: str, local_mqtt: bool, region: str, email: str,
-                 username: str, auth_token: str, access_code: str, usage_hours: float = 0, manual_refresh_mode: bool = False):
+                 username: str, auth_token: str, access_code: str, usage_hours: float = 0, manual_refresh_mode: bool = False, chamber_image: bool = True):
         self.callback = None
         self.host = host
         self._local_mqtt = local_mqtt
@@ -300,6 +300,7 @@ class BambuClient:
         self._device = Device(self)
         self.bambu_cloud = BambuCloud(region, email, username, auth_token)
         self.slicer_settings = SlicerSettings(self)
+        self.use_chamber_image = chamber_image
 
     @property
     def connected(self):
@@ -378,9 +379,10 @@ class BambuClient:
 
         if not self._device.supports_feature(Features.CAMERA_RTSP):
             if self._device.supports_feature(Features.CAMERA_IMAGE):
-                LOGGER.debug("Starting Chamber Image thread")
-                self._camera = ChamberImageThread(self)
-                self._camera.start()
+                if self.use_chamber_image:
+                    LOGGER.debug("Starting Chamber Image thread")
+                    self._camera = ChamberImageThread(self)
+                    self._camera.start()
             elif (self.client.host == "") or (self.client._access_code == ""):
                 LOGGER.debug("Skipping camera setup as local access details not provided.")
 


### PR DESCRIPTION
The P1S can only handle two simultaneous image streams and this integration will use one of them. I have plans to use other instances of this superb library where the image stream is not needed, and would eat the last stream slot. This PR allows for specifying that the image stream should not be initialized, but of course defaults to `on` for compatibility.