### PR TITLE
Handle auth token without embedded userid

### DIFF
--- a/custom_components/bambu_lab/const.py
+++ b/custom_components/bambu_lab/const.py
@@ -8,7 +8,7 @@ DOMAIN = "bambu_lab"
 BRAND = "Bambu Lab"
 
 LOGGER = logging.getLogger(__package__)
-LOGGERFORHA = logging.getLogger(f"{DOMAIN}_HA")
+LOGGERFORHA = logging.getLogger(f"{__package__}_HA")
 
 PLATFORMS = (
     Platform.BINARY_SENSOR,

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -1234,6 +1234,7 @@ class BambuUrl(Enum):
     BIND = 4,
     SLICER_SETTINGS = 5,
     TASKS = 6,
+    PROJECTS = 7,
 
 BAMBU_URL = {
     BambuUrl.LOGIN: 'https://api.bambulab.com/v1/user-service/user/login',
@@ -1242,4 +1243,5 @@ BAMBU_URL = {
     BambuUrl.BIND: 'https://api.bambulab.com/v1/iot-service/api/user/bind',
     BambuUrl.SLICER_SETTINGS: 'https://api.bambulab.com/v1/iot-service/api/slicer/setting?version=1.10.0.89',
     BambuUrl.TASKS: 'https://api.bambulab.com/v1/user-service/my/tasks',
+    BambuUrl.PROJECTS: 'https://api.bambulab.com/v1/iot-service/api/user/project',
 }

--- a/custom_components/bambu_lab/scripts/TestAuthentication.py
+++ b/custom_components/bambu_lab/scripts/TestAuthentication.py
@@ -136,7 +136,7 @@ auth_response = scraper.post(
 
 print(f"Response: {auth_response.status_code}")
 cloudFlared = 'cloudflare' in auth_response.text
-print(f"Clouldflared: {cloudFlared}")
+print(f"Cloudflared: {cloudFlared}")
 print("Response: ", auth_response.text)
 
 exit(0)

--- a/custom_components/bambu_lab/translations/de.json
+++ b/custom_components/bambu_lab/translations/de.json
@@ -12,7 +12,7 @@
     "abort": {
       "already_configured": "Das Gerät ist bereits eingerichtet",
       "no_printers": "Keine nicht konfigurierten Drucker im Konto gefunden",
-      "cloudflare": "Clouldflare hat den Verbindungsversuch blockiert.",
+      "cloudflare": "Cloudflare hat den Verbindungsversuch blockiert.",
       "curl_unavailable": "Die Bibliothek „curl_cffi“ ist nicht verfügbar."
     },
     "error": {
@@ -75,7 +75,7 @@
   },
   "options": {
     "abort": {
-      "cloudflare": "Clouldflare hat den Verbindungsversuch blockiert.",
+      "cloudflare": "Cloudflare hat den Verbindungsversuch blockiert.",
       "curl_unavailable": "Die Bibliothek „curl_cffi“ ist nicht verfügbar."
     },
     "error": {

--- a/custom_components/bambu_lab/translations/el.json
+++ b/custom_components/bambu_lab/translations/el.json
@@ -12,7 +12,7 @@
     "abort": {
       "already_configured": "Η συσκευή είναι ήδη ρυθμισμένη",
       "no_printers": "Δεν βρέθηκαν μη ρυθμισμένοι εκτυπωτές στον λογαριασμό.",
-      "cloudflare": "Το Clouldflare έχει μπλοκάρει την προσπάθεια σύνδεσης.",
+      "cloudflare": "Το Cloudflare έχει μπλοκάρει την προσπάθεια σύνδεσης.",
       "curl_unavailable": "Η βιβλιοθήκη curl_cffi δεν είναι διαθέσιμη."
     },
     "error": {
@@ -75,7 +75,7 @@
   },
   "options": {
     "abort": {
-      "cloudflare": "Το Clouldflare έχει μπλοκάρει την προσπάθεια σύνδεσης.",
+      "cloudflare": "Το Cloudflare έχει μπλοκάρει την προσπάθεια σύνδεσης.",
       "curl_unavailable": "Η βιβλιοθήκη curl_cffi δεν είναι διαθέσιμη."
     },
     "error": {

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -12,7 +12,7 @@
     "abort": {
       "already_configured": "Device is already configured",
       "no_printers": "No unconfigured printers found in the account.",
-      "cloudflare": "Clouldflare has blocked the connection attempt.",
+      "cloudflare": "Cloudflare has blocked the connection attempt.",
       "curl_unavailable": "curl_cffi library is not available."
     },
     "error": {
@@ -75,7 +75,7 @@
   },
   "options": {
     "abort": {
-      "cloudflare": "Clouldflare has blocked the connection attempt.",
+      "cloudflare": "Cloudflare has blocked the connection attempt.",
       "curl_unavailable": "curl_cffi library is not available."
     },
     "error": {

--- a/custom_components/bambu_lab/translations/es.json
+++ b/custom_components/bambu_lab/translations/es.json
@@ -12,7 +12,7 @@
     "abort": {
       "already_configured": "El dispositivo ya se encuentra configurado",
       "no_printers": "No se encontraron impresoras configuradas en la cuenta.",
-      "cloudflare": "Cloudflare ha bloqueado el intento de conexión.",
+      "cloudflare": "Clouldflare ha bloqueado el intento de conexión.",
       "curl_unavailable": "La biblioteca curl_cffi no está disponible."
     },
     "error": {
@@ -75,7 +75,7 @@
   },
   "options": {
     "abort": {
-      "cloudflare": "Cloudflare ha bloqueado el intento de conexión.",
+      "cloudflare": "Clouldflare ha bloqueado el intento de conexión.",
       "curl_unavailable": "La biblioteca curl_cffi no está disponible."
     },
     "error": {

--- a/custom_components/bambu_lab/translations/es.json
+++ b/custom_components/bambu_lab/translations/es.json
@@ -12,7 +12,7 @@
     "abort": {
       "already_configured": "El dispositivo ya se encuentra configurado",
       "no_printers": "No se encontraron impresoras configuradas en la cuenta.",
-      "cloudflare": "Clouldflare ha bloqueado el intento de conexión.",
+      "cloudflare": "Cloudflare ha bloqueado el intento de conexión.",
       "curl_unavailable": "La biblioteca curl_cffi no está disponible."
     },
     "error": {
@@ -75,7 +75,7 @@
   },
   "options": {
     "abort": {
-      "cloudflare": "Clouldflare ha bloqueado el intento de conexión.",
+      "cloudflare": "Cloudflare ha bloqueado el intento de conexión.",
       "curl_unavailable": "La biblioteca curl_cffi no está disponible."
     },
     "error": {

--- a/custom_components/bambu_lab/translations/it.json
+++ b/custom_components/bambu_lab/translations/it.json
@@ -12,7 +12,7 @@
     "abort": {
       "already_configured": "Il dispositivo è già configurato",
       "no_printers": "Nessuna stampante non configurata trovata nell'account.",
-      "cloudflare": "Clouldflare ha bloccato il tentativo di connessione.",
+      "cloudflare": "Cloudflare ha bloccato il tentativo di connessione.",
       "curl_unavailable": "La libreria curl_cffi non è disponibile."
     },
     "error": {
@@ -75,7 +75,7 @@
   },
   "options": {
     "abort": {
-      "cloudflare": "Clouldflare ha bloccato il tentativo di connessione.",
+      "cloudflare": "Cloudflare ha bloccato il tentativo di connessione.",
       "curl_unavailable": "La libreria curl_cffi non è disponibile."
     },
     "error": {

--- a/custom_components/bambu_lab/translations/pt.json
+++ b/custom_components/bambu_lab/translations/pt.json
@@ -12,7 +12,7 @@
     "abort": {
       "already_configured": "O dispositivo já está configurado",
       "no_printers": "Nenhuma impressora não configurada encontrada na conta.",
-      "cloudflare": "Clouldflare bloqueou a tentativa de conexão.",
+      "cloudflare": "Cloudflare bloqueou a tentativa de conexão.",
       "curl_unavailable": "A biblioteca curl_cffi não está disponível."
     },
     "error": {
@@ -75,7 +75,7 @@
   },
   "options": {
     "abort": {
-      "cloudflare": "Clouldflare bloqueou a tentativa de conexão.",
+      "cloudflare": "Cloudflare bloqueou a tentativa de conexão.",
       "curl_unavailable": "A biblioteca curl_cffi não está disponível."
     },
     "error": {


### PR DESCRIPTION
China is no longer returning a JWT auth token with embedded user id (of from 'u_digits'). For cloud mqtt connection we need that user id. So added a fallback to retrieve it from an existing API that includes it so that hopefully login will work again in China and if/when this change rolls out everywhere the integration just keeps working.

Fixed some typos in UI strings.