### PR TITLE
Load and unload filament service actions

### DIFF
--- a/custom_components/bambu_lab/__init__.py
+++ b/custom_components/bambu_lab/__init__.py
@@ -12,6 +12,8 @@ from .pybambu.const import (
     SEND_GCODE_BUS_EVENT,
     SKIP_OBJECTS_BUS_EVENT,
     EXTRUDE_RETRACT_BUS_EVENT,
+    LOAD_FILAMENT_BUS_EVENT,
+    UNLOAD_FILAMENT_BUS_EVENT,
 )
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -85,6 +87,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         skip_objects  # Handler function
     )
 
+    async def unload_filament(call: ServiceCall):
+        """Handle the service call."""
+        if check_service_call_payload(call) is False:
+            return
+        hass.bus.fire(UNLOAD_FILAMENT_BUS_EVENT, call.data)
+
+    # Register the service with Home Assistant
+    hass.services.async_register(
+        DOMAIN,
+        "unload_filament",  # Service name
+        unload_filament  # Handler function
+    )
+
+    async def load_filament(call: ServiceCall):
+        """Handle the service call."""
+        if check_service_call_payload(call) is False:
+            return
+        hass.bus.fire(LOAD_FILAMENT_BUS_EVENT, call.data)
+
+    # Register the service with Home Assistant
+    hass.services.async_register(
+        DOMAIN,
+        "load_filament",  # Service name
+        load_filament  # Handler function
+    )
 
     async def extrude_retract(call: ServiceCall):
         """Handle the service call."""

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -253,7 +253,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         # Printers with older firmware require a different method to change
         # filament. For now, only support newer firmware.
         if not self.get_model().supports_feature(Features.AMS_SWITCH_COMMAND):
-            LOGGER.error(f"Loading filament not yet available for this device")
+            LOGGER.error(f"Loading filament is not available for this printer's firmware version, please update it")
             return False
 
         tray = int(data.get('tray', 1))
@@ -301,7 +301,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         LOGGER.debug(f"_service_call_unload_filament: {data}")
 
         if not self.get_model().supports_feature(Features.AMS_SWITCH_COMMAND):
-            LOGGER.error(f"Loading filament not yet available for this device")
+            LOGGER.error(f"Loading filament is not available for this printer's firmware version, please update it")
             return
         
         command = SWITCH_AMS_TEMPLATE

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -265,7 +265,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
             # midway temperature of the filament set in the ext spool
             ext_spool = self.get_model().external_spool
             if data.get('temperature') is None and not ext_spool.empty:
-                temperature = (int(ext_spool.nozzle_temp_min) + int(ext_spool.nozzle_temp_min)) / 2
+                temperature = (int(ext_spool.nozzle_temp_min) + int(ext_spool.nozzle_temp_max)) / 2
         elif not self.get_model().supports_feature(Features.AMS):
             LOGGER.error(f"AMS not available")
             return False
@@ -283,7 +283,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
             # midway temperature of the filament set in the ext spool
             if data.get('temperature') is None:
                 ams_tray = self.get_model().ams.data[ams_idx].tray[tray]
-                temperature = (int(ams_tray.nozzle_temp_min) + int(ams_tray.nozzle_temp_min)) / 2
+                temperature = (int(ams_tray.nozzle_temp_min) + int(ams_tray.nozzle_temp_max)) / 2
         else:
             LOGGER.error(f"An AMS tray or external spool is required")
             return False

--- a/custom_components/bambu_lab/pybambu/commands.py
+++ b/custom_components/bambu_lab/pybambu/commands.py
@@ -44,6 +44,7 @@ PRINT_PROJECT_FILE_TEMPLATE = {
             }
 
 SKIP_OBJECTS_TEMPLATE = {"print": {"sequence_id": "0", "command": "skip_objects", "obj_list": []}}
+SWITCH_AMS_TEMPLATE = {"print": {"command": "ams_change_filament", "sequence_id": "0", "target": 255, "curr_temp": 0, "tar_temp": 0}}
 
 EXTRUDER_GCODE = "M83 \nG0 E{distance}.0 F900\n"
 

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -12,6 +12,8 @@ PRINT_PROJECT_FILE_BUS_EVENT = 'bambu_lab_project_file'
 SEND_GCODE_BUS_EVENT = 'bambu_lab_send_gcode'
 SKIP_OBJECTS_BUS_EVENT = 'bambu_lab_skip_objects'
 EXTRUDE_RETRACT_BUS_EVENT = 'bambu_lab_extrude_retract'
+LOAD_FILAMENT_BUS_EVENT = 'bambu_lab_load_filament'
+UNLOAD_FILAMENT_BUS_EVENT = 'bambu_lab_unload_filament'
 
 class Features(IntEnum):
     AUX_FAN = 1,

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -34,7 +34,8 @@ class Features(IntEnum):
     SET_TEMPERATURE = 19,
     PROMPT_SOUND = 20,
     FTP = 21,
