### PR TITLE
Merge in cards improvements

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -250,9 +250,15 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         key="printable_objects",
         translation_key="printable_objects",
         icon="mdi:cube-unfolded",
-        state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda self: len(self.coordinator.get_model().print_job.printable_objects),
-        extra_attributes=lambda self: self.coordinator.get_model().print_job.printable_objects,
+        value_fn=lambda self: len(self.coordinator.get_model().print_job.get_printable_objects),
+        extra_attributes=lambda self: {"objects": self.coordinator.get_model().print_job.get_printable_objects},
+    ),
+    BambuLabSensorEntityDescription(
+        key="skipped_objects",
+        translation_key="skipped_objects",
+        icon="mdi:cube-unfolded",
+        value_fn=lambda self: len(self.coordinator.get_model().print_job.get_skipped_objects),
+        extra_attributes=lambda self: {"objects": self.coordinator.get_model().print_job.get_skipped_objects},
     ),
     BambuLabSensorEntityDescription(
         key="start_time",

--- a/custom_components/bambu_lab/frontend/__init__.py
+++ b/custom_components/bambu_lab/frontend/__init__.py
@@ -72,7 +72,7 @@ class BambuLabCardRegistration:
                         })
 
                         # Remove old gzipped files
-                        await self.async_remove_gzipe_files()
+                        await self.async_remove_gzip_files()
                     else:
                         _LOGGER.debug("%s already registered as version %s", card.get("name"), card.get("version"))
 

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -343,7 +343,6 @@ class BambuClient:
         self._enable_camera = config.get('enable_camera', True)
         self._enable_ftp = config.get('enable_ftp', False)
         self._enable_timelapse = config.get('enable_timelapse', False)
-        self._label_pick_image = config.get('label_pick_image', self._enable_ftp)
 
         self._connected = False
         self._port = 1883
@@ -416,12 +415,6 @@ class BambuClient:
 
     def set_timelapse_enabled(self, enable):
         self._enable_timelapse = enable
