### PR TITLE
Do not default ftp enabled to true for all local mqtt installs

### DIFF
--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -366,7 +366,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
     @property
     def ftp_enabled(self):
         options = dict(self.config_entry.options)
-        return options.get('enable_ftp', options.get('local_mqtt', False))
+        return options.get('enable_ftp', False)
 
     async def set_ftp_enabled(self, enable):
         LOGGER.debug(f"Setting FTP enabled to {enable}")

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -342,7 +342,7 @@ class BambuClient:
         self._usage_hours = config.get('usage_hours', 0)
         self._username = config.get('username', '')
         self._enable_camera = config.get('enable_camera', True)
-        self._enable_ftp = config.get('enable_ftp', self._local_mqtt)
+        self._enable_ftp = config.get('enable_ftp', False)
         self._enable_timelapse = config.get('enable_timelapse', False)
 
         self._connected = False


### PR DESCRIPTION
It's not yet ready for prime time due to #898 so require people to explicitly enable it via the new switch.