### PR TITLE
Switch to curl_cffi to pass cloudflare

### DIFF
--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -111,16 +111,22 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     result = await self.hass.async_add_executor_job(
                         self._bambu_cloud.login_with_verification_code,
                         user_input['verifyCode'])
-                    LOGGER.debug(f"RESULT = {result}")
                     if result == 'success':
                         return await self.async_step_Bambu_Choose_Device(None)
+                    elif result == 'codeExpired':
+                        authentication_type = 'verifyCode'
+                        errors['base'] = "code_expired"
+                        # Fall through to form generation to ask for verification code
+                    elif result == 'codeIncorrect':
+                        authentication_type = 'verifyCode'
+                        errors['base'] = "code_incorrect"
+                        # Fall through to form generation to ask for verification code
                     else:
                         errors['base'] = "cannot_connect"
                 elif user_input.get('tfaCode', None) is not None:
                     result = await self.hass.async_add_executor_job(
                         self._bambu_cloud.login_with_2fa_code,
                         user_input['tfaCode'])
-                    LOGGER.debug(f"RESULT = {result}")
                     if result == 'success':
                         return await self.async_step_Bambu_Choose_Device(None)
                     else:
@@ -133,7 +139,6 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         user_input['region'],
                         user_input['email'],
                         user_input['password'])
-                    LOGGER.debug(f"RESULT = {result}")
                     if result == 'success':
                         return await self.async_step_Bambu_Choose_Device(None)
                     elif result == 'verifyCode':
@@ -422,16 +427,22 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
                     result = await self.hass.async_add_executor_job(
                         self._bambu_cloud.login_with_verification_code,
                         user_input['verifyCode'])
-                    LOGGER.debug(f"RESULT = {result}")
                     if result == 'success':
                         return await self.async_step_Bambu_Lan(None)
+                    elif result == 'codeExpired':
+                        authentication_type = 'verifyCode'
+                        errors['base'] = "code_expired"
+                        # Fall through to form generation to ask for verification code
+                    elif result == 'codeIncorrect':
+                        authentication_type = 'verifyCode'
+                        errors['base'] = "code_incorrect"
+                        # Fall through to form generation to ask for verification code
                     else:
                         errors['base'] = "cannot_connect"
                 elif user_input.get('tfaCode', None) is not None:
                     result = await self.hass.async_add_executor_job(
                         self._bambu_cloud.login_with_2fa_code,
                         user_input['tfaCode'])
-                    LOGGER.debug(f"RESULT = {result}")
                     if result == 'success':
                         return await self.async_step_Bambu_Lan(None)
                     else:
@@ -444,7 +455,6 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
                         user_input['region'],
                         user_input['email'],
                         user_input['password'])
-                    LOGGER.debug(f"RESULT = {result}")
                     if result == 'success':
                         return await self.async_step_Bambu_Lan(None)
                     elif result == 'verifyCode':

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -65,7 +65,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         self._eventloop.call_soon_threadsafe(self.event_handler_internal, event)
 
     def event_handler_internal(self, event):
-        LOGGER.debug(f"EVENT: {event}")
+        #LOGGER.debug(f"EVENT: {event}")
         if event == "event_printer_info_update":
             self._update_device_info()
             if self.get_model().supports_feature(Features.EXTERNAL_SPOOL):

--- a/custom_components/bambu_lab/manifest.json
+++ b/custom_components/bambu_lab/manifest.json
@@ -13,11 +13,13 @@
   "documentation": "https://github.com/greghesp/ha-bambulab",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/greghesp/ha-bambulab/issues",
-  "requirements": ["cloudscraper"],
+  "requirements": [
+    "curl_cffi"
+  ],
   "ssdp": [
     {
       "st": "urn:bambulab-com:device:3dprinter:1"
     }
   ],  
-  "version": "2.0.32"
+  "version": "2.0.33"
 }

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -78,7 +78,6 @@ class Device:
         send_event = send_event | self.home_flag.print_update(data = data)
 
         if send_event and self._client.callback is not None:
-            LOGGER.debug("event_printer_data_update")
             self._client.callback("event_printer_data_update")
 
         if data.get("msg", 0) == 0:

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -20,6 +20,8 @@
       "invalid_auth": "Invalid authentication.",
       "unknown": "Unexpected error.",
       "verifyCode": "Verification code is required. Check your email.",
+      "code_expired": "Verification code expired. New code requested. Check your email.",
+      "code_incorrect": "Verification code was incorrect. Please re-enter.",
       "tfaCode": "2FA code is required. Please enter it now."
     },
     "step": {
@@ -77,6 +79,8 @@
       "invalid_auth": "Invalid authentication.",
       "unknown": "Unexpected error.",
       "verifyCode": "Verification code is required. Check your email.",
+      "code_expired": "Verification code expired. New code requested. Check your email.",
+      "code_incorrect": "Verification code was incorrect. Please re-enter.",
       "tfaCode": "2FA code is required. Please enter it now."
     },
     "step": {

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,7 @@
+### V2.0.33
+- Switch to curl_cffi to get past cloudflare
+- Fix greek localization filename
+
 ### V2.0.32
 - Fix error when printer IP address isn't provided due to incorrect logging addition
 


### PR DESCRIPTION
curl_cffi claims to better model a real browser. While it doesn't have the cloudflare specific features that cloudscraper has around captchas etc., we don't need those and, at least for now, curl_cffi is able to pass cloudflare.

Add handling for incorrect or expired verification codes.