### PR TITLE
Add print_project_file action, print 3MF files

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ See [device triggers](docs/DeviceTrigger.md).
 
 * **Send Command**: Sends arbitrary GCODE to the printer. Be careful as it does not check if the printer is running a job
 or not so before invoking this action, you should check the printer state to ensure it is not running a job.
-*  **Print 3MF project file**: Prints 3MF file stored on SD card. 3MF file must be stored on SD card root and it must contain gcode (e.g., "Export sliced file" from slicer)
+* **Print 3MF project file**: Prints 3MF file stored on SD card. 3MF file must be stored on SD card root and it must contain gcode (e.g., "Export sliced file" from slicer)
 
 ## Example dashboard
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ See [device triggers](docs/DeviceTrigger.md).
 
 * **Send Command**: Sends arbitrary GCODE to the printer. Be careful as it does not check if the printer is running a job
 or not so before invoking this action, you should check the printer state to ensure it is not running a job.
+*  **Print 3MF project file**: Prints 3MF file stored on SD card. 3MF file must be stored on SD card root and it must contain gcode (e.g., "Export sliced file" from slicer)
 
 ## Example dashboard
 

--- a/custom_components/bambu_lab/pybambu/commands.py
+++ b/custom_components/bambu_lab/pybambu/commands.py
@@ -19,6 +19,26 @@ PUSH_ALL = {"pushing": {"sequence_id": "0", "command": "pushall"}}
 START_PUSH = { "pushing": {"sequence_id": "0", "command": "start"}}
 
 SEND_GCODE_TEMPLATE = {"print": {"sequence_id": "0", "command": "gcode_line", "param": ""}} # param = GCODE_EACH_LINE_SEPARATED_BY_\n
+PRINT_PROJECT_FILE_TEMPLATE = {
+                "print": {
+                    "sequence_id": 0,
+                    "command": "project_file",
+                    "param": "", # param = f"Metadata/plate_1.gcode"
+                    "url": "", # url = f"ftp://{file}"
+                    "subtask_name": "",
+                    "bed_type": "auto",
+                    "timelapse": False,
+                    "bed_leveling": True,
+                    "flow_cali": False,
+                    "vibration_cali": True,
+                    "layer_inspect": False,
+                    "use_ams": False,
+                    "profile_id": "0",
+                    "project_id": "0",
+                    "subtask_id": "0",
+                    "task_id": "0",
+                }
+            }
 
 # X1 only currently
 GET_ACCESSORIES = {"system": {"sequence_id": "0", "command": "get_accessories", "accessory_type": "none"}}

--- a/custom_components/bambu_lab/services.yaml
+++ b/custom_components/bambu_lab/services.yaml
@@ -28,4 +28,6 @@ print_project_file:
       default: 1
       selector:
         number:
+          mode: box
           min: 1
+          max: 100

--- a/custom_components/bambu_lab/services.yaml
+++ b/custom_components/bambu_lab/services.yaml
@@ -9,3 +9,23 @@ send_command:
       example: "M104 S200"
       selector:
         text:
+
+print_project_file:
+  name: Print 3MF project file
+  description: Print sliced 3MF file stored on the SD card
+  fields:
+    filepath:
+      name: File path
+      description: Filename on SD card
+      required: true
+      example: "filename.3mf"
+      selector:
+        text:
+    plate:
+      name: Plate number
+      description: Plate number to print
+      required: true
+      default: 1
+      selector:
+        number:
+          min: 1


### PR DESCRIPTION
Needed a way to start print from HA, might be worth sharing.
In general, first tried with gcode_file , but could not get that working on my P1, but project_file seems to be working as expected.

Inspiration for MQTT payloads was taken from:
- https://github.com/Doridian/OpenBambuAPI/blob/main/mqtt.md#printproject_file
- https://github.com/mattcar15/bambu-connect/blob/main/bambu_connect/ExecuteClient.py#L41

