### PR TITLE
Extrude and retract filament service actions

### DIFF
--- a/custom_components/bambu_lab/__init__.py
+++ b/custom_components/bambu_lab/__init__.py
@@ -11,6 +11,7 @@ from .pybambu.const import (
     PRINT_PROJECT_FILE_BUS_EVENT,
     SEND_GCODE_BUS_EVENT,
     SKIP_OBJECTS_BUS_EVENT,
+    EXTRUDE_RETRACT_BUS_EVENT,
 )
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -84,6 +85,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         skip_objects  # Handler function
     )
 
+
+    async def extrude_retract(call: ServiceCall):
+        """Handle the service call."""
+        if check_service_call_payload(call) is False:
+            return
+        hass.bus.fire(EXTRUDE_RETRACT_BUS_EVENT, call.data)
+
+    # Register the service with Home Assistant
+    hass.services.async_register(
+        DOMAIN,
+        "extrude_retract",  # Service name
+        extrude_retract  # Handler function
+    )
 
     # Set up all platforms for this device/entry.
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -191,6 +191,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         force = data.get('force')
 
         if move not in ['EXTRUDE', 'RETRACT']:
+            LOGGER.debug(f"Invalid extrusion move '{move}'")
             return False
         
         nozzle_temp = self.get_model().temperature.nozzle_temp

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -28,11 +28,13 @@ from .pybambu.const import (
     PRINT_PROJECT_FILE_BUS_EVENT,
     SEND_GCODE_BUS_EVENT,
     SKIP_OBJECTS_BUS_EVENT,
+    EXTRUDE_RETRACT_BUS_EVENT,
 )
 from .pybambu.commands import (
     PRINT_PROJECT_FILE_TEMPLATE,
     SEND_GCODE_TEMPLATE,
     SKIP_OBJECTS_TEMPLATE,
+    EXTRUDER_GCODE,
 )
 
 class BambuDataUpdateCoordinator(DataUpdateCoordinator):
@@ -66,6 +68,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         self.hass.bus.async_listen(PRINT_PROJECT_FILE_BUS_EVENT, self._service_call_print_project_file)
         self.hass.bus.async_listen(SEND_GCODE_BUS_EVENT, self._service_call_send_gcode)
         self.hass.bus.async_listen(SKIP_OBJECTS_BUS_EVENT, self._service_call_skip_objects)
+        self.hass.bus.async_listen(EXTRUDE_RETRACT_BUS_EVENT, self._service_call_extrude_retract)
 
     @callback
     def _async_shutdown(self, event: Event) -> None:
@@ -175,6 +178,33 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         LOGGER.debug(f"_service_call_send_gcode: {data}")
         command = SEND_GCODE_TEMPLATE
         command['print']['param'] = f"{data.get('command')}\n"
+        self.client.publish(command)
+
+    def _service_call_extrude_retract(self, event: Event):
+        data = event.data
+        if not self._service_call_is_for_me(data):
+            return
+
+        LOGGER.debug(f"_service_call_extrude_retract: {data}")
+
+        move = data.get('type').upper()
+        force = data.get('force')
+
+        if move not in ['EXTRUDE', 'RETRACT']:
+            return False
+        
+        nozzle_temp = self.get_model().temperature.nozzle_temp
+        if force is not True and nozzle_temp < 170:
+            LOGGER.debug(f"Nozzle temperature too low to perform extrusion: {nozzle_temp}ºC")
+            return False
+
+        command = SEND_GCODE_TEMPLATE
+        gcode = EXTRUDER_GCODE
+        distance = (1 if move == 'EXTRUDE' else -1) * 10
+        
+        gcode = gcode.format(distance=distance)
+        
+        command['print']['param'] = gcode
         self.client.publish(command)
 
     def _service_call_print_project_file(self, event: Event):

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -191,12 +191,12 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         force = data.get('force')
 
         if move not in ['EXTRUDE', 'RETRACT']:
-            LOGGER.debug(f"Invalid extrusion move '{move}'")
+            LOGGER.error(f"Invalid extrusion move '{move}'")
             return False
         
         nozzle_temp = self.get_model().temperature.nozzle_temp
         if force is not True and nozzle_temp < 170:
-            LOGGER.debug(f"Nozzle temperature too low to perform extrusion: {nozzle_temp}ºC")
+            LOGGER.error(f"Nozzle temperature too low to perform extrusion: {nozzle_temp}ºC")
             return False
 
         command = SEND_GCODE_TEMPLATE

--- a/custom_components/bambu_lab/pybambu/commands.py
+++ b/custom_components/bambu_lab/pybambu/commands.py
@@ -44,7 +44,9 @@ PRINT_PROJECT_FILE_TEMPLATE = {
             }
 
 SKIP_OBJECTS_TEMPLATE = {"print": {"sequence_id": "0", "command": "skip_objects", "obj_list": []}}
-  
+
+EXTRUDER_GCODE = "M83 \nG0 E{distance}.0 F900\n"
+
 # X1 only currently
 GET_ACCESSORIES = {"system": {"sequence_id": "0", "command": "get_accessories", "accessory_type": "none"}}
 

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -11,6 +11,7 @@ LOGGER = logging.getLogger(__package__)
 PRINT_PROJECT_FILE_BUS_EVENT = 'bambu_lab_project_file'
 SEND_GCODE_BUS_EVENT = 'bambu_lab_send_gcode'
 SKIP_OBJECTS_BUS_EVENT = 'bambu_lab_skip_objects'
+EXTRUDE_RETRACT_BUS_EVENT = 'bambu_lab_extrude_retract'
 
 class Features(IntEnum):
     AUX_FAN = 1,

--- a/custom_components/bambu_lab/services.yaml
+++ b/custom_components/bambu_lab/services.yaml
@@ -112,6 +112,7 @@ extrude_retract:
   fields:
     type:
       name: Type
+      description: The type of extrude action to perform
       required: true
       example: "Extrude"
       selector:

--- a/custom_components/bambu_lab/services.yaml
+++ b/custom_components/bambu_lab/services.yaml
@@ -102,3 +102,29 @@ skip_objects:
       example: "409,1463"
       selector:
         text:
+
+extrude_retract:
+  name: Extrude or retract filament
+  description: Perform an extrusion or extraction of the loaded filament
+  target:
+    entity:
+      integration: bambu_lab
+  fields:
+    type:
+      name: Type
+      required: true
+      example: "Extrude"
+      selector:
+        select:
+          multiple: false
+          mode: dropdown
+          options:
+            - Extrude
+            - Retract
+    force:
+      name: Force
+      description: >-
+        Perform extrusion or retraction if nozzle temperature is below 170ºC.
+      example: false
+      selector:
+        boolean:


### PR DESCRIPTION
## Changes
- Adds service command (actions) to extrude or retract filament

## Details
Action contains a soft block to prevent extrusion or retraction if the nozzle temperature is below 170ºC. This is the same threshold applied by [Bambu and Orca](https://github.com/SoftFever/OrcaSlicer/blob/c21b044a9c566db272adaee7d88bfd7198c2a572/src/slic3r/GUI/StatusPanel.cpp#L30). As those applications also have, the action has a "force" boolean that will let the user override it.

The distance and speed are hard-coded to 10mm and 900 respectively. If it would be advantegous to accept a dynamic distance, I'll update it per #971 (with hard limits).