### PR TITLE
Cleanup login flow and switch back to cloudscraper from curl_cffi

### DIFF
--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -24,6 +24,14 @@ from homeassistant.helpers.selector import (
 
 from .const import DOMAIN, LOGGER
 from .pybambu import BambuClient, BambuCloud
+from .pybambu.bambu_cloud import (
+    CloudflareError,
+    CurlUnavailableError,
+    EmailCodeRequiredError,
+    EmailCodeExpiredError,
+    EmailCodeIncorrectError,
+    TfaCodeRequiredError
+)
 
 CONFIG_VERSION = 2
 
@@ -137,61 +145,49 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 if user_input.get('verifyCode', None) is not None:
-                    result = await self.hass.async_add_executor_job(
+                    await self.hass.async_add_executor_job(
                         self._bambu_cloud.login_with_verification_code,
                         user_input['verifyCode'])
-                    if result == 'success':
-                        return await self.async_step_Bambu_Choose_Device(None)
-                    elif result == 'codeExpired':
-                        authentication_type = 'verifyCode'
-                        errors['base'] = "code_expired"
-                        # Fall through to form generation to ask for verification code
-                    elif result == 'codeIncorrect':
-                        authentication_type = 'verifyCode'
-                        errors['base'] = "code_incorrect"
-                        # Fall through to form generation to ask for verification code
-                    else:
-                        errors['base'] = "cannot_connect"
                 elif user_input.get('tfaCode', None) is not None:
-                    result = await self.hass.async_add_executor_job(
+                    await self.hass.async_add_executor_job(
                         self._bambu_cloud.login_with_2fa_code,
                         user_input['tfaCode'])
-                    if result == 'success':
-                        return await self.async_step_Bambu_Choose_Device(None)
-                    else:
-                        errors['base'] = "cannot_connect"
                 else:
                     self.region = user_input['region']
                     self.email = user_input['email']
-                    result = await self.hass.async_add_executor_job(
+                    await self.hass.async_add_executor_job(
                         self._bambu_cloud.login,
                         user_input['region'],
                         user_input['email'],
                         user_input['password'])
-                    if result == 'success':
-                        return await self.async_step_Bambu_Choose_Device(None)
+                return await self.async_step_Bambu_Choose_Device(None)
 
-                    # Handle possible failure cases
-                    if result == 'cloudflare':
-                        errors['base'] = 'cloudflare'
-                    elif result == 'curlUnavailable':
-                        errors['base'] = 'curl_unavailable'
-                    elif result == 'verifyCode':
-                        # User needs to provide the verification code sent to them
-                        authentication_type = 'verifyCode'
-                        errors['base'] = 'verifyCode'
-                        # Fall through to form generation to ask for verification code
-                    elif result == 'tfa':
-                        # User needs to provide their 2FA code
-                        authentication_type = 'tfaCode'
-                        errors['base'] = 'tfaCode'
-                        # Fall through to form generation to ask for verification code
-                    else:
-                        errors['base'] = "cannot_connect"
-
-            except Exception as e:
+            # Handle possible failure cases
+            except CloudflareError:
+                errors['base'] = 'cloudflare'
+            except CurlUnavailableError:
+                errors['base'] = 'curl_unavailable'
+            except EmailCodeRequiredError:
+                authentication_type = 'verifyCode'
+                errors['base'] = 'verifyCode'
+                # Fall through to form generation to ask for verification code
+            except EmailCodeExpiredError:
+                authentication_type = 'verifyCode'
+                errors['base'] = 'code_expired'
+                # Fall through to form generation to ask for verification code
+            except EmailCodeIncorrectError:
+                authentication_type = 'verifyCode'
+                errors['base'] = 'code_incorrect'
+                # Fall through to form generation to ask for verification code
+            except TfaCodeRequiredError:
+                authentication_type = 'tfaCode'
+                errors['base'] = 'tfaCode'
+                # Fall through to form generation to ask for verification code
+            except:
                 LOGGER.error(f"Failed to connect with error code {e.args}")
                 errors['base'] = "cannot_connect"
+            finally:
+                return await self.async_step_Bambu_Choose_Device(None)
 
 
         # Build form
@@ -473,21 +469,23 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             try:
                 if user_input.get('verifyCode', None) is not None:
-                    result = await self.hass.async_add_executor_job(
-                        self._bambu_cloud.login_with_verification_code,
-                        user_input['verifyCode'])
-                    if result == 'success':
-                        return await self.async_step_Bambu_Lan(None)
-                    elif result == 'codeExpired':
+                    try:
+                        result = await self.hass.async_add_executor_job(
+                            self._bambu_cloud.login_with_verification_code,
+                            user_input['verifyCode'])
+                    except EmailCodeExpiredError:
                         authentication_type = 'verifyCode'
                         errors['base'] = "code_expired"
                         # Fall through to form generation to ask for verification code
-                    elif result == 'codeIncorrect':
+                    except EmailCodeIncorrectError:
                         authentication_type = 'verifyCode'
                         errors['base'] = "code_incorrect"
                         # Fall through to form generation to ask for verification code
-                    else:
+                    except:
                         errors['base'] = "cannot_connect"
+                    finally:
+                        return await self.async_step_Bambu_Lan(None)
+
                 elif user_input.get('tfaCode', None) is not None:
                     result = await self.hass.async_add_executor_job(
                         self._bambu_cloud.login_with_2fa_code,
@@ -496,6 +494,7 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
                         return await self.async_step_Bambu_Lan(None)
                     else:
                         errors['base'] = "cannot_connect"
+
                 else:
                     self.region = user_input['region']
                     self.email = user_input['email']

--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -183,12 +183,9 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 authentication_type = 'tfaCode'
                 errors['base'] = 'tfaCode'
                 # Fall through to form generation to ask for verification code
-            except:
+            except Exception as e:
                 LOGGER.error(f"Failed to connect with error code {e.args}")
                 errors['base'] = "cannot_connect"
-            finally:
-                return await self.async_step_Bambu_Choose_Device(None)
-
 
         # Build form
         fields: OrderedDict[vol.Marker, Any] = OrderedDict()
@@ -469,61 +466,56 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             try:
                 if user_input.get('verifyCode', None) is not None:
-                    try:
-                        result = await self.hass.async_add_executor_job(
-                            self._bambu_cloud.login_with_verification_code,
-                            user_input['verifyCode'])
-                    except EmailCodeExpiredError:
-                        authentication_type = 'verifyCode'
-                        errors['base'] = "code_expired"
-                        # Fall through to form generation to ask for verification code
-                    except EmailCodeIncorrectError:
-                        authentication_type = 'verifyCode'
-                        errors['base'] = "code_incorrect"
-                        # Fall through to form generation to ask for verification code
-                    except:
-                        errors['base'] = "cannot_connect"
-                    finally:
-                        return await self.async_step_Bambu_Lan(None)
+                    await self.hass.async_add_executor_job(
+                        self._bambu_cloud.login_with_verification_code,
+                        user_input['verifyCode'])
+                    return await self.async_step_Bambu_Lan(None)
 
                 elif user_input.get('tfaCode', None) is not None:
-                    result = await self.hass.async_add_executor_job(
+                    await self.hass.async_add_executor_job(
                         self._bambu_cloud.login_with_2fa_code,
                         user_input['tfaCode'])
-                    if result == 'success':
-                        return await self.async_step_Bambu_Lan(None)
-                    else:
-                        errors['base'] = "cannot_connect"
+                    return await self.async_step_Bambu_Lan(None)
 
                 else:
                     self.region = user_input['region']
                     self.email = user_input['email']
-                    result = await self.hass.async_add_executor_job(
+                    await self.hass.async_add_executor_job(
                         self._bambu_cloud.login,
                         user_input['region'],
                         user_input['email'],
                         user_input['password'])
-                    if result == 'success':
-                        return await self.async_step_Bambu_Lan(None)
-                    
-                    # Handle possible failure cases
-                    if result == 'cloudflare':
-                        errors['base'] = 'cloudflare'
-                    elif result == 'curlUnavailable':
-                        errors['base'] = 'curl_unavailable'
-                    elif result == 'verifyCode':
-                        # User needs to provide the verification code sent to them
-                        authentication_type = 'verifyCode'
-                        errors['base'] = 'verifyCode'
-                        # Fall through to form generation to ask for verification code
-                    elif result == 'tfa':
-                        # User needs to provide their 2FA code
-                        authentication_type = 'tfaCode'
-                        errors['base'] = 'tfaCode'
-                        # Fall through to form generation to ask for verification code
-                    else:
-                        errors['base'] = "cannot_connect"
+                    return await self.async_step_Bambu_Lan(None)
 
+            # Handle possible failure cases
+            except EmailCodeExpiredError:
+                authentication_type = 'verifyCode'
+                errors['base'] = "code_expired"
+                # Fall through to form generation to ask for verification code
+            except EmailCodeIncorrectError:
+                authentication_type = 'verifyCode'
+                errors['base'] = "code_incorrect"
+                # Fall through to form generation to ask for verification code
+            except CloudflareError:
+                errors['base'] = 'cloudflare'
+            except CurlUnavailableError:
+                errors['base'] = 'curl_unavailable'
+            except EmailCodeRequiredError:
+                authentication_type = 'verifyCode'
+                errors['base'] = 'verifyCode'
+                # Fall through to form generation to ask for verification code
+            except EmailCodeExpiredError:
+                authentication_type = 'verifyCode'
+                errors['base'] = 'code_expired'
+                # Fall through to form generation to ask for verification code
+            except EmailCodeIncorrectError:
+                authentication_type = 'verifyCode'
+                errors['base'] = 'code_incorrect'
+                # Fall through to form generation to ask for verification code
+            except TfaCodeRequiredError:
+                authentication_type = 'tfaCode'
+                errors['base'] = 'tfaCode'
+                # Fall through to form generation to ask for verification code
             except Exception as e:
                 LOGGER.error(f"Failed to connect with error code {e.args}")
                 errors['base'] = "cannot_connect"

--- a/custom_components/bambu_lab/manifest.json
+++ b/custom_components/bambu_lab/manifest.json
@@ -14,7 +14,8 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/greghesp/ha-bambulab/issues",
   "requirements": [
-    "curl_cffi>=0.7.3"
+    "cloudscraper",
+    "curl_cffi"
   ],
   "ssdp": [
     {

--- a/custom_components/bambu_lab/manifest.json
+++ b/custom_components/bambu_lab/manifest.json
@@ -14,8 +14,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/greghesp/ha-bambulab/issues",
   "requirements": [
-    "cloudscraper",
-    "curl_cffi"
+    "cloudscraper"
   ],
   "ssdp": [
     {

--- a/custom_components/bambu_lab/pybambu/bambu_cloud.py
+++ b/custom_components/bambu_lab/pybambu/bambu_cloud.py
@@ -189,7 +189,7 @@ class BambuCloud:
                 raise EmailCodeExpiredError()
             elif response.json()['code'] == 2:
                 # Code was incorrect. Let the user try again.
-                return EmailCodeIncorrectError()
+                raise EmailCodeIncorrectError()
             else:
                 LOGGER.error(f"Response not understood: '{response.json()}'")
                 raise ValueError(response.json()['code'])

--- a/custom_components/bambu_lab/pybambu/bambu_cloud.py
+++ b/custom_components/bambu_lab/pybambu/bambu_cloud.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import base64
 import json
+import requests
 
 curl_available = True
 try:
     from curl_cffi import requests as curl_requests
 except ImportError:
     curl_available = False
+#import cloudscraper as curl_requests
 
 from dataclasses import dataclass
 
@@ -19,6 +21,89 @@ from .const import (
 from .utils import get_Url
 
 IMPERSONATE_BROWSER='chrome'
+
+class CloudflareError(Exception):
+    def __init__(self):
+        LOGGER.error('CloudFlare blocked connection attempt')
+        super().__init__("Blocked by Cloudflare")
+        self.error_code = 403
+    
+    def __str__(self):
+        return self.strerror
+
+class EmailCodeRequiredError(Exception):
+    def __init__(self):
+        super().__init__("Email code required")
+        self.error_code = 400
+    
+    def __str__(self):
+        return self.strerror
+
+class EmailCodeExpiredError(Exception):
+    def __init__(self):
+        super().__init__("Email code expired")
+        self.error_code = 400
+    
+    def __str__(self):
+        return self.strerror
+
+class EmailCodeIncorrectError(Exception):
+    def __init__(self):
+        super().__init__("Email code incorrect")
+        self.error_code = 400
+    
+    def __str__(self):
+        return self.strerror
+
+class TfaCodeRequiredError(Exception):
+    def __init__(self):
+        super().__init__("Two factor authentication code required")
+        self.error_code = 400
+    
+    def __str__(self):
+        return self.strerror
+
+class CurlUnavailableError(Exception):
+    def __init__(self):
+        super().__init__("Two factor authentication code required")
+        self.error_code = 400
+    
+    def __str__(self):
+        return self.strerror
+
+def _test_response(response):
+    # Check specifically for cloudflare block
+    if response.status_code == 403 and 'cloudflare' in response.text:
+        raise CloudflareError()
+        
+    if response.status_code > 400:
+        LOGGER.error(f"Login attempt failed with error code: {response.status_code}")
+        LOGGER.debug(f"Response: '{response.text}'")
+        raise PermissionError(response.status_code, response.text)
+
+    LOGGER.debug(f"Response: {response.status_code}")
+
+def get(url: str, headers={}):
+    response = curl_requests.get(url, headers=headers, timeout=10, impersonate=IMPERSONATE_BROWSER)
+    return response
+
+
+def post(url: str, json: str, headers={}):
+    response = curl_requests.post(url, headers=headers, json=json, impersonate=IMPERSONATE_BROWSER)
+    _test_response(response)
+    if response.status_code == 400:
+        LOGGER.error(f"Login attempt failed with error code: {response.status_code}")
+        LOGGER.debug(f"Response: '{response.text}'")
+        raise PermissionError(response.status_code, response.text)
+    return response
+
+
+def post_return400(url: str, json: str, headers={}):
+    response = curl_requests.post(url, headers=headers, json=json, impersonate=IMPERSONATE_BROWSER)
+    _test_response(response)
+    return response
+
+
 
 @dataclass
 class BambuCloud:
@@ -35,11 +120,11 @@ class BambuCloud:
         headers['Authorization'] = f"Bearer {self._auth_token}"
         return headers
     
-    def _get_authentication_token(self) -> dict:
+    def _get_authentication_token(self) -> str:
         LOGGER.debug("Getting accessToken from Bambu Cloud")
         if not curl_available:
             LOGGER.debug(f"Curl library is unavailable.")
-            return 'curlUnavailable'
+            raise CurlUnavailableError()
 
         # First we need to find out how Bambu wants us to login.
         data = {
@@ -48,20 +133,7 @@ class BambuCloud:
             "apiError": ""
         }
 
-        response = curl_requests.post(get_Url(BambuUrl.LOGIN, self._region), json=data, impersonate=IMPERSONATE_BROWSER)
-
-        # Check specifically for cloudflare block
-        if response.status_code == 403:
-            if 'cloudflare' in response.text:
-                LOGGER.error('CloudFlare blocked connection attempt')
-                return 'cloudFlare'
-            
-        if response.status_code >= 400:
-            LOGGER.error(f"Login attempt failed with error code: {response.status_code}")
-            LOGGER.debug(f"Response: '{response.text}'")
-            raise ValueError(response.status_code)
-
-        LOGGER.debug(f"Response: {response.status_code}")
+        response = post(get_Url(BambuUrl.LOGIN, self._region), json=data)
 
         auth_json = response.json()
         accessToken = auth_json.get('accessToken', '')
@@ -73,18 +145,19 @@ class BambuCloud:
         if loginType is None:
             LOGGER.error(f"loginType not present")
             LOGGER.error(f"Response not understood: '{response.text}'")
-            return None
+            return ValueError(0) # FIXME
         elif loginType == 'verifyCode':
             LOGGER.debug(f"Received verifyCode response")
+            raise EmailCodeRequiredError()
         elif loginType == 'tfa':
             # Store the tfaKey for later use
             LOGGER.debug(f"Received tfa response")
             self._tfaKey = auth_json.get("tfaKey")
+            raise TfaCodeRequiredError()
         else:
             LOGGER.debug(f"Did not understand json. loginType = '{loginType}'")
             LOGGER.error(f"Response not understood: '{response.text}'")
-
-        return loginType
+            return ValueError(1) # FIXME
     
     def _get_email_verification_code(self):
         # Send the verification code request
@@ -94,14 +167,8 @@ class BambuCloud:
         }
 
         LOGGER.debug("Requesting verification code")
-        response = curl_requests.post(get_Url(BambuUrl.EMAIL_CODE, self._region), json=data, impersonate=IMPERSONATE_BROWSER)
-        
-        if response.status_code == 200:
-            LOGGER.debug("Verification code requested successfully.")
-        else:
-            LOGGER.error(f"Received error trying to send verification code: {response.status_code}")
-            LOGGER.debug(f"Response: '{response.text}'")
-            raise ValueError(response.status_code)
+        response = post(get_Url(BambuUrl.EMAIL_CODE, self._region), json=data)
+        LOGGER.debug("Verification code requested successfully.")
 
     def _get_authentication_token_with_verification_code(self, code) -> dict:
         LOGGER.debug("Attempting to connect with provided verification code.")
@@ -110,27 +177,22 @@ class BambuCloud:
             "code": code
         }
 
-        response = curl_requests.post(get_Url(BambuUrl.LOGIN, self._region), json=data, impersonate=IMPERSONATE_BROWSER)
+        response = post_return400(get_Url(BambuUrl.LOGIN, self._region), json=data)
+        status_code = response.status_code
 
-        LOGGER.debug(f"Response: {response.status_code}")
-        if response.status_code == 200:
+        if status_code == 200:
             LOGGER.debug("Authentication successful.")
-        elif response.status_code == 400:
-            LOGGER.debug(f"Response: '{response.json()}'")
+        elif status_code == 400:           
             if response.json()['code'] == 1:
                 # Code has expired. Request a new one.
                 self._get_email_verification_code()
-                return 'codeExpired'
+                raise EmailCodeExpiredError()
             elif response.json()['code'] == 2:
                 # Code was incorrect. Let the user try again.
-                return 'codeIncorrect'
+                return EmailCodeIncorrectError()
             else:
                 LOGGER.error(f"Response not understood: '{response.json()}'")
                 raise ValueError(response.json()['code'])
-        else:
-            LOGGER.error(f"Received error trying to authenticate with verification code: {response.status_code}")
-            LOGGER.debug(f"Response: '{response.text}'")
-            raise ValueError(response.status_code)
 
         return response.json()['accessToken']
     
@@ -142,15 +204,11 @@ class BambuCloud:
             "tfaCode": code
         }
 
-        response = curl_requests.post(get_Url(BambuUrl.TFA_LOGIN, self._region), json=data, impersonate=IMPERSONATE_BROWSER)
+        response = post(get_Url(BambuUrl.TFA_LOGIN, self._region), json=data)
 
         LOGGER.debug(f"Response: {response.status_code}")
         if response.status_code == 200:
             LOGGER.debug("Authentication successful.")
-        else:
-            LOGGER.error(f"Received error trying to authenticate with verification code: {response.status_code}")
-            LOGGER.debug(f"Response: '{response.text}'")
-            raise ValueError(response.status_code)
 
         cookies = response.cookies.get_dict()
         token_from_tfa = cookies.get("token")
@@ -223,49 +281,26 @@ class BambuCloud:
         self._password = password
 
         result = self._get_authentication_token()
-        if result is None:
-            LOGGER.error("Unable to authenticate.")
-            return None
-        elif len(result) < 20:
-            return result
-        else:
-            self._auth_token = result
-            self._username = self._get_username_from_authentication_token()
-            return 'success'
+        self._auth_token = result
+        self._username = self._get_username_from_authentication_token()
         
     def login_with_verification_code(self, code: str):
         result = self._get_authentication_token_with_verification_code(code)
-        if len(result) < 20:
-            return result
         self._auth_token = result
         self._username = self._get_username_from_authentication_token()
-        return 'success'
 
     def login_with_2fa_code(self, code: str):
         result = self._get_authentication_token_with_2fa_code(code)
-        if len(result) < 20:
-            return result
         self._auth_token = result
         self._username = self._get_username_from_authentication_token()
-        return 'success'
 
     def get_device_list(self) -> dict:
         LOGGER.debug("Getting device list from Bambu Cloud")
         if not curl_available:
             LOGGER.debug(f"Curl library is unavailable.")
-            raise None
-        
-        response = curl_requests.get(get_Url(BambuUrl.BIND, self._region), headers=self._get_headers_with_auth_token(), timeout=10, impersonate=IMPERSONATE_BROWSER)
-        if response.status_code == 403:
-            if 'cloudflare' in response.text:
-                LOGGER.error('CloudFlare blocked connection attempt')
-            raise ValueError(response.status_code)
-
-        if response.status_code >= 400:
-            LOGGER.debug(f"Received error: {response.status_code}")
-            LOGGER.error(f"Received error: '{response.text}'")
-            raise ValueError(response.status_code)
-        
+            return None
+       
+        response = get(get_Url(BambuUrl.BIND, self._region), headers=self._get_headers_with_auth_token())
         return response.json()['devices']
 
     # The slicer settings are of the following form:
@@ -340,17 +375,7 @@ class BambuCloud:
         # Disabled for now since it may be contributing to cloudflare detection speed.
         # 
         # if curl_available:
-        #     response = curl_requests.get(get_Url(BambuUrl.SLICER_SETTINGS, self._region), headers=self._get_headers_with_auth_token(), timeout=10, impersonate=IMPERSONATE_BROWSER)
-        #     if response.status_code == 403:
-        #         if 'cloudflare' in response.text:
-        #             LOGGER.error(f"Cloudflare blocked slicer settings lookup.")
-        #             return None
-                
-        #     if response.status_code >= 400:
-        #         LOGGER.error(f"Slicer settings load failed: {response.status_code}")
-        #         LOGGER.error(f"Slicer settings load failed: '{response.text}'")
-        #         return None
-            
+        #     response = curl_requests.get(get_Url(BambuUrl.SLICER_SETTINGS, self._region), headers=self._get_headers_with_auth_token())
         #     return response.json()
         return None
         
@@ -403,22 +428,7 @@ class BambuCloud:
             raise None
         
         url = get_Url(BambuUrl.TASKS, self._region)
-        response = curl_requests.get(url, headers=self._get_headers_with_auth_token(), timeout=10, impersonate=IMPERSONATE_BROWSER)
-        if response.status_code == 403:
-            if 'cloudflare' in response.text:
-                LOGGER.error('CloudFlare blocked connection attempt')
-                return None
-
-        # Check specifically for cloudflare block
-        if response.status_code == 403:
-            if 'cloudflare' in response.text:
-                LOGGER.error('CloudFlare blocked connection attempt')
-                return None
-
-        if response.status_code >= 400:
-            LOGGER.debug(f"Received error: {response.status_code}")
-            LOGGER.debug(f"Received error: '{response.text}'")
-            raise None
+        response = get(url, headers=self._get_headers_with_auth_token())
 
         return response.json()
 
@@ -455,17 +465,7 @@ class BambuCloud:
             LOGGER.debug(f"Curl library is unavailable.")
             return None
 
-        response = curl_requests.get(url, timeout=10, impersonate=IMPERSONATE_BROWSER)
-        if response.status_code == 403:
-            if 'cloudflare' in response.text:
-                LOGGER.error('CloudFlare blocked connection attempt')
-                raise ValueError(response.status_code)
-
-        if response.status_code >= 400:
-            LOGGER.debug(f"Received error: {response.status_code}")
-            LOGGER.debug(f"Received error: {response.text}")
-            raise ValueError(response.status_code)
-        
+        response = get(url)
         return response.content
 
     @property


### PR DESCRIPTION
Switch to using exceptions for the various normal (code required) or failure (cloudflare, incorrect code etc.) to communicate these back to the config_flow logic. 

Centralize all the get/post logic through helper functions that I can more easily switch between connection technologies such as cloudscraper or curl_cffi.

Switch back to cloudscraper as Bambu's cloudflare deployment has relaxed and is no longer blocking and curl_cffi isn't available to all HA installs (32 bit raspberry pi hosted installs specifically). Since we don't currently need curl_cffi, reverting to cloudscraper unblocks those  users again to get the rest of the login flow fixes.