### PR TITLE
Fix integration restart mid print triggering two parallel FTP downloads

### DIFF
--- a/custom_components/bambu_lab/manifest.json
+++ b/custom_components/bambu_lab/manifest.json
@@ -25,5 +25,4 @@
       "st": "urn:bambulab-com:device:3dprinter:1"
     }
   ],  
-  "version": "2.1.3"
-}
+  "version": "2.1.4}

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -515,7 +515,7 @@ class PrintJob:
         self.print_type = ""
         self._printable_objects = {}
         self._skipped_objects = []
-        self._gcode_file_prepare_percent = 0
+        self._gcode_file_prepare_percent = -1
 
     def print_update(self, data) -> bool:
         old_data = f"{self.__dict__}"
@@ -608,11 +608,11 @@ class PrintJob:
                 # We can update task data from the cloud immediately. But ftp has to wait.
                 self._update_task_data()
 
-        old__gcode_file_prepare_percent = self._gcode_file_prepare_percent
+        old_gcode_file_prepare_percent = self._gcode_file_prepare_percent
         self._gcode_file_prepare_percent = int(data.get("gcode_file_prepare_percent", str(self._gcode_file_prepare_percent)))
         if self.gcode_state == "PREPARE":
             LOGGER.debug(f"DOWNLOAD PERCENTAGE: {self._gcode_file_prepare_percent}")
-        if self._gcode_file_prepare_percent != old__gcode_file_prepare_percent:
+        if (old_gcode_file_prepare_percent != -1) and (self._gcode_file_prepare_percent != old_gcode_file_prepare_percent):
             if self._gcode_file_prepare_percent == 100:
                 LOGGER.debug(f"DOWNLOAD TO PRINTER IS COMPLETE")
                 if self._client.ftp_enabled:

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,6 @@
+### V2.1.4
+- ???
+
 ### V2.1.3
 - Fix lan mode ftp download regression
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
