### PR TITLE
Fix startup error if you don't have an AMS

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -1567,10 +1567,15 @@ class PrintJob:
                 for ams_data in ams_print_data:
                     index = ams_data['ams']
                     weight = ams_data['weight']
-                    if not index in self._ams_print_weights:
+                    if index in self._ams_print_weights:
+                        self._ams_print_weights[index] = weight
+                        self._ams_print_lengths[index] = self.print_length * weight / self.print_weight
+                    else:
+                        # Common case is this is a machine without an AMS and we get index == 255 (not 254 as might be expected)
+                        # And probably also a machine with an AMS but you did a print from the external spool.
+                        # This could also hit if you have reconfigured your printer and removed an AMS.
                         LOGGER.debug(f"AMS tray {index} not found in _ams_print_weights")
-                    self._ams_print_weights[index] = weight
-                    self._ams_print_lengths[index] = self.print_length * weight / self.print_weight
+                        LOGGER.debug(f"ams_print_data: {ams_print_data}")
 
             status = self._task_data['status']
             LOGGER.debug(f"CLOUD PRINT STATUS: {status}")


### PR DESCRIPTION
## Description

Could also hit if you removed AMSs from a machine or probably just if you did a print from the external spool on a cloud connected machine and have it configured in the integration via bambu cloud.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [z] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
