### PR TITLE
Fix "Print Project File" action

### DIFF
--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -335,7 +335,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         command["print"]["use_ams"] = use_ams
         command["print"]["ams_mapping"] = [int(x) for x in ams_mapping.split(',')]
 
-        self.coordinator.client.publish(command)
+        self.client.publish(command)
 
     async def _async_update_data(self):
         LOGGER.debug(f"_async_update_data() called")


### PR DESCRIPTION
"Print Project File" stopped working for me after 2.1.0 update.
I had this error. I tested my fix and it worked for me, I would appreciate if someone can also test print action without and with my fix

```
2025-02-15 00:20:05.697 ERROR (MainThread) [homeassistant] Error doing job: Future exception was never retrieved (None)
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/custom_components/bambu_lab/coordinator.py", line 338, in _service_call_print_project_file
    self.coordinator.client.publish(command)
    ^^^^^^^^^^^^^^^^
AttributeError: 'BambuDataUpdateCoordinator' object has no attribute 'coordinator'
```