### PR TITLE
Enable debug logging always during setup flows

### DIFF
--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -62,6 +62,7 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     serial: str = ""
     authentication_type: str = None
     _show_existing: bool
+    _logging_level: None
 
     @staticmethod
     @callback
@@ -72,10 +73,17 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         # Set logging level to DEBUG during the configuration flow
+        LOGGER.warning("Setting logging level to DEBUG")
+        self.__logging_level = LOGGER.getEffectiveLevel()
         LOGGER.setLevel(logging.DEBUG)
 
         self._bambu_cloud = BambuCloud("", "", "", "")
         self._show_existing = False
+
+    def __del__(self) -> None:
+        # This isn't as immediate as I'd like it takes garbage collection but it'll kick in after a bit.
+        LOGGER.warning("Restoring logging level")
+        LOGGER.setLevel(self.__logging_level)
 
     async def async_step_user(
             self, user_input: dict[str, Any] | None = None
@@ -491,9 +499,12 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
     region: str = ""
     email: str = ""
     authentication_type: str = None
+    _logging_level: None
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         # Set logging level to DEBUG during the configuration flow
+        LOGGER.warning("Setting logging level to DEBUG")
+        self.__logging_level = LOGGER.getEffectiveLevel()
         LOGGER.setLevel(logging.DEBUG)
 
         self.config_entry = config_entry
@@ -503,6 +514,11 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
         self._bambu_cloud = BambuCloud("", "", "", "")
 
         LOGGER.debug(self.config_entry)
+
+    def __del__(self) -> None:
+        # This isn't as immediate as I'd like it takes garbage collection but it'll kick in after a bit.
+        LOGGER.warning("Restoring logging level")
+        LOGGER.setLevel(self.__logging_level)
 
     async def async_step_init(self, user_input: None = None) -> FlowResult:
         errors = {}

--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import voluptuous as vol
 
 from typing import Any
@@ -70,6 +71,9 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return BambuOptionsFlowHandler(config_entry)
 
     def __init__(self) -> None:
+        # Set logging level to DEBUG during the configuration flow
+        LOGGER.setLevel(logging.DEBUG)
+
         self._bambu_cloud = BambuCloud("", "", "", "")
         self._show_existing = False
 
@@ -489,6 +493,9 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
     authentication_type: str = None
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        # Set logging level to DEBUG during the configuration flow
+        LOGGER.setLevel(logging.DEBUG)
+
         self.config_entry = config_entry
         self.region = self.config_entry.options.get('region', '')
         self.email = self.config_entry.options.get('email', '')


### PR DESCRIPTION
## Description

Getting debug logs when the integration fails to setup due to printer connectivity issues requires manual configuration of HA that is a source of friction especially for folks that are less comfortable doing that or it is especially hard to do in the more locked down configurations like HASSOS.

Instead we always enabled debug logging when configuring/reconfiguring so that the logs needed to investigate issues here are already captured.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
