### PR TITLE
Fix off by one error in print weight attributes

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -386,7 +386,7 @@ class PrintJob:
         values = {}
         for i in range(16):
             if self._ams_print_weights[i] != 0:
-                values[f"AMS Slot {i}"] = self._ams_print_weights[i]
+                values[f"AMS Slot {i+1}"] = self._ams_print_weights[i]
         return values
 
     @property
@@ -394,7 +394,7 @@ class PrintJob:
         values = {}
         for i in range(16):
             if self._ams_print_lengths[i] != 0:
-                values[f"AMS Slot {i}"] = self._ams_print_lengths[i]
+                values[f"AMS Slot {i+1}"] = self._ams_print_lengths[i]
         return values
 
     def __init__(self, client):


### PR DESCRIPTION
The list Bambu returns is 0 based. So we need to add 1 to the UI description.