### PR TITLE
Fix mishandling of some file dates

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -658,15 +658,23 @@ class PrintJob:
                 match = re.match(pattern_with_time_no_year, line)
                 if match:
                     timestamp_str, filename = match.groups()
-                    timestamp = datetime.strptime(timestamp_str, '%b %d %H:%M')
-                    timestamp = timestamp.replace(year=datetime.now().year)
-                    return timestamp, filename
+                    if filename.endswith('.3mf'):
+                        timestamp = datetime.strptime(timestamp_str, '%b %d %H:%M')
+                        timestamp = timestamp.replace(year=datetime.now().year)
+                        if timestamp > datetime.now():
+                            timestamp = timestamp.replace(year=datetime.now().year - 1)
+                        return timestamp, filename
+                    else:
+                        return None
 
                 match = re.match(pattern_without_time_just_year, line)
                 if match:
                     timestamp_str, filename = match.groups()
-                    timestamp = datetime.strptime(timestamp_str, '%b %d %Y')
-                    return timestamp, filename
+                    if filename.endswith('.3mf'):
+                        timestamp = datetime.strptime(timestamp_str, '%b %d %Y')
+                        return timestamp, filename
+                    else:
+                        return None
                 
                 LOGGER.debug(f"UNEXPECTED LIST LINE FORMAT: '{line}'")
                 return None

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -659,6 +659,8 @@ class PrintJob:
                 if match:
                     timestamp_str, filename = match.groups()
                     if filename.endswith('.3mf'):
+                        # Since these dates don't have the year we have to work it out. If the date is earlier in 
+                        # the year than now then it's this year. If it's later it's last year.
                         timestamp = datetime.strptime(timestamp_str, '%b %d %H:%M')
                         timestamp = timestamp.replace(year=datetime.now().year)
                         if timestamp > datetime.now():


### PR DESCRIPTION
Missed that one of my printers was showing the wrong last print details. The date for the one it found was in December and the initial logic just set that to 2025. Needs to be a little smarter.