### PR TITLE
Fixes for differences between P1 and X1 for FTP file lookup

### DIFF
--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -400,6 +400,8 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         match option:
             case Options.CAMERA:
                 default = True
+            case Options.FTP:
+                default = options.get('local_mqtt', False)
 
         return options.get(OPTION_NAME[option], default)
         

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -341,7 +341,7 @@ class BambuClient:
         self._usage_hours = config.get('usage_hours', 0)
         self._username = config.get('username', '')
         self._enable_camera = config.get('enable_camera', True)
-        self._enable_ftp = config.get('enable_ftp', False)
+        self._enable_ftp = config.get('enable_ftp', self._local_mqtt)
         self._enable_timelapse = config.get('enable_timelapse', False)
 
         self._connected = False

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -669,68 +669,79 @@ class PrintJob:
     #     "bedType": "textured_plate"
     #     },
 
+
+    ftp_search_paths = ['/', '/cache/']
+
     def _cache_ftp_path(self, path: str, ftp):
         try:
-            LOGGER.debug(f"Running FTP nlst for {path or '/'}")
+            LOGGER.debug(f"Running FTP nlst for '{path}'")
             self._client._device.ftp_cache[path] = ftp.nlst(path)
         except Exception as e:
             LOGGER.error(f"FTP nlst Exception. Type: {type(e)} Args: {e}")
             pass
 
-    def _file_in_known_directory(self, filename: Union[str, callable], ftp, search_paths: list=None, use_cache=True) -> Union[str, None]:
+    def _find_file_in_cache(self, filename: str) -> Union[str, None]:
         # Attempt to find a file in one of many known directories
-        for search_path in (['', '/cache'] if search_paths is None else search_paths):
-            if use_cache is False or search_path not in self._client._device.ftp_cache:
-                self._cache_ftp_path(path=search_path, ftp=ftp)
+        LOGGER.debug(f"Searching for '{filename}'")
+        for search_path in self.ftp_search_paths:
+            cached_files = self._client._device.ftp_cache.get(search_path, [])
+            LOGGER.debug(f"In {cached_files}")
 
-            path_contents = self._client._device.ftp_cache.get(search_path) or []
+            # X1 includes the path in the returned files for an NLST command
+            filepath = f"{search_path}{filename}"
+            if filepath in cached_files:
+                return filepath
+            
+            # P1 does not include the path in the returned files for an NLST command
+            if filename in cached_files:
+                return filepath
+            
+        return None
 
-            # If a method was provided instead of a filename pass it the
-            # file contents to let it perform its own match
-            if callable(filename):
-                file_match = filename(path_contents, search_path)
-                if file_match is not None:
-                    return f"{file_match}"
-                continue
-
-            # Otherwise, perform a simple match on the path's contents
-            if filename in path_contents:
-                return f"{search_path}/{filename}"
+    # FTP implementation differences between P1 and X1 printers:
+    # - X1 includes the path in the returned filenames for the NLST command
+    # - P1 just returns the bare filename
+    #
+    # Known filepath configurations:
+    # 
+    # X1C cloud print:
+    #   Bambu Studio 'print' of unsaved workspace
+    #     gcode_filename = data/metadata/plate_1.gcode (ramdisk - not accessible via ftp)
+    #     subtask_name = 3mf file without .3mf extensions - e.g FILENAME
+    #     FILE: /cache/FILENAME.3mf
+    #
 
     def _find_model_path(self, ftp) -> Union[str, None]:
-        # Bail if there's neither gcode nor subtask to search for. If there's
-        # gcode, but it isn't a 3mf we can't use it.
         if self.gcode_file == '' and self.subtask_name == '':
-            # Attempt to find the latest file by date stamps
+            # Fall back to find the latest file by timestamp
             model_path = self._find_latest_file(ftp, '/cache', ['.3mf'])
             if model_path is not None:
                 return model_path
-            return
-        elif self.gcode_file != '' and not self.gcode_file.endswith('.3mf'):
-            return
+            return None
 
