### PR TITLE
Fix lan mode ftp regression

### DIFF
--- a/custom_components/bambu_lab/manifest.json
+++ b/custom_components/bambu_lab/manifest.json
@@ -25,5 +25,5 @@
       "st": "urn:bambulab-com:device:3dprinter:1"
     }
   ],  
-  "version": "2.1.2"
+  "version": "2.1.3"
 }

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -622,6 +622,7 @@ class PrintJob:
             # This is a lan mode print where the gcode was pushed to the printer before the print ever started so
             # there is no download to track. If we can find a definitive way to track true lan mode vs just a pure local
             # only connection to a cloud connected printer, we can move this update to IDLE -> PREPARE instead.
+            LOGGER.debug("LAN MODE DOWNLOAD STARTED")
             self._update_task_data()
 
         # When a print is canceled by the user, this is the payload that's sent. A couple of seconds later

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -457,7 +457,7 @@ class PrintJob:
     _ams_print_lengths: float
     _skipped_objects: list
     _printable_objects: dict
-    _gcode_file_prepare_percent : str
+    _gcode_file_prepare_percent : int
 
     @property
     def get_printable_objects(self) -> json:
@@ -515,7 +515,7 @@ class PrintJob:
         self.print_type = ""
         self._printable_objects = {}
         self._skipped_objects = []
-        self._gcode_file_prepare_percent = "0"
+        self._gcode_file_prepare_percent = 0
 
     def print_update(self, data) -> bool:
         old_data = f"{self.__dict__}"
@@ -609,14 +609,20 @@ class PrintJob:
                 self._update_task_data()
 
         old__gcode_file_prepare_percent = self._gcode_file_prepare_percent
-        self._gcode_file_prepare_percent = data.get("gcode_file_prepare_percent", self._gcode_file_prepare_percent)
+        self._gcode_file_prepare_percent = int(data.get("gcode_file_prepare_percent", str(self._gcode_file_prepare_percent)))
         if self._gcode_file_prepare_percent != old__gcode_file_prepare_percent:
-            if self._gcode_file_prepare_percent == "100":
+            if self._gcode_file_prepare_percent == 100:
                 LOGGER.debug(f"DOWNLOAD TO PRINTER IS COMPLETE")
                 if self._client.ftp_enabled:
                     # Now we can update the model data by ftp. By this point the model has been successfully loaded to the printer.
                     # and it's network stack is idle and shouldn't timeout or fail on us randomly.
-                    self._update_task_data()              
+                    self._update_task_data()
+
+        if self.gcode_state == "RUNNING" and previous_gcode_state == "PREPARE" and self._gcode_file_prepare_percent == 0:
+            # This is a lan mode print where the gcode was pushed to the printer before the print ever started so
+            # there is no download to track. If we can find a definitive way to track true lan mode vs just a pure local
+            # only connection to a cloud connected printer, we can move this update to IDLE -> PREPARE instead.
+            self._update_task_data()
 
         # When a print is canceled by the user, this is the payload that's sent. A couple of seconds later
         # print_error will be reset to zero.

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -610,6 +610,8 @@ class PrintJob:
 
         old__gcode_file_prepare_percent = self._gcode_file_prepare_percent
         self._gcode_file_prepare_percent = int(data.get("gcode_file_prepare_percent", str(self._gcode_file_prepare_percent)))
+        if self.gcode_state == "PREPARE":
+            LOGGER.debug(f"DOWNLOAD PERCENTAGE: {self._gcode_file_prepare_percent}")
         if self._gcode_file_prepare_percent != old__gcode_file_prepare_percent:
             if self._gcode_file_prepare_percent == 100:
                 LOGGER.debug(f"DOWNLOAD TO PRINTER IS COMPLETE")

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,9 @@
+### V2.1.3
+- Fix lan mode ftp download regression
+
 ### V2.1.2
-- ?
+- Lots of card improvements
+- New service actions
 
 ### V2.1.1
 - Fix A1/P1 FTP download


### PR DESCRIPTION
## Description

The change to wait for the cloud download to printer to complete before trying to ftp the file off the printer broke lan mode where there is no cloud download.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
