### PR TITLE
Further improved ftp reliability

### DIFF
--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -634,6 +634,7 @@ class BambuClient:
     def ftp_connection(self) -> ImplicitFTP_TLS:
         ftp = ImplicitFTP_TLS(context=create_local_ssl_context())
         ftp.connect(host=self._device.info.ip_address, port=990, timeout=5)
+        ftp.timeout = 30
         ftp.login(user='bblp', passwd=self._access_code)
         ftp.prot_p()
         return ftp


### PR DESCRIPTION
## Description

Better handle case that download to the printer jumps straight to 100% having never reset back to 0 from the last print.
Set the FTP library to an explicit 30s timeout to see if that helps with reports of timeouts.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