-
-    def label_pick_image_enabled(self):
-        return self._label_pick_image
-
-    def set_label_pick_image_enabled(self, enable):
-        self._label_pick_image = enable
 
     def setup_tls(self):
         if self._local_mqtt:

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -8,6 +8,9 @@ from enum import (
 
 LOGGER = logging.getLogger(__package__)
 
+PRINT_PROJECT_FILE_BUS_EVENT = 'bambu_lab_project_file'
+SEND_GCODE_BUS_EVENT = 'bambu_lab_send_gcode'
+SKIP_OBJECTS_BUS_EVENT = 'bambu_lab_skip_objects'
 
 class Features(IntEnum):
     AUX_FAN = 1,

--- a/custom_components/bambu_lab/services.yaml
+++ b/custom_components/bambu_lab/services.yaml
@@ -1,6 +1,9 @@
 send_command:
   name: Send Command
   description: Send an arbitrary command to the 3D printer
+  target:
+    entity:
+      integration: bambu_lab
   fields:
     command:
       name: Command
@@ -13,6 +16,9 @@ send_command:
 print_project_file:
   name: Print 3MF project file
   description: Print sliced 3MF file stored on the SD card
+  target:
+    entity:
+      integration: bambu_lab
   fields:
     filepath:
       name: File path
@@ -85,6 +91,9 @@ print_project_file:
 skip_objects:
   name: Skip objects
   description: Skip objects currently being printed
+  target:
+    entity:
+      integration: bambu_lab
   fields:
     objects:
       name: Object IDs

--- a/custom_components/bambu_lab/translations/ca.json
+++ b/custom_components/bambu_lab/translations/ca.json
@@ -580,6 +580,9 @@
       },
       "printable_objects": {
         "name": "Objectes imprimibles"
+      },
+      "skipped_objects": {
+        "name": "Objectes saltats"
       }
     },
     "camera": {

--- a/custom_components/bambu_lab/translations/da.json
+++ b/custom_components/bambu_lab/translations/da.json
@@ -580,6 +580,9 @@
       },
       "printable_objects": {
         "name": "Udskrivbare objekter"
+      },
+      "skipped_objects": {
+        "name": "Springede objekter"
       }
     },
     "camera": {

--- a/custom_components/bambu_lab/translations/de.json
+++ b/custom_components/bambu_lab/translations/de.json
@@ -580,6 +580,9 @@
       },
       "printable_objects": {
         "name": "Druckbare Objekte"
+      },
+      "skipped_objects": {
+        "name": "Übersprungene Objekte"
       }
     },
     "camera": {

--- a/custom_components/bambu_lab/translations/el.json
+++ b/custom_components/bambu_lab/translations/el.json
@@ -580,6 +580,9 @@
       },
       "printable_objects": {
         "name": "Εκτυπώσιμα αντικείμενα"
+      },
+      "skipped_objects": {
+        "name": "Παραλείποντα αντικείμενα"
       }
     },
     "camera": {

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -333,6 +333,9 @@
       "printable_objects": {
         "name": "Printable objects"
       },
+      "skipped_objects": {
+        "name": "Skipped objects"
+      },
       "mqtt_mode": {
         "name": "MQTT connection mode",
         "state": {

--- a/custom_components/bambu_lab/translations/es.json
+++ b/custom_components/bambu_lab/translations/es.json
@@ -580,6 +580,9 @@
       },
       "printable_objects": {
         "name": "Objetos imprimibles"
+      },
+      "skipped_objects": {
+        "name": "Objetos omitidos"
       }
     },
     "camera": {

--- a/custom_components/bambu_lab/translations/fr.json
+++ b/custom_components/bambu_lab/translations/fr.json
@@ -580,6 +580,9 @@
       },
       "printable_objects": {
         "name": "Objets imprimables"
+      },
+      "skipped_objects": {
+        "name": "Objets sautés"
       }
     },
     "camera": {

--- a/custom_components/bambu_lab/translations/it.json
+++ b/custom_components/bambu_lab/translations/it.json
@@ -580,6 +580,9 @@
       },
       "printable_objects": {
         "name": "Oggetti stampabili"
+      },
+      "skipped_objects": {
+        "name": "Oggetti saltati"
       }
     },
     "camera": {

--- a/custom_components/bambu_lab/translations/ko.json
+++ b/custom_components/bambu_lab/translations/ko.json
@@ -580,6 +580,9 @@
       },
       "printable_objects": {
         "name": "인쇄 가능한 물체"
+      },
+      "skipped_objects": {
+        "name": "건너 뛰는 물체"
       }
     },
     "camera": {

--- a/custom_components/bambu_lab/translations/pt-br.json
+++ b/custom_components/bambu_lab/translations/pt-br.json
@@ -580,6 +580,9 @@
       },
       "printable_objects": {
         "name": "Objetos imprimíveis"
+      },
+      "skipped_objects": {
+        "name": "Objetos ignorados"
       }
     },
     "camera": {

--- a/custom_components/bambu_lab/translations/pt.json
+++ b/custom_components/bambu_lab/translations/pt.json
@@ -580,6 +580,9 @@
       },
       "printable_objects": {
         "name": "Objetos imprimíveis"
+      },
+      "skipped_objects": {
+        "name": "Objetos ignorados"
       }
     },
     "camera": {

--- a/custom_components/bambu_lab/translations/sk.json
+++ b/custom_components/bambu_lab/translations/sk.json
@@ -580,6 +580,9 @@
       },
       "printable_objects": {
         "name": "Tlačiteľné objekty"
+      },
+      "skipped_objects": {
+        "name": "Preskočené predmety"
       }
     },
     "camera": {

--- a/custom_components/bambu_lab/translations/zh-Hans.json
+++ b/custom_components/bambu_lab/translations/zh-Hans.json
@@ -580,6 +580,9 @@
       },
       "printable_objects": {
         "name": "可打印对象"
+      },
+      "skipped_objects": {
+        "name": "跳过对象"
       }
     },
     "camera": {


### PR DESCRIPTION
- Fix service calls to re-broadcast off the event bus since only one instance of the integration receives the call and it needs to be broadcast so the correct instance can react to it.
- Add skipped objects sensor to hold the list of already skipped objects from the printer.
- Update printable objects to be count in the main sensor and json in the extra attributes rather than two separate lists that would need to be recombined to use.