### PR TITLE
Change load filament service call to take the tray entity

### DIFF
--- a/custom_components/bambu_lab/__init__.py
+++ b/custom_components/bambu_lab/__init__.py
@@ -25,7 +25,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
-    def check_service_call_payload(call: ServiceCall):
+    def check_service_call_payload_for_device(call: ServiceCall):
         LOGGER.debug(call)
 
         area_ids = call.data.get("area_id", [])
@@ -49,9 +49,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         
         return True
 
+    def check_service_call_payload_for_entity(call: ServiceCall):
+        LOGGER.debug(call)
+
+        area_ids = call.data.get("area_id", [])
+        device_ids = call.data.get("device_id", [])
+        entity_ids = call.data.get("entity_id", [])
+        label_ids = call.data.get("label_ids", [])
+
+        # Ensure only one entity ID is passed
+        if not isinstance(area_ids, list) or len(area_ids) != 0:
+            LOGGER.error("A single entity id must be specified as the target.")
+            return False
+        if not isinstance(device_ids, list) or len(device_ids) != 0:
+            LOGGER.error("A single entity id must be specified as the target.")
+            return False
+        if not isinstance(entity_ids, list) or len(entity_ids) != 1:
+            LOGGER.error("A single entity id must be specified as the target.")
+            return False
+        if not isinstance(label_ids, list) or len(label_ids) != 0:
+            LOGGER.error("A single entity id must be specified as the target.")
+            return False
+        
+        return True
+
     async def send_command(call: ServiceCall):
         """Handle the service call."""
-        if check_service_call_payload(call) is False:
+        if check_service_call_payload_for_device(call) is False:
             return
         hass.bus.fire(SEND_GCODE_BUS_EVENT, call.data)
 
@@ -64,7 +88,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def print_project_file(call: ServiceCall):
         """Handle the service call."""
-        if check_service_call_payload(call) is False:
+        if check_service_call_payload_for_device(call) is False:
             return
         hass.bus.fire(PRINT_PROJECT_FILE_BUS_EVENT, call.data)
 
@@ -77,7 +101,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def skip_objects(call: ServiceCall):
         """Handle the service call."""
-        if check_service_call_payload(call) is False:
+        if check_service_call_payload_for_device(call) is False:
             return
         hass.bus.fire(SKIP_OBJECTS_BUS_EVENT, call.data)
 
@@ -90,7 +114,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def move_axis(call: ServiceCall):
         """Handle the service call."""
-        if check_service_call_payload(call) is False:
+        if check_service_call_payload_for_device(call) is False:
             return
         hass.bus.fire(MOVE_AXIS_BUS_EVENT, call.data)
 
@@ -103,7 +127,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def unload_filament(call: ServiceCall):
         """Handle the service call."""
-        if check_service_call_payload(call) is False:
+        if check_service_call_payload_for_entity(call) is False:
             return
         hass.bus.fire(UNLOAD_FILAMENT_BUS_EVENT, call.data)
 
@@ -116,7 +140,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def load_filament(call: ServiceCall):
         """Handle the service call."""
-        if check_service_call_payload(call) is False:
+        if check_service_call_payload_for_entity(call) is False:
             return
         hass.bus.fire(LOAD_FILAMENT_BUS_EVENT, call.data)
 
@@ -129,7 +153,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def extrude_retract(call: ServiceCall):
         """Handle the service call."""
-        if check_service_call_payload(call) is False:
+        if check_service_call_payload_for_device(call) is False:
             return
         hass.bus.fire(EXTRUDE_RETRACT_BUS_EVENT, call.data)
 

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -9,11 +9,15 @@ from .const import (
     OPTION_NAME,
 )
 import asyncio
+import re
 from typing import Any
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers import device_registry
+from homeassistant.helpers import (
+    device_registry,
+    entity_registry
+)
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.core import Event, HomeAssistant, callback
@@ -170,11 +174,24 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         hadevice = dev_reg.async_get_device(identifiers={(DOMAIN, self.get_model().info.serial)})
         device_id = data.get('device_id', [])
         if len(device_id) != 1:
-            LOGGER.error("Invalid skip objects data payload: {data}")
+            LOGGER.error("Invalid device data payload: {data}")
             return False
 
         return (device_id[0] == hadevice.id)
 
+    def _get_device_from_entity(self, entity_id):
+        """Get the device associated with a given entity_id."""
+        er = entity_registry.async_get(self._hass)
+        entity_entry = er.async_get(entity_id)
+
+        if not entity_entry or not entity_entry.device_id:
+            return None  # No associated device
+
+        dr = device_registry.async_get(self._hass)
+        device_entry = dr.async_get(entity_entry.device_id)
+
+        return device_entry  # Returns a DeviceEntry object or None
+        
     def _service_call_skip_objects(self, event: Event):
         data = event.data
         if not self._service_call_is_for_me(data):
@@ -252,10 +269,28 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
 
     def _service_call_load_filament(self, event: Event):
         data = event.data
-        if not self._service_call_is_for_me(data):
-            return
+        device_id = data.get('device_id', [])
+        if len(device_id) != 0:
+            LOGGER.error("Invalid entity data payload: {data}")
+            return False
+        entity_id = data.get('entity_id', [])
+        if len(entity_id) != 1:
+            LOGGER.error("Invalid entity data payload: {data}")
+            return False
+        entity_id = entity_id[0]
 
