### PR TITLE
Disable manual refresh mode (scream test)

### DIFF
--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -336,7 +336,7 @@ class BambuClient:
         self._auth_token = config.get('auth_token', '')
         self._device_type = config.get('device_type', 'unknown').upper()
         self._local_mqtt = config.get('local_mqtt', False)
-        self._manual_refresh_mode = config.get('manual_refresh_mode', False)
+        self._manual_refresh_mode = False #config.get('manual_refresh_mode', False)
         self._serial = config.get('serial', '')
         self._usage_hours = config.get('usage_hours', 0)
         self._username = config.get('username', '')
@@ -386,7 +386,7 @@ class BambuClient:
             self.disconnect()
         else:
             # Reconnect normally
-            self.connect(self._callback)
+            await self.connect(self._callback)
 
     @property
     def camera_enabled(self):
@@ -613,7 +613,7 @@ class BambuClient:
         """Force refresh data"""
 
         if self._manual_refresh_mode:
-            self.connect(self._callback)
+            await self.connect(self._callback)
         else:
             LOGGER.debug("Force Refresh: Getting Version Info")
             self._refreshed = True

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -145,7 +145,7 @@ class Device:
         elif feature == Features.DOOR_SENSOR:
             return self.info.device_type == "X1" or self.info.device_type == "X1C" or self.info.device_type == "X1E"
         elif feature == Features.MANUAL_MODE:
-            return self.info.device_type == "P1P" or self.info.device_type == "P1S" or self.info.device_type == "A1" or self.info.device_type == "A1MINI"
+            return False
         elif feature == Features.AMS_FILAMENT_REMAINING:
             # Technically this is not the AMS Lite but that's currently tied to only these printer types.
             return self.info.device_type != "A1" and self.info.device_type != "A1MINI"

--- a/custom_components/bambu_lab/switch.py
+++ b/custom_components/bambu_lab/switch.py
@@ -114,7 +114,7 @@ class BambuLabManualModeSwitch(BambuLabSwitch):
             config_entry: ConfigEntry
     ) -> None:
         super().__init__(coordinator, config_entry)
-        self._attr_is_on = self.coordinator.client.manual_refresh_mode
+        self._attr_is_on = self.coordinator.get_option_enabled(Options.MANUALREFRESH)
 
     @property
     def available(self) -> bool:
@@ -127,12 +127,12 @@ class BambuLabManualModeSwitch(BambuLabSwitch):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Enable manual refresh mode."""
-        self._attr_is_on = not self.coordinator.client.manual_refresh_mode
+        self._attr_is_on = True
         await self.coordinator.set_option_enabled(Options.MANUALREFRESH, True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable manual refresh mode."""
-        self._attr_is_on = not self.coordinator.client.manual_refresh_mode
+        self._attr_is_on = False
         await self.coordinator.set_option_enabled(Options.MANUALREFRESH, False)
 
 
@@ -161,12 +161,12 @@ class BambuLabCameraSwitch(BambuLabSwitch):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Enable the camera."""
         self._attr_is_on = True
-        await self.coordinator.set_option_enabled(Options.CAMERA, self._attr_is_on)
+        await self.coordinator.set_option_enabled(Options.CAMERA, True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable the camera."""
         self._attr_is_on = False
-        await self.coordinator.set_option_enabled(Options.CAMERA, self._attr_is_on)
+        await self.coordinator.set_option_enabled(Options.CAMERA, False)
 
 
 class BambuLabCameraImageSwitch(BambuLabSwitch):


### PR DESCRIPTION
While I was aligning how this option was persisted to the config I discovered that it didn't work. And probably hasn't done for a long time. Since no one has complained I believe the need for this feature disappeared as the printer connection limits were relaxed. So to keep the code simpler I'm going to remove it and see if anyone screams.