### PR TITLE
Drop cloudscraper requirement

### DIFF
--- a/custom_components/bambu_lab/manifest.json
+++ b/custom_components/bambu_lab/manifest.json
@@ -18,8 +18,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/greghesp/ha-bambulab/issues",
   "requirements": [
-    "beautifulsoup4",
-    "cloudscraper"
+    "beautifulsoup4"
   ],
   "ssdp": [
     {


### PR DESCRIPTION
## Description

We aren't current needing to use cloudscraper and it causes problems on some Home Assistant setups that fail to auto install it. Remove it for now.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
