### PR TITLE
local gcode download feature

### DIFF
--- a/custom_components/bambu_lab/const.py
+++ b/custom_components/bambu_lab/const.py
@@ -43,6 +43,7 @@ class Options(IntEnum):
     TIMELAPSE = 4,
     MANUALREFRESH = 5,
     FIRMWAREUPDATE = 6,
+    DOWNLOAD_GCODE_FILE = 7
 
 OPTION_NAME = {
     Options.CAMERA:         "enable_camera",
@@ -50,5 +51,6 @@ OPTION_NAME = {
     Options.FIRMWAREUPDATE: "enable_firmware_update",
     Options.FTP:            "enable_ftp",
     Options.TIMELAPSE:      "enable_timelapse",
-    Options.MANUALREFRESH:  "manual_refresh_mode"
+    Options.MANUALREFRESH:  "manual_refresh_mode",
+    Options.DOWNLOAD_GCODE_FILE: "enable_download_gcode_file"
 }

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -695,6 +695,14 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
     async def set_option_enabled(self, option: Options, enable: bool):
         LOGGER.debug(f"Setting {OPTION_NAME[option]} to {enable}")
         options = dict(self.config_entry.options)
+        
+        if option == Options.DOWNLOAD_GCODE_FILE:
+            if enable:
+                enable = self.get_option_enabled(Options.FTP)
+        if option == Options.FTP:
+            if not enable:
+                options[OPTION_NAME[Options.DOWNLOAD_GCODE_FILE]] = enable
+                
         options[OPTION_NAME[option]] = enable
         self._hass.config_entries.async_update_entry(
             entry=self.config_entry,
@@ -714,6 +722,8 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
             case Options.FTP:
                 force_reload = True
             case Options.TIMELAPSE:
+                force_reload = True
+            case Options.DOWNLOAD_GCODE_FILE:
                 force_reload = True
 
         if force_reload:

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -723,8 +723,6 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
                 force_reload = True
             case Options.TIMELAPSE:
                 force_reload = True
-            case Options.DOWNLOAD_GCODE_FILE:
-                force_reload = True
 
         if force_reload:
             # Force reload of sensors.

--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -342,6 +342,13 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         icon_fn=lambda self: self.coordinator.get_model().print_job.file_type_icon
     ),
     BambuLabSensorEntityDescription(
+        key="gcode_file_downloaded",
+        translation_key="gcode_file_downloaded",
+        available_fn=lambda self: self.coordinator.get_model().print_job.gcode_file_downloaded != "",
+        value_fn=lambda self: self.coordinator.get_model().print_job.gcode_file_downloaded,
+        icon_fn=lambda self: self.coordinator.get_model().print_job.file_type_icon
+    ),
+    BambuLabSensorEntityDescription(
         key="subtask_name",
         translation_key="subtask_name",
         available_fn=lambda self: self.coordinator.get_model().print_job.subtask_name != "",

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -344,6 +344,7 @@ class BambuClient:
         self._enable_ftp = config.get('enable_ftp', self._local_mqtt)
         self._enable_timelapse = config.get('enable_timelapse', False)
         self._disable_ssl_verify = config.get('disable_ssl_verify', False)
+        self._enable_download_gcode_file = config.get('enable_download_gcode_file', False)
 
         self._connected = False
         self._port = 1883
@@ -409,6 +410,13 @@ class BambuClient:
 
     def set_ftp_enabled(self, enable):
         self._enable_ftp = enable
+        
+    @property
+    def download_gcode_file_enabled(self):
+        return self._device.supports_feature(Features.DOWNLOAD_GCODE_FILE) and self._enable_download_gcode_file
+
+    def set_download_gcode_file_enabled(self, enable):
+        self._enable_download_gcode_file = enable
 
     @property
     def timelapse_enabled(self):

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -40,6 +40,7 @@ class Features(IntEnum):
     FTP = 21,
     TIMELAPSE = 22,
     AMS_SWITCH_COMMAND = 23,
+    DOWNLOAD_GCODE_FILE = 24
 
 
 class FansEnum(IntEnum):

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -1184,7 +1184,7 @@ class PrintJob:
                                     self.gcode_file_downloaded = local_gcode_filename
                             except Exception as e:
                                 self.gcode_file_downloaded = "ERROR"
-                                LOGGER.debug(f"Error while extracting gcode zip entry to target path. {repr(e)}")
+                                LOGGER.error(f"Error while extracting gcode zip entry to target path. {repr(e)}")
                         
                         # And extract the plate type from the plate json.
                         self.print_bed_type = json.loads(archive.read(f"Metadata/plate_{plate_number}.json")).get('bed_type')

--- a/custom_components/bambu_lab/switch.py
+++ b/custom_components/bambu_lab/switch.py
@@ -60,7 +60,7 @@ TIMELAPSE_SWITCH_DESCRIPTION = SwitchEntityDescription(
 )
 
 DOWNLOAD_GCODE_FILE_SWITCH_DESCRIPTION = SwitchEntityDescription(
-    key="downnload_gcode_file",
+    key="download_gcode_file",
     icon="mdi:folder-network",
     translation_key="download_gcode_file",
     entity_category=EntityCategory.CONFIG,

--- a/custom_components/bambu_lab/switch.py
+++ b/custom_components/bambu_lab/switch.py
@@ -59,6 +59,13 @@ TIMELAPSE_SWITCH_DESCRIPTION = SwitchEntityDescription(
     entity_category=EntityCategory.CONFIG,
 )
 
+DOWNLOAD_GCODE_FILE_SWITCH_DESCRIPTION = SwitchEntityDescription(
+    key="downnload_gcode_file",
+    icon="mdi:folder-network",
+    translation_key="download_gcode_file",
+    entity_category=EntityCategory.CONFIG,
+)
+
 
 async def async_setup_entry(
         hass: HomeAssistant,
@@ -85,6 +92,9 @@ async def async_setup_entry(
 
     if coordinator.get_model().supports_feature(Features.TIMELAPSE):
         async_add_entities([BambuLabTimelapseSwitch(coordinator, entry)])
+        
+    if coordinator.get_model().supports_feature(Features.DOWNLOAD_GCODE_FILE):
+        async_add_entities([BambuLabDownloadGcodeFileSwitch(coordinator, entry)])
 
 
 class BambuLabSwitch(BambuLabEntity, SwitchEntity):
@@ -290,3 +300,37 @@ class BambuLabPromptSoundSwitch(BambuLabSwitch):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable manual refresh mode."""
         self.coordinator.get_model().info.set_prompt_sound(False)
+
+
+class BambuLabDownloadGcodeFileSwitch(BambuLabSwitch):
+    """BambuLab DOWNLOAD_GCODE_FILE Switch"""
+
+    entity_description = DOWNLOAD_GCODE_FILE_SWITCH_DESCRIPTION
+
+    def __init__(
+            self,
+            coordinator: BambuDataUpdateCoordinator,
+            config_entry: ConfigEntry
+    ) -> None:
+        super().__init__(coordinator, config_entry)
+        self._attr_is_on = self.coordinator.get_option_enabled(Options.DOWNLOAD_GCODE_FILE)
+
+    @property
+    def available(self) -> bool:
+        return True
+
+    @property
+    def icon(self) -> str:
+        """Return the icon for the switch."""
+        return "mdi:folder-network" if self.is_on else "mdi:folder-hidden"
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable DOWNLOAD_GCODE_FILE."""
+        self._attr_is_on = True
+        await self.coordinator.set_option_enabled(Options.DOWNLOAD_GCODE_FILE, self._attr_is_on)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable DOWNLOAD_GCODE_FILE."""
+        self._attr_is_on = False
+        await self.coordinator.set_option_enabled(Options.DOWNLOAD_GCODE_FILE, self._attr_is_on)
+

--- a/custom_components/bambu_lab/translations/de.json
+++ b/custom_components/bambu_lab/translations/de.json
@@ -380,6 +380,9 @@
       "gcode_file": {
         "name": "Gcode Dateiname"
       },
+      "gcode_file_downloaded": {
+        "name": "Gcode Dateiname heruntergeladen"
+      },
       "print_bed_type": {
         "name": "Druckbett Typ",
         "state": {
@@ -675,6 +678,9 @@
       },
       "timelapse": {
         "name": "Laden Sie den neuesten Zeitplan aus dem Drucker"
+      },
+      "download_gcode_file": {
+        "name": "GCode Datei in HA speichern"
       }
     },
     "update": {

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -386,6 +386,9 @@
       "gcode_file": {
         "name": "Gcode filename"
       },
+      "gcode_file_downloaded": {
+        "name": "Gcode file downloaded"
+      },
       "print_bed_type": {
         "name": "Print bed type",
         "state": {
@@ -675,6 +678,9 @@
       },
       "timelapse": {
         "name": "Load latest timelapse from printer"
+      },
+      "download_gcode_file": {
+        "name": "Save GCode file in HA"
       }
     },
     "update": {


### PR DESCRIPTION
## Description
EDIT: redid my last PR now based on current ha-bambulab release

With this PR I added a feature to be able to download gcode from printer to local HA directory via ftp. The intention is to use this gcode for a custom card for a three.js 3d live gcode preview I am currently working on.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [ ] Bug fix
- [x ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

to enable this feature I added a config switch to the printer to enable local gcode download (only if ftp is enabled), otherwise it cannot being enabled.
When ftp data is being fetched by '_async_download_task_data_from_printer' it checks if this feature is enabled and if so, it will download the corresponding gcode file to '/config/www/media/ha-bambulab/{self._client._serial}/tmp_gcode/{tmpFile.name}.gcode'

I also added a sensor holding the currently downloaded gcode filename. This is used by my custom card for picking up the right gcode file.
