### PR TITLE
Fix custom settings overwriting default filaments

### DIFF
--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -383,7 +383,16 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         self.client.publish(command)
 
     def _service_call_get_filament_data(self, data: dict):
-        return FILAMENT_DATA | self.client.slicer_settings.filaments
+        # Create a copy of FILAMENT_DATA
+        combined_data = FILAMENT_DATA.copy()
+        
+        # Only add entries from slicer_settings that don't exist in FILAMENT_DATA otherwise named custom settings entries
+        # overwrite the default settings. We can only support one entry per filament id.
+        for filament_id, filament_data in self.client.slicer_settings.filaments.items():
+            if filament_id not in FILAMENT_DATA:
+                combined_data[filament_id] = filament_data
+        
+        return combined_data
 
     def _service_call_load_filament(self, data: dict):
         device_id = data.get('device_id', [])


### PR DESCRIPTION
## Description

Custom settings are an existing filament that has modified settings. They have the same filament_id as the existing filament (e.g. Generic PLA Silk) but the slicer has customized settings for them (e.g. to print at 240C). These are distinct from custom filaments which have a unique auto generated filament_id. We can support the latter but not the former as we have no way to distinguish custom settings from the base filaments as the printer doesn't have the information to be able to do so in the mqtt payloads we receive. So for now I'm filtering them out.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
