### PR TITLE
Use credentials from other instances if they are working

### DIFF
--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -530,9 +530,9 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
 
         # Build form
         fields: OrderedDict[vol.Marker, Any] = OrderedDict()
-        default_region = default_region if user_input is None else user_input.get('region', '')
+        default_region = self.config_entry.options.get('region', '') if user_input is None else user_input.get('region', '')
         fields[vol.Required("region", default=default_region)] = REGION_SELECTOR
-        default_email = default_email if user_input is None else user_input.get('email', '')
+        default_email = self.config_entry.options.get('email','') if user_input is None else user_input.get('email', '')
         fields[vol.Required('email', default=default_email)] = EMAIL_SELECTOR
         default_password = '' if user_input is None else user_input.get('password', '')
         fields[vol.Required('password', default=default_password)] = PASSWORD_SELECTOR

--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -103,6 +103,8 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         errors = {}
+        default_region = ''
+        default_email = ''
 
         if user_input is None:
             # Iterate over all existing entries and try any existing credentials to see if they work
@@ -194,9 +196,9 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Build form
         fields: OrderedDict[vol.Marker, Any] = OrderedDict()
-        default_region = '' if user_input is None else user_input.get('region', '')
+        default_region = default_region if user_input is None else user_input.get('region', '')
         fields[vol.Required("region", default=default_region)] = REGION_SELECTOR
-        default_email = '' if user_input is None else user_input.get('email', '')
+        default_email = default_email if user_input is None else user_input.get('email', '')
         fields[vol.Required('email', default=default_email)] = EMAIL_SELECTOR
         default_password = '' if user_input is None else user_input.get('password', '')
         fields[vol.Required('password', default=default_password)] = PASSWORD_SELECTOR

--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -448,21 +448,21 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
             for config_entry in config_entries:
                 if config_entry.options.get('region', '') != '' and config_entry.options.get('email', '') != '' and config_entry.options.get('username', '') != '' and config_entry.options.get('auth_token', '') != '':
                     LOGGER.debug(f"Testing credentials from existing entry id: {config_entry.entry_id}")
-                    default_region = config_entry.options['region']
-                    default_email = config_entry.options['email']
+                    region = config_entry.options['region']
+                    email = config_entry.options['email']
                     username = config_entry.options['username']
                     auth_token = config_entry.options['auth_token']
                     if await self.hass.async_add_executor_job(self._bambu_cloud.test_authentication,
-                                                              default_region,
-                                                              default_email,
+                                                              region,
+                                                              email,
                                                               username,
                                                               auth_token):
                         LOGGER.debug("Found working credentials.")
-                        self.region = default_region
-                        self.email = default_email
+                        self.region = region
+                        self.email = email
                         self.bambu_cloud = BambuCloud(
-                            default_region,
-                            default_email,
+                            region,
+                            email,
                             username,
                             auth_token
                         )

--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -104,7 +104,6 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         errors = {}
 
-        credentialsGood = False
         if user_input is None:
             # Iterate over all existing entries and try any existing credentials to see if they work
             config_entries = self.hass.config_entries.async_entries(DOMAIN)
@@ -116,13 +115,11 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     default_email = config_entry.options['email']
                     username = config_entry.options['username']
                     auth_token = config_entry.options['auth_token']
-                    credentialsGood = await self.hass.async_add_executor_job(
-                        self._bambu_cloud.test_authentication,
-                        default_region,
-                        default_email,
-                        username,
-                        auth_token)
-                    if credentialsGood:
+                    if await self.hass.async_add_executor_job(self._bambu_cloud.test_authentication,
+                                                              default_region,
+                                                              default_email,
+                                                              username,
+                                                              auth_token):
                         LOGGER.debug("Found working credentials.")
                         self.region = default_region
                         self.email = default_email
@@ -444,7 +441,6 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
     ) -> FlowResult:
         errors = {}
 
-        credentialsGood = False
         if user_input is None:
             # Iterate over all existing entries and try any existing credentials to see if they work
             config_entries = self.hass.config_entries.async_entries(DOMAIN)
@@ -456,13 +452,11 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
                     default_email = config_entry.options['email']
                     username = config_entry.options['username']
                     auth_token = config_entry.options['auth_token']
-                    credentialsGood = await self.hass.async_add_executor_job(
-                        self._bambu_cloud.test_authentication,
-                        default_region,
-                        default_email,
-                        username,
-                        auth_token)
-                    if credentialsGood:
+                    if await self.hass.async_add_executor_job(self._bambu_cloud.test_authentication,
+                                                              default_region,
+                                                              default_email,
+                                                              username,
+                                                              auth_token):
                         LOGGER.debug("Found working credentials.")
                         self.region = default_region
                         self.email = default_email

--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -104,6 +104,36 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         errors = {}
 