-        # The subtask_name is stripped of its file ext, so use a filter when
-        # matching against a *.3mf files
-        def find_subtask_file(path_contents, search_path) -> Union[str, None]:
-            def match_subtask_file(filename) -> bool:
-                return filename.endswith(".3mf") and filename.startswith(self.subtask_name)
-            matches = list(filter(match_subtask_file, path_contents))
-            if len(matches):
-                return f"{search_path}/{matches[0]}"
+        model_path = None
+        for attempt in range(2):
+            # If we fail to find it on the first pass, refresh the ftp file cache and try again
+            if attempt == 1:
+                for search_path in self.ftp_search_paths:
+                    self._cache_ftp_path(search_path, ftp)
 
-        # Use the gcode 3mf if available otherwise fall back to subtask_name
-        model_name = self.gcode_file if self.gcode_file != '' else find_subtask_file
-        model_path = self._file_in_known_directory(filename=model_name, ftp=ftp, use_cache=True)
+            # First test if the subtaskname exists as a 3mf
+            if self.subtask_name != '':
+                model_path = self._find_file_in_cache(filename=f"{self.subtask_name}.3mf")
+                if model_path is not None:
+                    break
+
+            # If we didn't find it then try the gcode file
+            if self.gcode_file != '':
+                model_path = self._find_file_in_cache(filename=f"{self.gcode_file}.3mf")
+                if model_path is not None:
+                    break
 
         if model_path is not None:
-            LOGGER.debug(f"Found model {model_path}")
-            return model_path
+            LOGGER.debug(f"Found model: '{model_path}'")
 
-        LOGGER.debug(f"FTP cache exhausted, retrying without")
-        model_path = self._file_in_known_directory(filename=model_name, ftp=ftp, use_cache=False)
-        if model_path is not None:
-            LOGGER.debug(f"Found model {model_path}")
-            return model_path
+        return model_path
     
     def _find_latest_file(self, ftp, path, extensions: list):
         # Look for the newest file with extension in directory.
@@ -863,6 +874,7 @@ class PrintJob:
         model_path = self._find_model_path(ftp)
 
         if model_path is None:
+            LOGGER.debug("No model file found.")
             return
 
         # Create a temporary file we can download the 3mf into

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -682,10 +682,8 @@ class PrintJob:
 
     def _find_file_in_cache(self, filename: str) -> Union[str, None]:
         # Attempt to find a file in one of many known directories
-        LOGGER.debug(f"Searching for '{filename}'")
         for search_path in self.ftp_search_paths:
             cached_files = self._client._device.ftp_cache.get(search_path, [])
-            LOGGER.debug(f"In {cached_files}")
 
             # X1 includes the path in the returned files for an NLST command
             filepath = f"{search_path}{filename}"

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -736,9 +736,6 @@ class PrintJob:
                 if model_path is not None:
                     break
 
-        if model_path is not None:
-            LOGGER.debug(f"Found model: '{model_path}'")
-
         return model_path
     
     def _find_latest_file(self, ftp, path, extensions: list):
@@ -871,7 +868,9 @@ class PrintJob:
         ftp = self._client.ftp_connection()
         model_path = self._find_model_path(ftp)
 
-        if model_path is None:
+        if model_path is not None:
+            LOGGER.debug(f"Found model: '{model_path}'")
+        else:
             LOGGER.debug("No model file found.")
             return
 
@@ -879,7 +878,6 @@ class PrintJob:
         with tempfile.NamedTemporaryFile(delete=True) as f:
             try:
                 # Fetch the 3mf from FTP and close the connection
-                LOGGER.debug(f"Downloading '{model_path}'")
                 ftp.retrbinary(f"RETR {model_path}", f.write)
                 f.flush()
                 ftp.quit()


### PR DESCRIPTION
- Prior changes mishandled the X1 as the gcode_file is an in-memory path and not useful to use.
- Fixed that by making the gcode_file and subtask_name treated much more equivalently.
- Simplified the existing file cache and lookup logic to make it a lot clearer what's going on.