### PR TITLE
Streamline configuration settings. Add switch to turn camera on/off with persisted state.

### DIFF
--- a/custom_components/bambu_lab/camera.py
+++ b/custom_components/bambu_lab/camera.py
@@ -35,7 +35,7 @@ class BambuLabRtspCamera(BambuLabEntity, Camera):
 
     _attr_translation_key = "camera"
     _attr_icon = "mdi:camera"
-    _attr_supported_features = CameraEntityFeature.STREAM | CameraEntityFeature.ON_OFF
+    _attr_supported_features = CameraEntityFeature.STREAM
     _attr_brand = "Bambu Lab"
 
     def __init__(

--- a/custom_components/bambu_lab/camera.py
+++ b/custom_components/bambu_lab/camera.py
@@ -35,7 +35,7 @@ class BambuLabRtspCamera(BambuLabEntity, Camera):
 
     _attr_translation_key = "camera"
     _attr_icon = "mdi:camera"
-    _attr_supported_features = CameraEntityFeature.STREAM
+    _attr_supported_features = CameraEntityFeature.STREAM | CameraEntityFeature.ON_OFF
     _attr_brand = "Bambu Lab"
 
     def __init__(
@@ -58,14 +58,12 @@ class BambuLabRtspCamera(BambuLabEntity, Camera):
 
     @property
     def is_recording(self) -> bool:
-        if self.coordinator.get_model().camera.recording == "enable":
-            return True
         return False
 
     @property
     def use_stream_for_stills(self) -> bool:
         return True
-    
+
     @property
     def available(self) -> bool:
         url = self.coordinator.get_model().camera.rtsp_url
@@ -112,3 +110,15 @@ class BambuLabImageCamera(BambuLabEntity, Camera):
 
     def camera_image(self, width: int | None = None, height: int | None = None) -> bytes | None:
         return self.coordinator.get_model().chamber_image.get_jpeg()
+
+    @property
+    def is_streaming(self) -> bool:
+        return self.available
+    
+    @property
+    def is_recording(self) -> bool:
+        return False
+    
+    @property
+    def available(self) -> bool:
+        return self.coordinator.get_model().chamber_image.available

--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -248,15 +248,15 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             device_type = self._bambu_cloud.get_device_type_from_device_product_name(device['dev_product_name'])
             if user_input.get('host', "") != "":
                 LOGGER.debug("Config Flow: Testing local mqtt connection")
-                bambu = BambuClient(device_type=device_type,
-                                    serial=device['dev_id'],
-                                    host=user_input['host'],
-                                    local_mqtt=True,
-                                    region=self.region,
-                                    email="",
-                                    username="",
-                                    auth_token="",
-                                    access_code=user_input['access_code'])
+                config = {
+                    'access_code': user_input['access_code'],
+                    'device_type': device_type,
+                    'host': user_input['host'],
+                    'local_mqtt': True,
+                    'region': self.region,
+                    'serial': device['dev_id'],
+                }
+                bambu = BambuClient(config)
                 success = await bambu.try_connection()
                 if not success:
                     errors['base'] = "cannot_connect_local_all"
@@ -312,15 +312,13 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             user_input['serial'] = user_input['serial'].upper()
 
             LOGGER.debug("Config Flow: Testing local mqtt connection")
-            bambu = BambuClient(device_type="unknown",
-                                serial=user_input['serial'],
-                                host=user_input['host'],
-                                local_mqtt=True,
-                                region="",
-                                email="",
-                                username="",
-                                auth_token="",
-                                access_code=user_input['access_code'])
+            config = {
+                'access_code': user_input['access_code'],
+                'serial': user_input['serial'],
+                'host': user_input['host'],
+                'local_mqtt': True,
+            }
+            bambu = BambuClient(config)
             success = await bambu.try_connection()
 
             if success:
@@ -527,15 +525,14 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
                     success = True
                     if user_input.get('host', "") != "":
                         LOGGER.debug(f"Options Flow: Testing local mqtt connection to {user_input.get('host')}")
-                        bambu = BambuClient(device_type=self.config_entry.data['device_type'],
-                                            serial=self.config_entry.data['serial'],
-                                            host=user_input['host'],
-                                            local_mqtt=True,
-                                            region="",
-                                            email="",
-                                            username="",
-                                            auth_token="",
-                                            access_code=user_input['access_code'])
+                        config = {
+                            'access_code': user_input['access_code'],
+                            'device_type': self.config_entry.data['device_type'],
+                            'host': user_input['host'],
+                            'local_mqtt': True,
+                            'serial': self.config_entry.data['serial'],
+                        }
+                        bambu = BambuClient(config)
                         success = await bambu.try_connection()
                         if not success:
                             errors['base'] = "cannot_connect_local_ip"
@@ -601,15 +598,14 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
 
         if user_input is not None:
             LOGGER.debug("Options Flow: Testing local mqtt Connection")
-            bambu = BambuClient(device_type=self.config_entry.data['device_type'],
-                                serial=self.config_entry.data['serial'],
-                                host=user_input['host'],
-                                local_mqtt=True,
-                                region="",
-                                email="",
-                                username="",
-                                auth_token="",
-                                access_code=user_input['access_code'])
+            config = {
+                'access_code': user_input['access_code'],
+                'device_type': self.config_entry.data['device_type'],
+                'host': user_input['host'],
+                'local_mqtt': True,
+                'serial': self.config_entry.data['serial'],
+            }
+            bambu = BambuClient(config)
             success = await bambu.try_connection()
 
             if success:

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -31,17 +31,9 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         LOGGER.debug(f"ConfigEntry.Id: {entry.entry_id}")
 
         self.latest_usage_hours = float(entry.options.get('usage_hours', 0))
-        self.client = BambuClient(device_type = entry.data["device_type"],
-                                  serial = entry.data["serial"],
-                                  host = entry.options['host'],
-                                  local_mqtt = entry.options['local_mqtt'],
-                                  region = entry.options.get('region', ''),
-                                  email = entry.options.get('email', ''),
-                                  username = entry.options['username'],
-                                  auth_token = entry.options['auth_token'],
-                                  access_code = entry.options['access_code'],
-                                  usage_hours = self.latest_usage_hours,
-                                  manual_refresh_mode = entry.options.get('manual_refresh_mode', False))
+        config = entry.data.copy()
+        config.update(entry.options.items())
+        self.client = BambuClient(config)
             
         self._updatedDevice = False
         self.data = self.get_model()

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -323,3 +323,14 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
             title=self.get_model().info.serial,
             data=self.config_entry.data,
             options=options)
+
+    async def enable_camera(self, enable):
+        LOGGER.debug(f"Setting camera enabled to {enable}")
+        self.client.enable_camera(enable)
+        options = dict(self.config_entry.options)
+        options['enable_camera'] = enable
+        self._hass.config_entries.async_update_entry(
+            entry=self.config_entry,
+            title=self.get_model().info.serial,
+            data=self.config_entry.data,
+            options=options)

--- a/custom_components/bambu_lab/manifest.json
+++ b/custom_components/bambu_lab/manifest.json
@@ -21,5 +21,5 @@
       "st": "urn:bambulab-com:device:3dprinter:1"
     }
   ],  
