### PR TITLE
add dependabot.yml to keep GitHub Actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Set update schedule for GitHub Actions
+version: 2
+updates:
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  groups:
+    updates:
+      applies-to: version-updates
+      patterns:
+      - "*"
+    security-updates:
+      applies-to: security-updates
+      patterns:
+      - "*"


### PR DESCRIPTION
## Description

This repo is using some pretty out of date actions, including versions of `actions/checkout` (@v3.x) that run on versions of node (16) that don't get security updates anymore.

Rather than update all the dependencies and risk being accused of trying to supply-chain attack the repo, This PR adds a `dependabot.yaml` that has @dependabot propose updates to GitHub Actions that are used weekly. docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other: dependency updates for GitHub Actions only

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [-] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [-] I have added/updated tests that prove my fix is effective or that my feature works
- [-] All new and existing tests passed

## Additional Notes

Dependabot, with the group config I've put here, is likely to try to make a bunch of major updates at once. If that's not wanted, you can use the following dependabot.yml to get individual PRs:

```yaml
version: 2
updates:
- package-ecosystem: "github-actions" 
  directory: "/" # Location of package manifests
  schedule:
    interval: "weekly"
```
