### PR TITLE
Added tray weight and filament_id to attributes

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -409,6 +409,8 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "tag_uid": self.coordinator.get_model().get_active_tray().tag_uid,
             "tray_uuid": self.coordinator.get_model().get_active_tray().tray_uuid,
             "type": self.coordinator.get_model().get_active_tray().type,
+            "filament_id": self.coordinator.get_model().get_active_tray().idx,
+            "tray_weight": self.coordinator.get_model().get_active_tray().tray_weight,
         },
         available_fn=lambda self: self.coordinator.get_model().get_active_tray() is not None,
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.AMS)
@@ -493,6 +495,8 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "tag_uid": self.coordinator.get_model().ams.data[self.index].tray[0].tag_uid,
             "tray_uuid": self.coordinator.get_model().ams.data[self.index].tray[0].tray_uuid,
             "type": self.coordinator.get_model().ams.data[self.index].tray[0].type,
+            "filament_id": self.coordinator.get_model().ams.data[self.index].tray[0].idx,
+            "tray_weight": self.coordinator.get_model().ams.data[self.index].tray[0].tray_weight,
         },
     ),
     BambuLabSensorEntityDescription(
@@ -515,6 +519,8 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "tag_uid": self.coordinator.get_model().ams.data[self.index].tray[1].tag_uid,
             "tray_uuid": self.coordinator.get_model().ams.data[self.index].tray[1].tray_uuid,
             "type": self.coordinator.get_model().ams.data[self.index].tray[1].type,
+            "filament_id": self.coordinator.get_model().ams.data[self.index].tray[1].idx,
+            "tray_weight": self.coordinator.get_model().ams.data[self.index].tray[1].tray_weight,
         },
     ),
     BambuLabSensorEntityDescription(
@@ -537,6 +543,8 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "tag_uid": self.coordinator.get_model().ams.data[self.index].tray[2].tag_uid,
             "tray_uuid": self.coordinator.get_model().ams.data[self.index].tray[2].tray_uuid,
             "type": self.coordinator.get_model().ams.data[self.index].tray[2].type,
+            "filament_id": self.coordinator.get_model().ams.data[self.index].tray[2].idx,
+            "tray_weight": self.coordinator.get_model().ams.data[self.index].tray[2].tray_weight,
         },
     ),
     BambuLabSensorEntityDescription(
@@ -559,6 +567,8 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "tag_uid": self.coordinator.get_model().ams.data[self.index].tray[3].tag_uid,
             "tray_uuid": self.coordinator.get_model().ams.data[self.index].tray[3].tray_uuid,
             "type": self.coordinator.get_model().ams.data[self.index].tray[3].type,
+            "filament_id": self.coordinator.get_model().ams.data[self.index].tray[3].idx,
+            "tray_weight": self.coordinator.get_model().ams.data[self.index].tray[3].tray_weight,
         },
     ),
 )

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -1771,7 +1771,7 @@ class AMSTray:
     k: float
     tag_uid: str
     tray_uuid: str
-
+    tray_weight: int
 
     def __init__(self, client):
         self._client = client
@@ -1787,7 +1787,7 @@ class AMSTray:
         self.k = 0
         self.tag_uid = ""
         self.tray_uuid = ""
-
+        self.tray_weight = 0
     def print_update(self, data) -> bool:
         old_data = f"{self.__dict__}"
 
@@ -1805,6 +1805,7 @@ class AMSTray:
             self.tag_uid = ""
             self.tray_uuid = ""
             self.k = 0
+            self.tray_weight = 0
         else:
             self.empty = False
             self.idx = data.get('tray_info_idx', self.idx)
@@ -1818,7 +1819,7 @@ class AMSTray:
             self.tag_uid = data.get('tag_uid', self.tag_uid)
             self.tray_uuid = data.get('tray_uuid', self.tray_uuid)
             self.k = data.get('k', self.k)
-        
+            self.tray_weight = data.get('tray_weight', self.tray_weight)
         return (old_data != f"{self.__dict__}")
 
 

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -522,6 +522,9 @@
           },
           "filament_id": {
             "name": "Filament ID"
+          },
+          "tray_weight": {
+            "name": "Maximum weight of filament"
           }
         }
       },
@@ -560,6 +563,9 @@
           },
           "filament_id": {
             "name": "Filament ID"
+          },
+          "tray_weight": {
+            "name": "Maximum weight of filament"
           }
         }
       },
@@ -598,6 +604,9 @@
           },
           "filament_id": {
             "name": "Filament ID"
+          },
+          "tray_weight": {
+            "name": "Maximum weight of filament"
           }
         }
       },
@@ -636,6 +645,9 @@
           },
           "filament_id": {
             "name": "Filament ID"
+          },
+          "tray_weight": {
+            "name": "Maximum weight of filament"
           }
         }
       }

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -519,6 +519,9 @@
           },
           "type": {
             "name": "Type"
+          },
+          "filament_id": {
+            "name": "Filament ID"
           }
         }
       },
@@ -554,6 +557,9 @@
           },
           "type": {
             "name": "Type"
+          },
+          "filament_id": {
+            "name": "Filament ID"
           }
         }
       },
@@ -589,6 +595,9 @@
           },
           "type": {
             "name": "Type"
+          },
+          "filament_id": {
+            "name": "Filament ID"
           }
         }
       },
@@ -624,6 +633,9 @@
           },
           "type": {
             "name": "Type"
+          },
+          "filament_id": {
+            "name": "Filament ID"
           }
         }
       }


### PR DESCRIPTION
## Description

Added 2 additional attributes to active tray and AMS trays to show filament_id and tray_weight 

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

Tested against 2 AMS devices on X1C

## Additional Notes

<!-- Add any additional information that reviewers should know -->