-  "version": "2.0.34"
+  "version": "2.0.35"
 }

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -297,7 +297,7 @@ class BambuClient:
         self._serial = config.get('serial', '')
         self._usage_hours = config.get('usage_hours', 0)
         self._username = config.get('username', '')
-        self._use_chamber_image = config.get('chamber_image', False)
+        self._disable_camera = config.get('disable_camera', False)
 
         self._connected = False
         self._port = 1883
@@ -389,7 +389,7 @@ class BambuClient:
 
         if not self._device.supports_feature(Features.CAMERA_RTSP):
             if self._device.supports_feature(Features.CAMERA_IMAGE):
-                if self._use_chamber_image:
+                if not self._disable_camera:
                     LOGGER.debug("Starting Chamber Image thread")
                     self._camera = ChamberImageThread(self)
                     self._camera.start()

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -297,7 +297,7 @@ class BambuClient:
         self._serial = config.get('serial', '')
         self._usage_hours = config.get('usage_hours', 0)
         self._username = config.get('username', '')
-        self._disable_camera = config.get('disable_camera', False)
+        self._enable_camera = config.get('enable_camera', True)
 
         self._connected = False
         self._port = 1883
@@ -330,6 +330,17 @@ class BambuClient:
         else:
             # Reconnect normally
             self.connect(self.callback)
