### PR TITLE
Pick up Skydev0h's changes so I can make some adjustments.

### DIFF
--- a/custom_components/bambu_lab/const.py
+++ b/custom_components/bambu_lab/const.py
@@ -16,6 +16,7 @@ PLATFORMS = (
     Platform.FAN,
     Platform.IMAGE,
     Platform.LIGHT,
+    Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH

--- a/custom_components/bambu_lab/number.py
+++ b/custom_components/bambu_lab/number.py
@@ -1,0 +1,110 @@
+from dataclasses import dataclass
+from collections.abc import Callable
+
+from homeassistant.components.number import (
+    NumberEntity,
+    NumberEntityDescription, NumberDeviceClass, NumberMode
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, LOGGER
+from .coordinator import BambuDataUpdateCoordinator
+from .models import BambuLabEntity
+from .pybambu.const import Features, TempEnum
+
+
+@dataclass
+class BambuLabTemperatureEntityDescriptionMixin:
+    """Mixin for required keys."""
+    value_fn: Callable[..., any]
+    set_value_fn: Callable[..., None]
+    exists_fn: Callable[..., bool]
+
+
+@dataclass
+class BambuLabNumberEntityDescription(NumberEntityDescription, BambuLabTemperatureEntityDescriptionMixin):
+    """Editable (number) temperature entity description for Bambu Lab."""
+
+
+NUMBERS: tuple[BambuLabNumberEntityDescription, ...] = (
+    # TODO: Maybe hide for devices that must wait for temp? (P1*, A1*)
+    # On the one hand, it kinda works, on the other hand, it may freeze print and possibly cause side effects
+    # (especially if interrupt is attempted with M108)
+    BambuLabNumberEntityDescription(
+        key="target_nozzle_temperature",
+        translation_key="target_nozzle_temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=NumberDeviceClass.TEMPERATURE,
+        icon="mdi:printer-3d-nozzle",
+        mode=NumberMode.BOX,
+        native_min_value=0,
+        native_max_value=320, # TODO: Determine by actual printer model
+        native_step=1,
+        value_fn=lambda device: device.temperature.target_nozzle_temp,
+        set_value_fn=lambda device, value: device.temperature.set_target_temp(TempEnum.NOZZLE, value),
+        exists_fn=lambda device: True  # not device.must_wait_for_temp()
+    ),
+    BambuLabNumberEntityDescription(
+        key="target_bed_temperature",
+        translation_key="target_bed_temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=NumberDeviceClass.TEMPERATURE,
+        mode=NumberMode.BOX,
+        native_min_value=0,
+        native_max_value=120,  # TODO: Determine by actual printer model and voltage
+        native_step=1,
+        value_fn=lambda device: device.temperature.target_bed_temp,
+        set_value_fn=lambda device, value: device.temperature.set_target_temp(TempEnum.HEATBED, value),
+        exists_fn=lambda device: True  # not device.must_wait_for_temp()
+    ),
+)
+
+
+async def async_setup_entry(
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback
+) -> None:
+    LOGGER.debug("NUMBER::async_setup_entry")
+    coordinator: BambuDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    for description in NUMBERS:
+        if description.exists_fn(coordinator):
+            async_add_entities([BambuLabNumber(coordinator, description, entry)])
+
+    LOGGER.debug("NUMBER::async_setup_entry DONE")
+
+
+class BambuLabNumber(BambuLabEntity, NumberEntity):
+    """ Defined the Number"""
+    entity_description: BambuLabNumberEntityDescription
+
+    def __init__(
+            self,
+            coordinator: BambuDataUpdateCoordinator,
+            description: BambuLabNumberEntityDescription,
+            config_entry: ConfigEntry
+    ) -> None:
+        """Initialize the number."""
+        self.entity_description = description
+        self._attr_unique_id = f"{config_entry.data['serial']}_{description.key}"
+        self._attr_native_value = description.value_fn(coordinator.get_model())
+
+        super().__init__(coordinator=coordinator)
+
+    @property
+    def available(self) -> bool:
+        """Is the number available"""
+        return True
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the value reported by the number."""
+        return self.entity_description.value_fn(self.coordinator.get_model())
+
+    def set_native_value(self, value: float) -> None:
+        """Update the current value."""
+        self.entity_description.set_value_fn(self.coordinator.get_model(), round(value))

--- a/custom_components/bambu_lab/number.py
+++ b/custom_components/bambu_lab/number.py
@@ -30,9 +30,6 @@ class BambuLabNumberEntityDescription(NumberEntityDescription, BambuLabTemperatu
 
 
 NUMBERS: tuple[BambuLabNumberEntityDescription, ...] = (
-    # TODO: Maybe hide for devices that must wait for temp? (P1*, A1*)
-    # On the one hand, it kinda works, on the other hand, it may freeze print and possibly cause side effects
-    # (especially if interrupt is attempted with M108)
     BambuLabNumberEntityDescription(
         key="target_nozzle_temperature",
         translation_key="target_nozzle_temperature",
@@ -45,7 +42,7 @@ NUMBERS: tuple[BambuLabNumberEntityDescription, ...] = (
         native_step=1,
         value_fn=lambda device: device.temperature.target_nozzle_temp,
         set_value_fn=lambda device, value: device.temperature.set_target_temp(TempEnum.NOZZLE, value),
-        exists_fn=lambda device: True  # not device.must_wait_for_temp()
+        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.SET_TEMPERATURE)
     ),
     BambuLabNumberEntityDescription(
         key="target_bed_temperature",
@@ -58,7 +55,7 @@ NUMBERS: tuple[BambuLabNumberEntityDescription, ...] = (
         native_step=1,
         value_fn=lambda device: device.temperature.target_bed_temp,
         set_value_fn=lambda device, value: device.temperature.set_target_temp(TempEnum.HEATBED, value),
-        exists_fn=lambda device: True  # not device.must_wait_for_temp()
+        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.SET_TEMPERATURE)
     ),
 )
 

--- a/custom_components/bambu_lab/pybambu/bambu_cloud.py
+++ b/custom_components/bambu_lab/pybambu/bambu_cloud.py
@@ -456,5 +456,9 @@ class BambuCloud:
         return self._auth_token
     
     @property
+    def bambu_connected(self) -> bool:
+        return self._auth_token != "" and self._auth_token != None
+    
+    @property
     def cloud_mqtt_host(self):
         return "cn.mqtt.bambulab.com" if self._region == "China" else "us.mqtt.bambulab.com"

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -37,6 +37,11 @@ class FansEnum(Enum):
     HEATBREAK = 4,
 
 
+class TempEnum(Enum):
+    HEATBED = 1,
+    NOZZLE = 2
+
+
 CURRENT_STAGE_IDS = {
     "default": "unknown",
     0: "printing",

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -28,6 +28,7 @@ class Features(Enum):
     DOOR_SENSOR = 16,
     MANUAL_MODE = 17,
     AMS_FILAMENT_REMAINING = 18,
+    SET_TEMPERATURE = 19,
 
 
 class FansEnum(Enum):

--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -50,19 +50,15 @@ def fan_percentage_to_gcode(fan: FansEnum, percentage: int):
     return command
 
 
-def set_temperature_to_gcode(temp: TempEnum, temperature: int, wait: bool):
+def set_temperature_to_gcode(temp: TempEnum, temperature: int):
     """Converts a temperature to the gcode command to set that"""
     if temp == TempEnum.NOZZLE:
-        tempCommand = "M109" if wait else "M104"
+        tempCommand = "M104"
     elif temp == TempEnum.HEATBED:
-        tempCommand = "M190" if wait else "M140"
-
-    # TODO: Evaluate possible side effects of M108 and consider it
-    # second_command = "M108\n" if wait else ""
-    second_command = ""
+        tempCommand = "M140"
 
     command = SEND_GCODE_TEMPLATE
-    command['print']['param'] = f"{tempCommand} S{temperature}\n{second_command}"
+    command['print']['param'] = f"{tempCommand} S{temperature}\n"
     return command
 
 

--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -11,8 +11,9 @@ from .const import (
     HMS_SEVERITY_LEVELS,
     HMS_MODULES,
     LOGGER,
+    BAMBU_URL,
     FansEnum,
-    BAMBU_URL
+    TempEnum
 )
 from .commands import SEND_GCODE_TEMPLATE
 
@@ -46,6 +47,22 @@ def fan_percentage_to_gcode(fan: FansEnum, percentage: int):
     speed = math.ceil(255 * percentage / 100)
     command = SEND_GCODE_TEMPLATE
     command['print']['param'] = f"M106 {fanString} S{speed}\n"
+    return command
+
+
+def set_temperature_to_gcode(temp: TempEnum, temperature: int, wait: bool):
+    """Converts a temperature to the gcode command to set that"""
+    if temp == TempEnum.NOZZLE:
+        tempCommand = "M109" if wait else "M104"
+    elif temp == TempEnum.HEATBED:
+        tempCommand = "M190" if wait else "M140"
+
+    # TODO: Evaluate possible side effects of M108 and consider it
+    # second_command = "M108\n" if wait else ""
+    second_command = ""
+
+    command = SEND_GCODE_TEMPLATE
+    command['print']['param'] = f"{tempCommand} S{temperature}\n{second_command}"
     return command
 
 

--- a/custom_components/bambu_lab/translations/de.json
+++ b/custom_components/bambu_lab/translations/de.json
@@ -186,6 +186,14 @@
         "name": "Kamerabeleuchtung"
       }
     },
+    "number": {
+      "target_bed_temperature": {
+        "name": "Zieltemperatur des Druckbett"
+      },
+      "target_nozzle_temperature": {
+        "name": "Zieltemperatur der Düse"
+      }
+    },
     "select": {
       "printing_speed": {
         "name": "Druckgeschwindigkeit",

--- a/custom_components/bambu_lab/translations/el.json
+++ b/custom_components/bambu_lab/translations/el.json
@@ -186,6 +186,14 @@
         "name": "Φωτισμός κάμερας"
       }
     },
+    "number": {
+      "target_bed_temperature": {
+        "name": "Στόχος θερμοκρασίας βάσης"
+      },
+      "target_nozzle_temperature": {
+        "name": "Στόχος θερμοκρασίας ακροφυσίου"
+      }
+    },
     "select": {
       "printing_speed": {
         "name": "Ταχύτητα εκτύπωσης",

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -182,6 +182,14 @@
         "name": "Cover Image"
       }
     },
+    "number": {
+      "target_bed_temperature": {
+        "name": "Target Bed temperature"
+      },
+      "target_nozzle_temperature": {
+        "name": "Nozzle target temperature"
+      }
+    },
     "light": {
       "chamber_light": {
         "name": "Chamber light"

--- a/custom_components/bambu_lab/translations/es.json
+++ b/custom_components/bambu_lab/translations/es.json
@@ -186,6 +186,14 @@
         "name": "Luz de cámara"
       }
     },
+    "number": {
+      "target_bed_temperature": {
+        "name": "Temperatura de la cama objetivo"
+      },
+      "target_nozzle_temperature": {
+        "name": "Temperatura de la boquilla objetivo"
+      }
+    },
     "select": {
       "printing_speed": {
         "name": "Velocidad de impresión",

--- a/custom_components/bambu_lab/translations/fr.json
+++ b/custom_components/bambu_lab/translations/fr.json
@@ -186,6 +186,14 @@
         "name": "Lumière de la caméra"
       }
     },
+    "number": {
+      "target_bed_temperature": {
+        "name": "Température cible du lit"
+      },
+      "target_nozzle_temperature": {
+        "name": "Température cible de la buse"
+      }
+    },
     "select": {
       "printing_speed": {
         "name": "Vitesse d'impression",

--- a/custom_components/bambu_lab/translations/it.json
+++ b/custom_components/bambu_lab/translations/it.json
@@ -186,6 +186,14 @@
         "name": "Luce della fotocamera"
       }
     },
+    "number": {
+      "target_bed_temperature": {
+        "name": "Temperatura target del letto"
+      },
+      "target_nozzle_temperature": {
+        "name": "Temperatura target dell'ugello"
+      }
+    },
     "select": {
       "printing_speed": {
         "name": "Velocità di stampa",

--- a/custom_components/bambu_lab/translations/ko.json
+++ b/custom_components/bambu_lab/translations/ko.json
@@ -186,6 +186,14 @@
         "name": "카메라 라이트"
       }
     },
+    "number": {
+      "target_bed_temperature": {
+        "name": "목표 베드 온도"
+      },
+      "target_nozzle_temperature": {
+        "name": "노즐 목표 온도"
+      }
+    },
     "select": {
       "printing_speed": {
         "name": "출력 속도",

--- a/custom_components/bambu_lab/translations/pt.json
+++ b/custom_components/bambu_lab/translations/pt.json
@@ -186,6 +186,14 @@
         "name": "Luz da câmara"
       }
     },
+    "number": {
+      "target_bed_temperature": {
+        "name": "Temperatura alvo da mesa"
+      },
+      "target_nozzle_temperature": {
+        "name": "Temperatura alvo do bico"
+      }
+    },
     "select": {
       "printing_speed": {
         "name": "Velocidade de impressão",

--- a/custom_components/bambu_lab/translations/zh-Hans.json
+++ b/custom_components/bambu_lab/translations/zh-Hans.json
@@ -186,6 +186,14 @@
         "name": "摄像头灯"
       }
     },
+    "number": {
+      "target_bed_temperature": {
+        "name": "热床目标温度"
+      },
+      "target_nozzle_temperature": {
+        "name": "喷嘴目标温度"
+      }
+    },
     "select": {
       "printing_speed": {
         "name": "打印速度",


### PR DESCRIPTION
Pick up change from @Skydev0h 

Added number components that allow to adjust heatbed and nozzle temperature using Number components.

NB: For X1E it is also possible to set chamber temperature, but it is done using a completely separate command, not with gcode, and I do not have a X1E unit to test that.

I simplified their changes to remove the use of set and wait commands since that could easily have undesirable consequences and it's always possible to get this to work by the user simply running in full cloud mqtt mode or full Lan mode so I don't want to support that approach.