### PR TITLE
Emulate different browser & fix error when no printers are left

### DIFF
--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -220,12 +220,12 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
         LOGGER.debug("async_step_Bambu_Choose_Device")
 
-        device_list = await self.hass.async_add_executor_job(
-            self._bambu_cloud.get_device_list)
-
         if user_input is not None:
             self.serial = user_input['serial']
             return await self.async_step_Bambu_Lan(None)
+            
+        device_list = await self.hass.async_add_executor_job(
+            self._bambu_cloud.get_device_list)
             
         printer_list = []
         for device in device_list:
@@ -245,12 +245,11 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         LOGGER.debug(f"Printer count = {len(printer_list)}")
         if len(printer_list) == 0:
-            errors['base'] = "no_printers"
+            return self.async_abort(reason='no_printers')
 
         # Build form
         fields: OrderedDict[vol.Marker, Any] = OrderedDict()
-        if len(printer_list) != 0:
-            fields[vol.Required('serial')] = printer_selector
+        fields[vol.Required('serial')] = printer_selector
 
         return self.async_show_form(
             step_id="Bambu_Choose_Device",

--- a/custom_components/bambu_lab/scripts/TestAuthentication.py
+++ b/custom_components/bambu_lab/scripts/TestAuthentication.py
@@ -33,7 +33,7 @@ headers = {
     'Upgrade-Insecure-Requests': '1'
 }
 
-IMPERSONATE_BROWSER='chrome'
+IMPERSONATE_BROWSER='safari15_3'
 
 # Prompt the user for their Bambu Lab username and password if not provided on the command line
 if username is None:

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -10,7 +10,8 @@
   },
   "config": {
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Device is already configured",
+      "no_printers": "No unconfigured printers found in the account."
     },
     "error": {
       "cannot_connect": "Failed to connect. Check credentials.",


### PR DESCRIPTION
Switch curl_cffi to emulate a different browser to get past cloudflare for a bit again.
Disable the custom filament retrieval code as I have a suspicion that's contributing to cloudflare detecting and blocking the integration.
Fix runtime error if there are no remaining printers to configure on the account (#624). But doesn't fix the rare case where that's not true.