### PR TITLE
Add AMS temperature, humidity percentage and drying entities

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -486,8 +486,15 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         # We subtract from 6 to match the new Bambu Handy/Studio presentation of 1 = dry, 5 = wet while the printer sends 1 = wet, 5 = dry
     ),
     BambuLabSensorEntityDescription(
+        key="humidity",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.HUMIDITY,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda self: self.coordinator.get_model().ams.data[self.index].humidity,
+        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.AMS_HUMIDITY)
+    ),
+    BambuLabSensorEntityDescription(
         key="temperature",
-        translation_key="ams_temp",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,

--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -519,7 +519,7 @@ AMS_SENSORS: tuple[BambuLabAMSSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTime.MINUTES,
         suggested_unit_of_measurement=UnitOfTime.HOURS,
         suggested_display_precision=3,
-        icon="mdi:timer-sand",
+        icon="mdi:fan-clock",
         device_class=SensorDeviceClass.DURATION,
         value_fn=lambda self: self.coordinator.get_model().ams.data[self.index].remaining_drying_time,
         exists_fn=lambda coordinator, index: coordinator.get_model().supports_feature(Features.AMS_DRYING) and coordinator.get_model().ams.data[index].model == "AMS 2 Pro"

--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import math
 from collections.abc import Callable
 from dataclasses import dataclass
+from .coordinator import BambuDataUpdateCoordinator
 
 from .const import Options
 
@@ -64,6 +65,17 @@ class BambuLabSensorEntityDescription(SensorEntityDescription, BambuLabSensorEnt
     extra_attributes: Callable[..., dict] = lambda _: {}
     icon_fn: Callable[..., str] = lambda _: None
 
+
+@dataclass
+class BambuLabAMSSensorEntityDescription(
+    SensorEntityDescription, BambuLabSensorEntityDescriptionMixin
+):
+    """Sensor entity description for Bambu Lab."""
+
+    available_fn: Callable[..., bool] = lambda _: True
+    exists_fn: Callable[[BambuDataUpdateCoordinator, int], bool] = lambda coordinator, index: True
+    extra_attributes: Callable[..., dict] = lambda _: {}
+    icon_fn: Callable[..., str] = lambda _: None
 
 @dataclass
 class BambuLabBinarySensorEntityDescriptionMixIn:
@@ -476,8 +488,8 @@ VIRTUAL_TRAY_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
     ),
 )
 
-AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
-    BambuLabSensorEntityDescription(
+AMS_SENSORS: tuple[BambuLabAMSSensorEntityDescription, ...] = (
+    BambuLabAMSSensorEntityDescription(
         key="humidity_index",
         translation_key="humidity_index",
         icon="mdi:water-percent",
@@ -485,23 +497,34 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         value_fn=lambda self: 6 - self.coordinator.get_model().ams.data[self.index].humidity_index
         # We subtract from 6 to match the new Bambu Handy/Studio presentation of 1 = dry, 5 = wet while the printer sends 1 = wet, 5 = dry
     ),
-    BambuLabSensorEntityDescription(
+    BambuLabAMSSensorEntityDescription(
         key="humidity",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.HUMIDITY,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda self: self.coordinator.get_model().ams.data[self.index].humidity,
-        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.AMS_HUMIDITY)
+        exists_fn=lambda coordinator, index: coordinator.get_model().supports_feature(Features.AMS_HUMIDITY)
     ),
-    BambuLabSensorEntityDescription(
+    BambuLabAMSSensorEntityDescription(
         key="temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda self: self.coordinator.get_model().ams.data[self.index].temperature,
-        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.AMS_TEMPERATURE)
+        exists_fn=lambda coordinator, index: coordinator.get_model().supports_feature(Features.AMS_TEMPERATURE)
     ),
-    BambuLabSensorEntityDescription(
+    BambuLabAMSSensorEntityDescription(
+        key="remaining_drying_time",
+        translation_key="remaining_drying_time",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        suggested_unit_of_measurement=UnitOfTime.HOURS,
+        suggested_display_precision=3,
+        icon="mdi:timer-sand",
+        device_class=SensorDeviceClass.DURATION,
+        value_fn=lambda self: self.coordinator.get_model().ams.data[self.index].remaining_drying_time,
+        exists_fn=lambda coordinator, index: coordinator.get_model().supports_feature(Features.AMS_DRYING) and coordinator.get_model().ams.data[index].model == "AMS 2 Pro"
+    ),
+    BambuLabAMSSensorEntityDescription(
         key="tray_1",
         translation_key="tray_1",
         icon="mdi:printer-3d-nozzle",
@@ -525,7 +548,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "type": self.coordinator.get_model().ams.data[self.index].tray[0].type,
         },
     ),
-    BambuLabSensorEntityDescription(
+    BambuLabAMSSensorEntityDescription(
         key="tray_2",
         translation_key="tray_2",
         icon="mdi:printer-3d-nozzle",
@@ -549,7 +572,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "type": self.coordinator.get_model().ams.data[self.index].tray[1].type,
         },
     ),
-    BambuLabSensorEntityDescription(
+    BambuLabAMSSensorEntityDescription(
         key="tray_3",
         translation_key="tray_3",
         icon="mdi:printer-3d-nozzle",
@@ -573,7 +596,7 @@ AMS_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
             "type": self.coordinator.get_model().ams.data[self.index].tray[2].type,
         },
     ),
-    BambuLabSensorEntityDescription(
+    BambuLabAMSSensorEntityDescription(
         key="tray_4",
         translation_key="tray_4",
         icon="mdi:printer-3d-nozzle",

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -43,7 +43,8 @@ class Features(IntEnum):
     TIMELAPSE = 22,
     AMS_SWITCH_COMMAND = 23,
     DOWNLOAD_GCODE_FILE = 24,
-    AMS_HUMIDITY = 25
+    AMS_HUMIDITY = 25,
+    AMS_DRYING = 26
 
 
 class FansEnum(IntEnum):

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -43,7 +43,7 @@ class Features(IntEnum):
     TIMELAPSE = 22,
     AMS_SWITCH_COMMAND = 23,
     DOWNLOAD_GCODE_FILE = 24,
-    AMS_HUMIDITY = 15,
+    AMS_HUMIDITY = 25
 
 
 class FansEnum(IntEnum):

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -42,7 +42,8 @@ class Features(IntEnum):
     FTP = 21,
     TIMELAPSE = 22,
     AMS_SWITCH_COMMAND = 23,
-    DOWNLOAD_GCODE_FILE = 24
+    DOWNLOAD_GCODE_FILE = 24,
+    AMS_HUMIDITY = 15,
 
 
 class FansEnum(IntEnum):

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -182,19 +182,19 @@ class Device:
         elif feature == Features.DOWNLOAD_GCODE_FILE:
             return True
         elif feature == Features.AMS_HUMIDITY:
-            if (self.info.device_type == "H2D"):
+            if (self.info.device_type == Printers.H2D):
                 return True
-            elif (self.info.device_type == "X1" or self.info.device_type == "X1C") and self.supports_sw_version("01.08.50.18"):
+            elif (self.info.device_type == Printers.H2D or self.info.device_type == Printers.X1C) and self.supports_sw_version("01.08.50.18"):
                 return True
-            elif (self.info.device_type == "P1S" or self.info.device_type == "P1P") and self.supports_sw_version("01.07.50.18"):
+            elif (self.info.device_type == Printers.P1S or self.info.device_type == Printers.P1P) and self.supports_sw_version("01.07.50.18"):
                 return True
             return False
         elif feature == Features.AMS_DRYING:
-            if (self.info.device_type == "H2D"):
+            if (self.info.device_type == Printers.H2D):
                 return True
-            elif (self.info.device_type == "X1" or self.info.device_type == "X1C") and self.supports_sw_version("01.08.50.18"):
+            elif (self.info.device_type == Printers.H2D or self.info.device_type == Printers.X1C) and self.supports_sw_version("01.08.50.18"):
                 return True
-            elif (self.info.device_type == "P1S" or self.info.device_type == "P1P") and self.supports_sw_version("01.07.50.18"):
+            elif (self.info.device_type == Printers.P1S or self.info.device_type == Printers.P1P) and self.supports_sw_version("01.07.50.18"):
                 return True
             return False
         return False

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -147,7 +147,11 @@ class Device:
         elif feature == Features.START_TIME_GENERATED:
             return True
         elif feature == Features.AMS_TEMPERATURE:
-            return self.info.device_type == Printers.X1 or self.info.device_type == Printers.X1C or self.info.device_type == Printers.X1E or self.info.device_type == Printers.H2D
+            if (self.info.device_type == Printers.X1 or self.info.device_type == Printers.X1C or self.info.device_type == self.info.device_type == Printers.X1E or self.info.device_type == Printers.H2D):
+                return True
+            elif (self.info.device_type == Printers.P1S or self.info.device_type == Printers.P1P) and self.supports_sw_version("01.07.50.18"):
+                return True
+            return False
         elif feature == Features.CAMERA_RTSP:
             return self.info.device_type == Printers.X1 or self.info.device_type == Printers.X1C or self.info.device_type == Printers.X1E or self.info.device_type == Printers.H2D
         elif feature == Features.CAMERA_IMAGE:
@@ -177,6 +181,14 @@ class Device:
             return False
         elif feature == Features.DOWNLOAD_GCODE_FILE:
             return True
+        elif feature == Features.AMS_HUMIDITY:
+            if (self.info.device_type == "H2D"):
+                return True
+            elif (self.info.device_type == "X1" or self.info.device_type == "X1C") and self.supports_sw_version("01.08.50.18"):
+                return True
+            elif (self.info.device_type == "P1S" or self.info.device_type == "P1P") and self.supports_sw_version("01.07.50.18"):
+                return True
+            return False
 
         return False
     
@@ -1665,6 +1677,7 @@ class AMSInstance:
     sw_version: str
     hw_version: str
     humidity_index: int
+    humidity: int
     temperature: int
     model: str
     tray: list["AMSTray"]
@@ -1674,6 +1687,7 @@ class AMSInstance:
         self.sw_version = ""
         self.hw_version = ""
         self.humidity_index = 0
+        self.humidity = 0
         self.temperature = 0
         self.model = model
         self.tray = [None] * 4
@@ -1841,6 +1855,9 @@ class AMSList:
                     self.data[index] = AMSInstance(self._client, "Unknown")
                 if self.data[index].humidity_index != int(ams['humidity']):
                     self.data[index].humidity_index = int(ams['humidity'])
+                if self.data[index].humidity != int(ams["humidity_raw"]):
+                    self.data[index].humidity = int(ams["humidity_raw"])
+
                 if self.data[index].temperature != float(ams['temp']):
                     self.data[index].temperature = float(ams['temp'])
 

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -189,7 +189,14 @@ class Device:
             elif (self.info.device_type == "P1S" or self.info.device_type == "P1P") and self.supports_sw_version("01.07.50.18"):
                 return True
             return False
-
+        elif feature == Features.AMS_DRYING:
+            if (self.info.device_type == "H2D"):
+                return True
+            elif (self.info.device_type == "X1" or self.info.device_type == "X1C") and self.supports_sw_version("01.08.50.18"):
+                return True
+            elif (self.info.device_type == "P1S" or self.info.device_type == "P1P") and self.supports_sw_version("01.07.50.18"):
+                return True
+            return False
         return False
     
     def supports_sw_version(self, version: str) -> bool:
@@ -1676,20 +1683,24 @@ class AMSInstance:
     serial: str
     sw_version: str
     hw_version: str
+    model: str
     humidity_index: int
     humidity: int
     temperature: int
     model: str
+    remaining_drying_time: int
     tray: list["AMSTray"]
 
     def __init__(self, client, model):
         self.serial = ""
         self.sw_version = ""
         self.hw_version = ""
+        self.model = ""
         self.humidity_index = 0
         self.humidity = 0
         self.temperature = 0
         self.model = model
+        self.remaining_drying_time = 0
         self.tray = [None] * 4
         self.tray[0] = AMSTray(client)
         self.tray[1] = AMSTray(client)
@@ -1773,6 +1784,9 @@ class AMSList:
                     if self.data[index].hw_version != module['hw_ver']:
                         data_changed = True
                         self.data[index].hw_version = module['hw_ver']
+                    if self.data[index].model != model:
+                        data_changed = True
+                        self.data[index].model = model
             elif not self._first_initialization_done:
                 self._first_initialization_done = True
                 data_changed = True
@@ -1861,6 +1875,9 @@ class AMSList:
 
                 if self.data[index].temperature != float(ams['temp']):
                     self.data[index].temperature = float(ams['temp'])
+
+                if self.data[index].remaining_drying_time != int(ams['dry_time']):
+                    self.data[index].remaining_drying_time = int(ams['dry_time'])
 
                 tray_list = ams['tray']
                 for tray in tray_list:

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -1855,6 +1855,7 @@ class AMSList:
                     self.data[index] = AMSInstance(self._client, "Unknown")
                 if self.data[index].humidity_index != int(ams['humidity']):
                     self.data[index].humidity_index = int(ams['humidity'])
+
                 if self.data[index].humidity != int(ams["humidity_raw"]):
                     self.data[index].humidity = int(ams["humidity_raw"])
 

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -1784,9 +1784,6 @@ class AMSList:
                     if self.data[index].hw_version != module['hw_ver']:
                         data_changed = True
                         self.data[index].hw_version = module['hw_ver']
-                    if self.data[index].model != model:
-                        data_changed = True
-                        self.data[index].model = model
             elif not self._first_initialization_done:
                 self._first_initialization_done = True
                 data_changed = True

--- a/custom_components/bambu_lab/sensor.py
+++ b/custom_components/bambu_lab/sensor.py
@@ -7,7 +7,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, LOGGER
-from .definitions import PRINTER_SENSORS, VIRTUAL_TRAY_SENSORS, AMS_SENSORS, BambuLabSensorEntityDescription
+from .definitions import (
+    PRINTER_SENSORS,
+    VIRTUAL_TRAY_SENSORS,
+    AMS_SENSORS,
+    BambuLabAMSSensorEntityDescription,
+    BambuLabSensorEntityDescription,
+)
 from .coordinator import BambuDataUpdateCoordinator
 from .models import BambuLabEntity, AMSEntity, VirtualTrayEntity
 from .pybambu.const import Features
@@ -28,9 +34,9 @@ async def async_setup_entry(
                 async_add_entities([BambuLabVirtualTraySensor(coordinator, sensor)])
 
     for sensor in AMS_SENSORS:
-        if sensor.exists_fn(coordinator):
-            for index in range (0, len(coordinator.get_model().ams.data)):
-                if coordinator.get_model().ams.data[index] is not None:
+        for index in range (0, len(coordinator.get_model().ams.data)):
+            if coordinator.get_model().ams.data[index] is not None:
+                if sensor.exists_fn(coordinator, index):
                     async_add_entities([BambuLabAMSSensor(coordinator, sensor, index)])
 
     for sensor in PRINTER_SENSORS:    
@@ -81,7 +87,7 @@ class BambuLabAMSSensor(AMSEntity, SensorEntity):
     def __init__(
             self,
             coordinator: BambuDataUpdateCoordinator,
-            description: BambuLabSensorEntityDescription,
+            description: BambuLabAMSSensorEntityDescription,
             index: int
     ) -> None:
         """Initialise the sensor"""

--- a/custom_components/bambu_lab/translations/ca.json
+++ b/custom_components/bambu_lab/translations/ca.json
@@ -446,9 +446,6 @@
       "humidity_index": {
         "name": "Índex d'humitat"
       },
-      "ams_temp": {
-        "name": "Temperatura de l'AMS"
-      },
       "external_spool": {
         "name": "Bobina externa",
         "state_attributes": {

--- a/custom_components/bambu_lab/translations/da.json
+++ b/custom_components/bambu_lab/translations/da.json
@@ -446,9 +446,6 @@
       "humidity_index": {
         "name": "Fugtighedsindeks"
       },
-      "ams_temp": {
-        "name": "AMS temperatur"
-      },
       "external_spool": {
         "name": "Ekstern spole",
         "state_attributes": {

--- a/custom_components/bambu_lab/translations/de.json
+++ b/custom_components/bambu_lab/translations/de.json
@@ -449,9 +449,6 @@
       "humidity_index": {
         "name": "Index der Luftfeuchtigkeit"
       },
-      "ams_temp": {
-        "name": "AMS-Temperatur"
-      },
       "external_spool": {
         "name": "Externe Spule",
         "state_attributes": {

--- a/custom_components/bambu_lab/translations/el.json
+++ b/custom_components/bambu_lab/translations/el.json
@@ -446,9 +446,6 @@
       "humidity_index": {
         "name": "Δείκτης υγρασίας"
       },
-      "ams_temp": {
-        "name": "Θερμοκρασία AMS"
-      },
       "external_spool": {
         "name": "Εξωτερικό νήμα",
         "state_attributes": {

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -458,9 +458,6 @@
       "humidity_index": {
         "name": "Humidity index"
       },
-      "ams_temp": {
-        "name": "AMS temperature"
-      },
       "external_spool": {
         "name": "External spool",
         "state_attributes": {

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -424,6 +424,9 @@
       "remaining_time": {
         "name": "Remaining time"
       },
+      "remaining_drying_time": {
+        "name": "Remaining drying time"
+      },
       "end_time": {
         "name": "End time"
       },

--- a/custom_components/bambu_lab/translations/es.json
+++ b/custom_components/bambu_lab/translations/es.json
@@ -446,9 +446,6 @@
       "humidity_index": {
         "name": "Índice de humedad"
       },
-      "ams_temp": {
-        "name": "Temperatura del AMS"
-      },
       "external_spool": {
         "name": "Bobina externa",
         "state_attributes": {

--- a/custom_components/bambu_lab/translations/fr.json
+++ b/custom_components/bambu_lab/translations/fr.json
@@ -446,9 +446,6 @@
       "humidity_index": {
         "name": "Indice d'humidité"
       },
-      "ams_temp": {
-        "name": "Température de la AMS"
-      },
       "external_spool": {
         "name": "Bobine externe",
         "state_attributes": {

--- a/custom_components/bambu_lab/translations/fr.json
+++ b/custom_components/bambu_lab/translations/fr.json
@@ -415,6 +415,9 @@
       "remaining_time": {
         "name": "Temps restant"
       },
+      "remaining_drying_time": {
+        "name": "Temps de chauffage restant"
+      },
       "end_time": {
         "name": "Heure de fin"
       },

--- a/custom_components/bambu_lab/translations/it.json
+++ b/custom_components/bambu_lab/translations/it.json
@@ -446,9 +446,6 @@
       "humidity_index": {
         "name": "Indice Umidità"
       },
-      "ams_temp": {
-        "name": "Temperatura AMS"
-      },
       "external_spool": {
         "name": "Bobina Esterna",
         "state_attributes": {

--- a/custom_components/bambu_lab/translations/ko.json
+++ b/custom_components/bambu_lab/translations/ko.json
@@ -446,9 +446,6 @@
       "humidity_index": {
         "name": "습도 지수"
       },
-      "ams_temp": {
-        "name": "AMS 온도"
-      },
       "external_spool": {
         "name": "외부 스풀",
         "state_attributes": {

--- a/custom_components/bambu_lab/translations/nl.json
+++ b/custom_components/bambu_lab/translations/nl.json
@@ -452,9 +452,6 @@
       "humidity_index": {
         "name": "Luchtvochtigheidsindex"
       },
-      "ams_temp": {
-        "name": "AMS-temperatuur"
-      },
       "external_spool": {
         "name": "Externe spoel",
         "state_attributes": {

--- a/custom_components/bambu_lab/translations/pl.json
+++ b/custom_components/bambu_lab/translations/pl.json
@@ -458,9 +458,6 @@
       "humidity_index": {
         "name": "Indeks wilgotności"
       },
-      "ams_temp": {
-        "name": "Temperatura AMS"
-      },
       "external_spool": {
         "name": "Zewnętrzna szpula",
         "state_attributes": {

--- a/custom_components/bambu_lab/translations/pt-br.json
+++ b/custom_components/bambu_lab/translations/pt-br.json
@@ -446,9 +446,6 @@
       "humidity_index": {
         "name": "Índice de umidade"
       },
-      "ams_temp": {
-        "name": "Temperatura AMS"
-      },
       "external_spool": {
         "name": "Carretel externo",
         "state_attributes": {

--- a/custom_components/bambu_lab/translations/pt.json
+++ b/custom_components/bambu_lab/translations/pt.json
@@ -446,9 +446,6 @@
       "humidity_index": {
         "name": "Índice de umidade"
       },
-      "ams_temp": {
-        "name": "Temperatura AMS"
-      },
       "external_spool": {
         "name": "Carretel externo",
         "state_attributes": {

--- a/custom_components/bambu_lab/translations/sk.json
+++ b/custom_components/bambu_lab/translations/sk.json
@@ -446,9 +446,6 @@
       "humidity_index": {
         "name": "Index vlhkosti"
       },
-      "ams_temp": {
-        "name": "Teplota AMS"
-      },
       "external_spool": {
         "name": "Vonkajšia cievka",
         "state_attributes": {

--- a/custom_components/bambu_lab/translations/th.json
+++ b/custom_components/bambu_lab/translations/th.json
@@ -455,9 +455,6 @@
       "humidity_index": {
         "name": "ดัชนีความชื้น"
       },
-      "ams_temp": {
-        "name": "อุณหภูมิ AMS"
-      },
       "external_spool": {
         "name": "สปูลภายนอก",
         "state_attributes": {

--- a/custom_components/bambu_lab/translations/zh-Hans.json
+++ b/custom_components/bambu_lab/translations/zh-Hans.json
@@ -446,9 +446,6 @@
       "humidity_index": {
         "name": "湿度指数"
       },
-      "ams_temp": {
-        "name": "AMS 温度"
-      },
       "external_spool": {
         "name": "外挂料盘",
         "state_attributes": {

--- a/docs/entities.mdx
+++ b/docs/entities.mdx
@@ -84,15 +84,16 @@ nextTitle: Device Triggers
 | Active tray index | If AMS present |
 
 
-| Sensor         | Notes          |
-| -------------- | -------------- |
-| Humidity Index |                |
-| Humidity       | P1/X1/H2D only | 
-| Temperature    | P1/X1/H2D only |
-| Tray 1         |                |
-| Tray 2         |                |
-| Tray 3         |                |
-| Tray 4         |                |
+| Sensor                | Notes          |
+| --------------------- | ---------------|
+| Humidity Index        |                |
+| Humidity              | P1/X1/H2D only | 
+| Temperature           | P1/X1/H2D only |
+| Remaining drying time | AMS 2 Pro only |
+| Tray 1                |                |
+| Tray 2                |                |
+| Tray 3                |                |
+| Tray 4                |                |
 
 | Tray attributes:    | Notes      |
 | ------------------- | ---------- |

--- a/docs/entities.mdx
+++ b/docs/entities.mdx
@@ -84,14 +84,15 @@ nextTitle: Device Triggers
 | Active tray index | If AMS present |
 
 
-| Sensor         | Notes   |
-| -------------- | ------- |
-| Humidity Index |         |
-| Temperature    | X1 only |
-| Tray 1         |         |
-| Tray 2         |         |
-| Tray 3         |         |
-| Tray 4         |         |
+| Sensor         | Notes          |
+| -------------- | -------------- |
+| Humidity Index |                |
+| Humidity       | P1/X1/H2D only | 
+| Temperature    | P1/X1/H2D only |
+| Tray 1         |                |
+| Tray 2         |                |
+| Tray 3         |                |
+| Tray 4         |                |
 
 | Tray attributes:    | Notes      |
 | ------------------- | ---------- |


### PR DESCRIPTION
## Description

- Add AMS temperature entity for P1 (01.07.50.18) (it was already available for X1)
- Add AMS humidity for H2D, P1 (01.07.50.18) and X1, X1C (01.08.50.18). I didn't added X1E because I don't know if it has the right firmware.
- Add drying remaining time for AMS 2 Pro
- Rename `AMS temperature` to `Temperature`. The AMS prefix is not needed because the entity is part of the AMS device.

AMS 2 Pro

![CleanShot 2025-04-23 at 23 07 41@2x](https://github.com/user-attachments/assets/25f57577-d517-4e98-8c8b-1addf38343ba)

AMS 1

![CleanShot 2025-04-23 at 17 57 19](https://github.com/user-attachments/assets/c62f3431-4dd2-4c38-afc8-d7de0b637b47)

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

Fixes https://github.com/greghesp/ha-bambulab/issues/1235

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