-    TIMELAPSE = 22
+    TIMELAPSE = 22,
+    AMS_SWITCH_COMMAND = 23,
 
 
 class FansEnum(IntEnum):

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -161,6 +161,14 @@ class Device:
             return True
         elif feature == Features.TIMELAPSE:
             return False
+        elif feature == Features.AMS_SWITCH_COMMAND:
+            if self.info.device_type == "A1" or self.info.device_type == "A1MINI" or self.info.device_type == "X1E":
+                return True
+            elif (self.info.device_type == "P1S" or self.info.device_type == "P1P") and self.supports_sw_version("01.02.99.10"):
+                return True
+            elif (self.info.device_type == "X1" or self.info.device_type == "X1C") and self.supports_sw_version("01.05.06.01"):
+                return True
+            return False
 
         return False
     

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -27,6 +27,7 @@ from .utils import (
     get_speed_name,
     get_hw_version,
     get_sw_version,
+    compare_version,
     get_start_time,
     get_end_time,
     get_HMS_error_text,
@@ -163,6 +164,9 @@ class Device:
 
         return False
     
+    def supports_sw_version(self, version: str) -> bool:
+        return compare_version(self.info.sw_ver, version) >= 0
+
     def get_active_tray(self):
         if self.supports_feature(Features.AMS):
             if self.ams.tray_now == 255:

--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -238,6 +238,12 @@ def get_sw_version(modules, default):
         return ota.get("sw_ver")
     return default
 
+def compare_version(version_max, version_min):
+    maxver = list(map(int, version_max.split('.')))
+    minver = list(map(int, version_min.split('.')))
+
+    # Returns 1 if max > min, -1 if max < min, 0 if equal
+    return (maxver > minver) - (maxver < minver)
 
 def get_start_time(timestamp):
     """Return start time of a print"""

--- a/custom_components/bambu_lab/services.yaml
+++ b/custom_components/bambu_lab/services.yaml
@@ -129,3 +129,46 @@ extrude_retract:
       example: false
       selector:
         boolean:
+
+unload_filament:
+  name: Unload filament
+  description: Unload the filament currently loaded into the extruder
+  target:
+    entity:
+      integration: bambu_lab
+
+load_filament:
+  name: Load filament
+  description: Load a new filament into the extruder
+  target:
+    entity:
+      integration: bambu_lab
+  fields:
+    tray:
+      name: AMS tray
+      description: The AMS tray to load filament from
+      example: 1
+      selector:
+        number:
+          min: 1
+          max: 16
+          step: 1
+    external_spool:
+      name: External spool
+      description: >-
+        Load filament from the external spool. Enabling the external spool will
+        override the AMS tray value if also set.
+      example: 1
+      selector:
+        boolean:
+    temperature:
+      name: Temperature
+      description: >-
+        Target nozzle temperature once the filament is loaded. By default uses
+        the midpoint between min and max temperature of the chosen filament.
+      example: 220
+      selector:
+        number:
+          min: 0
+          max: 250
+          step: 1


### PR DESCRIPTION
## Changes
- Adds service command (actions) to load and unload filament (#533)
- Adds `compare_version` utility method to compare two software versions
- Adds Device method `supports_sw_version` to check its software is equal to or newer than the given version
- Adds `AMS_SWITCH_COMMAND` feature to check Device's software supports `ams_change_filament` command

## Details
This is an initial version to provide filament unloading and loading from AMS and external spool. It uses the MQTT `ams_change_filament` command which is available after the firmware versions listed below. It's possible to load and unload on devices with older software, but I can add that in a follow-up PR.

The `compare_version` utility performs a simple match against two given versions to determine which is greater. `supports_sw_version` uses it to ensure the device is of at least _this_ version.

After the new filament is loaded, the nozzle temperature is set to the temperature provided, otherwise it attempts to find the midpoint between the min and max temperatures defined in the filament profile.

_MQTT command available since:_
| Device | Firmware |
| -- | -- |
| A1 | Always |
| A1 Mini | Always |
| X1E | Always |
| X1 | `01.05.06.01` |
| X1C | `01.05.06.01` |
| P1S | `01.02.99.10` |
| P1P | `01.02.99.10` |

_Version flags available in OrcaSlicer's [device profiles](https://github.com/SoftFever/OrcaSlicer/tree/main/resources/printers)._

<img width="866" alt="Screenshot 2025-02-12 at 20 52 14" src="https://github.com/user-attachments/assets/cacc5ce6-2da7-47ac-b876-92a5f0138ff7" />
