### PR TITLE
Move axis service actions

### DIFF
--- a/custom_components/bambu_lab/__init__.py
+++ b/custom_components/bambu_lab/__init__.py
@@ -11,6 +11,7 @@ from .pybambu.const import (
     PRINT_PROJECT_FILE_BUS_EVENT,
     SEND_GCODE_BUS_EVENT,
     SKIP_OBJECTS_BUS_EVENT,
+    MOVE_AXIS_BUS_EVENT,
 )
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -84,6 +85,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         skip_objects  # Handler function
     )
 
+    async def move_axis(call: ServiceCall):
+        """Handle the service call."""
+        if check_service_call_payload(call) is False:
+            return
+        hass.bus.fire(MOVE_AXIS_BUS_EVENT, call.data)
+
+    # Register the service with Home Assistant
+    hass.services.async_register(
+        DOMAIN,
+        "move_axis",  # Service name
+        move_axis  # Handler function
+    )
 
     # Set up all platforms for this device/entry.
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/bambu_lab/pybambu/commands.py
+++ b/custom_components/bambu_lab/pybambu/commands.py
@@ -44,7 +44,10 @@ PRINT_PROJECT_FILE_TEMPLATE = {
             }
 
 SKIP_OBJECTS_TEMPLATE = {"print": {"sequence_id": "0", "command": "skip_objects", "obj_list": []}}
-  
+
+MOVE_AXIS_GCODE = "M211 S\nM211 X1 Y1 Z1\nM1002 push_ref_mode\nG91 \nG1 {axis}{distance}.0 F3000\nM1002 pop_ref_mode\nM211 R\n"
+HOME_GCODE = "G28\n"
+
 # X1 only currently
 GET_ACCESSORIES = {"system": {"sequence_id": "0", "command": "get_accessories", "accessory_type": "none"}}
 

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -11,6 +11,7 @@ LOGGER = logging.getLogger(__package__)
 PRINT_PROJECT_FILE_BUS_EVENT = 'bambu_lab_project_file'
 SEND_GCODE_BUS_EVENT = 'bambu_lab_send_gcode'
 SKIP_OBJECTS_BUS_EVENT = 'bambu_lab_skip_objects'
+MOVE_AXIS_BUS_EVENT = 'bambu_lab_move_axis'
 
 class Features(IntEnum):
     AUX_FAN = 1,

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -184,6 +184,9 @@ class Device:
             return True
         return False
 
+    @property
+    def is_core_xy(self) -> bool:
+        return self.info.device_type != "A1" and self.info.device_type != "A1MINI"
 
 @dataclass
 class Lights:

--- a/custom_components/bambu_lab/services.yaml
+++ b/custom_components/bambu_lab/services.yaml
@@ -102,3 +102,40 @@ skip_objects:
       example: "409,1463"
       selector:
         text:
+
+move_axis:
+  name: Move axis
+  description: Move the printhead or bed
+  target:
+    entity:
+      integration: bambu_lab
+  fields:
+    axis:
+      name: Axis
+      description: >-
+        The axis to move.
+        X1 and P1 devices, X and Y move the printhead, Z moves the bed.
+        A1, Z moves the gantry, Y the bed, X the printhead.
+      required: true
+      example: "X"
+      selector:
+        select:
+          multiple: false
+          mode: dropdown
+          options:
+            - X
+            - Y
+            - Z
+            - Home
+
+    distance:
+      name: Distance
+      description: >-
+        The distance (in mm) to move the axis
+        A negative distance moves Z up, X left, Y forward.
+      example: 10
+      selector:
+        number:
+          min: -100
+          max: 100
+          step: 1


### PR DESCRIPTION
## Changes
- Adds service command (actions) to move X, Y, Z axis and run "home"
- Adds `is_core_xy` Device property

## Details
I opted to use the same gcode as Bambu Studio, OrcaSlicer and XTouch ([example](https://github.com/SoftFever/OrcaSlicer/blob/c21b044a9c566db272adaee7d88bfd7198c2a572/src/slic3r/GUI/DeviceManager.cpp#L2088)) which includes software endstops to prevent extending beyond the bounds. I've seen a few implementations that use the simpler `G91\nG0 ...` command, but perhaps better to play it safe.

Questions mainly for @AdrianGarside:

- I went with literal `X`, `Y`, `Z` axis descriptors, but if you'd prefer "up", "down", "left", "right", "backward", "forward" for ease of use, I'd be happy to modify _(I used the latter in my own implementation)_.
- I set an arbitrary limit of 100mm directional move in all directions. This could be made dynamic to the device's printable area if preferrable?
- I was going to include extrude (#533) into this but removed it to be added as a separate action. If you'd rather it was added as one, I'll do so.