+
+    @property
+    def camera_enabled(self):
+        return self._enable_camera
+
+    def enable_camera(self, enable):
+        self._enable_camera = enable
+        if self._enable_camera:
+            self._start_camera()
+        else:
+            self._stop_camera()
 
     def setup_tls(self):
         self.client.tls_set(tls_version=ssl.PROTOCOL_TLS, cert_reqs=ssl.CERT_NONE)
@@ -379,6 +390,22 @@ class BambuClient:
         LOGGER.info("On Connect: Connected to printer")
         self._on_connect()
 
+    def _start_camera(self):
+        if not self._device.supports_feature(Features.CAMERA_RTSP):
+            if self._device.supports_feature(Features.CAMERA_IMAGE):
+                if self._enable_camera:
+                    LOGGER.debug("Starting Chamber Image thread")
+                    self._camera = ChamberImageThread(self)
+                    self._camera.start()
+            elif (self.host == "") or (self._access_code == ""):
+                LOGGER.debug("Skipping camera setup as local access details not provided.")
+
+    def _stop_camera(self):
+        if self._camera is not None:
+            LOGGER.debug("Stopping camera thread")
+            self._camera.stop()
+            self._camera.join()
+
     def _on_connect(self):
         self._connected = True
         self.subscribe_and_request_info()
@@ -387,14 +414,7 @@ class BambuClient:
         self._watchdog = WatchdogThread(self)
         self._watchdog.start()
 
