### PR TITLE
Only update slicer settings on a successful connection to the printer

### DIFF
--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -385,8 +385,6 @@ class BambuClient:
         self._mqtt.start()
 
     def subscribe_and_request_info(self):
-        LOGGER.debug("Loading slicer settings...")
-        self.slicer_settings.update()
         LOGGER.debug("Now subscribing...")
         self.subscribe()
         LOGGER.debug("On Connect: Getting version info")
@@ -503,6 +501,9 @@ class BambuClient:
                 elif json_data.get("info") and json_data.get("info").get("command") == "get_version":
                     LOGGER.debug("Got Version Data")
                     self._device.info_update(data=json_data.get("info"))
+                    # Only update slicer settings on a successful connection to the printer.
+                    self.slicer_settings.update()
+
         except Exception as e:
             LOGGER.error("An exception occurred processing a message:", exc_info=e)
 
@@ -534,8 +535,6 @@ class BambuClient:
             LOGGER.debug("Force Refresh: Request Push All")
             self._refreshed = True
             self.publish(PUSH_ALL)
-
-        self.slicer_settings.update()
 
     def get_device(self):
         """Return device"""


### PR DESCRIPTION
Previously we would update the slicer settings on every attempt to connect to the printer so in a repetitive failure cause such as the bambu credentials having expired we would spam connect for the slicer settings in a near tight loop leading to throttling on the Bambu end.