-        LOGGER.debug(f"_service_call_load_filament: {data}")
+        # Get the AMS device
+        ams_device = self._get_device_from_entity(entity_id)
+        # Get the device the AMS is connected to.
+        parent_device_id = ams_device.via_device_id
+        # Get my device id
+        dr = device_registry.async_get(self._hass)
+        hadevice = dr.async_get_device(identifiers={(DOMAIN, self.get_model().info.serial)})
+
+        if parent_device_id != hadevice.id:
+            return
+        
+        # This call is for us.
 
         # Printers with older firmware require a different method to change
         # filament. For now, only support newer firmware.
@@ -263,10 +298,18 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
             LOGGER.error(f"Loading filament is not available for this printer's firmware version, please update it")
             return False
 
-        tray = int(data.get('tray', 1))
+        # Get the entity details.
+        er = entity_registry.async_get(self._hass)
+        entity_entry = er.async_get(entity_id)
+        entity_unique_id = entity_entry.unique_id
+        # entity_entry.unique_id is of the form:
+        #   X1C_<PRINTERSERIAL>_AMS_<AMSSERIAL>_tray_1
+        # or
+        #   X1C_<PRINTERSERIAL>_ExternalSpool_external_spool
+
         temperature = int(data.get('temperature', 0))
 
-        if data.get('external_spool') is True:
+        if entity_unique_id.endswith('_external_spool'):
             tray = 254
             # Unless a target temperature override is set, try and find the
             # midway temperature of the filament set in the ext spool
@@ -276,20 +319,34 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         elif not self.get_model().supports_feature(Features.AMS):
             LOGGER.error(f"AMS not available")
             return False
-        elif data.get('tray') is not None and tray >= 1 and tray <= 16:
+        elif re.search(r"tray_([1-4])$", entity_unique_id):
+            match = re.search(r"tray_([1-4])$", entity_unique_id)
             # Zero-index the tray ID and find the AMS index
-            tray = tray -1
-            ams_idx = (tray // 4)
-            
-            # Check the AMS exists and has filament
-            if not self.get_model().ams.data[ams_idx] or self.get_model().ams.data[ams_idx].tray[tray].empty:
-                LOGGER.error(f"AMS tray '{data.get('tray')}' is empty")
-                return False
+            tray = int(match.group(1)) - 1
+            # identifiers is a set of tuples. We only have one tuple in the set - DOMAIN + serial.
+            ams_serial = next(iter(ams_device.identifiers))[1]
+            ams_index = None
+            for index in range(0,4):
+                ams = self.get_model().ams.data[index]
+                if ams is not None:
+                    if ams.serial == ams_serial:
+                        # We found the right AMS.
+                        ams_index = index
+                        if ams.tray[tray].empty:
+                            LOGGER.error(f"AMS {ams_index + 1} tray {tray} is empty")
+                            return
+                        
+            if ams_index is None:
+                LOGGER.error("Unable to locate AMS.")
+                return
+
+            tray = tray + ams_index * 4
+            LOGGER.debug(f"FINAL TRAY VALUE: {tray}/15 = Tray {(tray)%4 + 1}/4 on AMS {ams_index+1}/4")
 
             # Unless a target temperature override is set, try and find the
             # midway temperature of the filament set in the ext spool
             if data.get('temperature') is None:
-                ams_tray = self.get_model().ams.data[ams_idx].tray[tray]
+                ams_tray = self.get_model().ams.data[ams_index].tray[tray]
                 temperature = (int(ams_tray.nozzle_temp_min) + int(ams_tray.nozzle_temp_max)) // 2
         else:
             LOGGER.error(f"An AMS tray or external spool is required")

--- a/custom_components/bambu_lab/manifest.json
+++ b/custom_components/bambu_lab/manifest.json
@@ -25,5 +25,5 @@
       "st": "urn:bambulab-com:device:3dprinter:1"
     }
   ],  
-  "version": "2.1.4"
+  "version": "0.0.0"
 }

--- a/custom_components/bambu_lab/services.yaml
+++ b/custom_components/bambu_lab/services.yaml
@@ -175,28 +175,11 @@ unload_filament:
 
 load_filament:
   name: Load filament
-  description: Load a new filament into the extruder
+  description: Load a new filament into the extruder passed an AMS tray or an External spool entity
   target:
     entity:
       integration: bambu_lab
   fields:
-    tray:
-      name: AMS tray
-      description: The AMS tray to load filament from
-      example: 1
-      selector:
-        number:
-          min: 1
-          max: 16
-          step: 1
-    external_spool:
-      name: External spool
-      description: >-
-        Load filament from the external spool. Enabling the external spool will
-        override the AMS tray value if also set.
-      example: 1
-      selector:
-        boolean:
     temperature:
       name: Temperature
       description: >-


### PR DESCRIPTION
## Description

The 0 based tray index that it previously took is not very user friendly once you have more than one AMS. Switching to passing the AMS tray entity or the external spool tray entity is much more accessible for automation and for card use.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
