### PR TITLE
Fix camera take two

### DIFF
--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -444,6 +444,9 @@ class BambuClient:
         self._mqtt = MqttThread(self)
         self._mqtt.start()
 
+        # Start camera if enabled
+        self.start_camera()
+
     def subscribe_and_request_info(self):
         LOGGER.debug("Now subscribing...")
         self.subscribe()
@@ -478,6 +481,7 @@ class BambuClient:
             LOGGER.debug("Stopping camera thread")
             self._camera.stop()
             self._camera.join()
+            self._camera = None
 
     def _on_connect(self):
         self._connected = True

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -149,7 +149,7 @@ class Device:
         elif feature == Features.PROMPT_SOUND:
             return self.info.device_type == "A1" or self.info.device_type == "A1MINI"
         elif feature == Features.FTP:
-            return True
+            return False
 
         return False
     


### PR DESCRIPTION
Now that the IP address doesn't change in the common case - nothing starts the camera. So need to add back the explicit start.