### PR TITLE
Re-add HMS error event but dumbed down to first event only

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -1208,7 +1208,8 @@ class HMSList:
                 attr = int(hms['attr'])
                 code = int(hms['code'])
                 hms_notif = HMSNotification(attr=attr, code=code)
-                errors[f"{index}-Error"] = f"HMS_{hms_notif.hms_code}: {get_HMS_error_text(hms_notif.hms_code)}"
+                errors[f"{index}-Code"] = f"HMS_{hms_notif.hms_code}"
+                errors[f"{index}-Error"] = get_HMS_error_text(hms_notif.hms_code)
                 errors[f"{index}-Wiki"] = hms_notif.wiki_url
                 errors[f"{index}-Severity"] = hms_notif.severity
                 #LOGGER.debug(f"HMS error for '{hms_notif.module}' and severity '{hms_notif.severity}': HMS_{hms_notif.hms_code}")
@@ -1219,6 +1220,7 @@ class HMSList:
                 self._errors = errors
                 if self._count != 0:
                     LOGGER.warning(f"HMS ERRORS: {errors}")
+                self._client.callback("event_printer_error")
                 return True
         
         return False
@@ -1261,7 +1263,7 @@ class PrintErrorList:
 
             if self._error != errors:
                 self._error = errors
-                self._client.callback("event_printer_error")
+                self._client.callback("event_print_error")
 
         # We send the error event directly so always return False for the general data event.
         return False

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -5,6 +5,8 @@
       "event_print_failed": "Print failed",
       "event_print_finished": "Print finished",
       "event_print_started": "Print started",
+      "event_print_error": "Print error",
+      "event_print_error_cleared": "Print error cleared",
       "event_printer_error": "Printer error",
       "event_printer_error_cleared": "Printer error cleared"
     }


### PR DESCRIPTION
print_error is only set for certain truly print-related errors
printer_error is set for all HMS errors.
Sadly that means for full notification support in HA you need automations to trigger off both.