+        credentialsGood = False
+        if user_input is None:
+            # Iterate over all existing entries and try any existing credentials to see if they work
+            config_entries = self.hass.config_entries.async_entries(DOMAIN)
+            LOGGER.debug(f"Found {len(config_entries)} existing config entries for the integration.")
+            for config_entry in config_entries:
+                if config_entry.options.get('region', '') != '' and config_entry.options.get('email', '') != '' and config_entry.options.get('username', '') != '' and config_entry.options.get('auth_token', '') != '':
+                    LOGGER.debug(f"Testing credentials from existing entry id: {config_entry.entry_id}")
+                    default_region = config_entry.options['region']
+                    default_email = config_entry.options['email']
+                    username = config_entry.options['username']
+                    auth_token = config_entry.options['auth_token']
+                    credentialsGood = await self.hass.async_add_executor_job(
+                        self._bambu_cloud.test_authentication,
+                        default_region,
+                        default_email,
+                        username,
+                        auth_token)
+                    if credentialsGood:
+                        LOGGER.debug("Found working credentials.")
+                        self.region = default_region
+                        self.email = default_email
+                        self.bambu_cloud = BambuCloud(
+                            default_region,
+                            default_email,
+                            username,
+                            auth_token
+                        )
+                        return await self.async_step_Bambu_Choose_Device(None)
+
         authentication_type = None
         if user_input is not None:
             try:
@@ -416,14 +446,34 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
 
         credentialsGood = False
         if user_input is None:
-            if self.config_entry.options.get('region', '') != '' and self.config_entry.options.get('email', '') != '' and self.config_entry.options.get('username', '') != '' and self.config_entry.options.get('auth_token', '') != '':
-                credentialsGood = await self.hass.async_add_executor_job(
-                    self._bambu_cloud.test_authentication,
-                    self.config_entry.options['region'],
-                    self.config_entry.options['email'],
-                    self.config_entry.options['username'],
-                    self.config_entry.options['auth_token'])
-
+            # Iterate over all existing entries and try any existing credentials to see if they work
+            config_entries = self.hass.config_entries.async_entries(DOMAIN)
+            LOGGER.debug(f"Found {len(config_entries)} existing config entries for the integration.")
+            for config_entry in config_entries:
+                if config_entry.options.get('region', '') != '' and config_entry.options.get('email', '') != '' and config_entry.options.get('username', '') != '' and config_entry.options.get('auth_token', '') != '':
+                    LOGGER.debug(f"Testing credentials from existing entry id: {config_entry.entry_id}")
+                    default_region = config_entry.options['region']
+                    default_email = config_entry.options['email']
+                    username = config_entry.options['username']
+                    auth_token = config_entry.options['auth_token']
+                    credentialsGood = await self.hass.async_add_executor_job(
+                        self._bambu_cloud.test_authentication,
+                        default_region,
+                        default_email,
+                        username,
+                        auth_token)
+                    if credentialsGood:
+                        LOGGER.debug("Found working credentials.")
+                        self.region = default_region
+                        self.email = default_email
+                        self.bambu_cloud = BambuCloud(
+                            default_region,
+                            default_email,
+                            username,
+                            auth_token
+                        )
+                        return await self.async_step_Bambu_Lan(None)
+                    
         authentication_type = None
         if user_input is not None:
             try:
@@ -484,16 +534,11 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
                 LOGGER.error(f"Failed to connect with error code {e.args}")
                 errors['base'] = "cannot_connect"
 
-        elif credentialsGood:
-            self.region = self.config_entry.options['region']
-            self.email = self.config_entry.options['email']
-            return await self.async_step_Bambu_Lan(None)
-
         # Build form
         fields: OrderedDict[vol.Marker, Any] = OrderedDict()
-        default_region = self.config_entry.options.get('region', '') if user_input is None else user_input.get('region', '')
+        default_region = default_region if user_input is None else user_input.get('region', '')
         fields[vol.Required("region", default=default_region)] = REGION_SELECTOR
-        default_email = self.config_entry.options.get('email','') if user_input is None else user_input.get('email', '')
+        default_email = default_email if user_input is None else user_input.get('email', '')
         fields[vol.Required('email', default=default_email)] = EMAIL_SELECTOR
         default_password = '' if user_input is None else user_input.get('password', '')
         fields[vol.Required('password', default=default_password)] = PASSWORD_SELECTOR

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,10 +1,12 @@
 ### V2.0.35
 - Switch to dictionary for initialization settings.
 - Allow cameras to be turned off.
+- Use working credentials from other integration instances if present
 
 ### V2.0.34
 - Update translations for new strings
 - Fix off by one error in print weight attributes
+- Set curl_cffi to impersonate Chrome
 
 ### V2.0.33
 - Switch to curl_cffi to get past cloudflare


### PR DESCRIPTION
When adding multiple printers, credentials from any existing instance will be used if they are found to be working to skip the authentication step entirely for second printers onwards.