-        if not self._device.supports_feature(Features.CAMERA_RTSP):
-            if self._device.supports_feature(Features.CAMERA_IMAGE):
-                if not self._disable_camera:
-                    LOGGER.debug("Starting Chamber Image thread")
-                    self._camera = ChamberImageThread(self)
-                    self._camera.start()
-            elif (self.host == "") or (self._access_code == ""):
-                LOGGER.debug("Skipping camera setup as local access details not provided.")
+        self._start_camera()
 
     def try_on_connect(self,
                        client_: mqtt.Client,
@@ -427,10 +447,7 @@ class BambuClient:
             LOGGER.debug("Stopping watchdog thread")
             self._watchdog.stop()
             self._watchdog.join()
-        if self._camera is not None:
-            LOGGER.debug("Stopping camera thread")
-            self._camera.stop()
-            self._camera.join()
+        self._stop_camera()
 
     def _on_watchdog_fired(self):
         LOGGER.info("Watch dog fired")

--- a/custom_components/bambu_lab/pybambu/bambu_cloud.py
+++ b/custom_components/bambu_lab/pybambu/bambu_cloud.py
@@ -434,6 +434,7 @@ class BambuCloud:
         response = curl_requests.get(url, timeout=10, impersonate=IMPERSONATE_BROWSER)
         if response.status_code >= 400:
             LOGGER.debug(f"Received error: {response.status_code}")
+            LOGGER.debug(f"Received error: {response.text}")
             raise ValueError(response.status_code)
         
         return response.content

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -53,7 +53,7 @@ class Device:
         self.external_spool = ExternalSpool(client = client)
         self.hms = HMSList(client = client)
         self.print_error = PrintErrorList(client = client)
-        self.camera = Camera()
+        self.camera = Camera(client = client)
         self.home_flag = HomeFlag(client=client)
         self.push_all_data = None
         self.get_version_data = None
@@ -205,7 +205,8 @@ class Camera:
     rtsp_url: str
     timelapse: str
 
-    def __init__(self):
+    def __init__(self, client):
+        self._client = client
         self.recording = ''
         self.resolution = ''
         self.rtsp_url = None
@@ -227,7 +228,10 @@ class Camera:
         self.timelapse = data.get("ipcam", {}).get("timelapse", self.timelapse)
         self.recording = data.get("ipcam", {}).get("ipcam_record", self.recording)
         self.resolution = data.get("ipcam", {}).get("resolution", self.resolution)
-        self.rtsp_url = data.get("ipcam", {}).get("rtsp_url", self.rtsp_url)
+        if self._client._disable_camera:
+            self.rtsp_url = None
+        else:
+            self.rtsp_url = data.get("ipcam", {}).get("rtsp_url", self.rtsp_url)
         
         return (old_data != f"{self.__dict__}")
 
@@ -1302,6 +1306,10 @@ class ChamberImage:
     
     def get_jpeg(self) -> bytearray:
         return self._bytes.copy()
+    
+    @property
+    def available(self):
+        return not self._client._disable_camera 
     
 @dataclass
 class CoverImage:

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -228,10 +228,10 @@ class Camera:
         self.timelapse = data.get("ipcam", {}).get("timelapse", self.timelapse)
         self.recording = data.get("ipcam", {}).get("ipcam_record", self.recording)
         self.resolution = data.get("ipcam", {}).get("resolution", self.resolution)
-        if self._client._disable_camera:
-            self.rtsp_url = None
-        else:
+        if self._client._enable_camera:
             self.rtsp_url = data.get("ipcam", {}).get("rtsp_url", self.rtsp_url)
+        else:
+            self.rtsp_url = None
         
         return (old_data != f"{self.__dict__}")
 
@@ -1309,7 +1309,7 @@ class ChamberImage:
     
     @property
     def available(self):
-        return not self._client._disable_camera 
+        return self._client._enable_camera 
     
 @dataclass
 class CoverImage:

--- a/custom_components/bambu_lab/switch.py
+++ b/custom_components/bambu_lab/switch.py
@@ -24,6 +24,12 @@ MANUAL_REFRESH_MODE_SWITCH_DESCRIPTION = SwitchEntityDescription(
     entity_category=EntityCategory.CONFIG,
 )
 
+CAMERA_SWITCH_DESCRIPION = SwitchEntityDescription(
+    key="camera",
+    icon="mdi:refresh-auto",
+    translation_key="camera",
+    entity_category=EntityCategory.CONFIG,
+)
 
 async def async_setup_entry(
         hass: HomeAssistant,
@@ -35,6 +41,8 @@ async def async_setup_entry(
 
     if coordinator.get_model().supports_feature(Features.MANUAL_MODE):
         async_add_entities([BambuLabManualModeSwitch(coordinator, entry)])
+
+    async_add_entities([BambuLabCameraSwitch(coordinator, entry)])
 
 
 class BambuLabSwitch(BambuLabEntity, SwitchEntity):
@@ -84,3 +92,35 @@ class BambuLabManualModeSwitch(BambuLabSwitch):
         """Disable manual refresh mode."""
         self._attr_is_on = not self.coordinator.client.manual_refresh_mode
         await self.coordinator.set_manual_refresh_mode(False)
+
+class BambuLabCameraSwitch(BambuLabSwitch):
+    """BambuLab Refresh data Switch"""
+
+    entity_description = CAMERA_SWITCH_DESCRIPION
+
+    def __init__(
+            self,
+            coordinator: BambuDataUpdateCoordinator,
+            config_entry: ConfigEntry
+    ) -> None:
+        super().__init__(coordinator, config_entry)
+        self._attr_is_on = self.coordinator.client.camera_enabled
+
+    @property
+    def available(self) -> bool:
+        return True
+
+    @property
+    def icon(self) -> str:
+        """Return the icon for the switch."""
+        return "mdi:video" if self.is_on else "mdi:video-off"
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable manual refresh mode."""
+        self._attr_is_on = not self.coordinator.client.camera_enabled
+        await self.coordinator.enable_camera(self._attr_is_on)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable manual refresh mode."""
+        self._attr_is_on = not self.coordinator.client.camera_enabled
+        await self.coordinator.enable_camera(self._attr_is_on)

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -562,6 +562,9 @@
     "switch": {
       "manual": {
         "name": "Manual refresh mode"
+      },
+      "camera": {
+        "name": "Camera"
       }
     }
   }

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,7 @@
+### V2.0.35
+- Switch to dictionary for initialization settings.
+- Allow cameras to be turned off.
+
 ### V2.0.34
 - Update translations for new strings
 - Fix off by one error in print weight attributes


### PR DESCRIPTION
- Switch to a dictionary for configuration as individual parameters has gotten very unwieldy.
- Add new camera_enabled option that is persisted to HASS.
- If False, the cameras are not enabled (RTSP never sets URL, A1/P1 never start the chamber image collection thread).
- Add switch to toggle this state.
- Turn the camera streaming on/off when the switch is toggled.