### PR TITLE
Fix door sensor

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -159,8 +159,8 @@ PRINTER_BINARY_SENSORS: tuple[BambuLabBinarySensorEntityDescription, ...] = (
         translation_key="door_open",
         device_class=BinarySensorDeviceClass.DOOR,
         entity_category=EntityCategory.DIAGNOSTIC,
-        available_fn=lambda self: self.coordinator.get_model().home_flag.door_open_available,
-        is_on_fn=lambda self: self.coordinator.get_model().home_flag.door_open,
+        available_fn=lambda self: self.coordinator.get_model().stat_flag.door_open_available or self.coordinator.get_model().home_flag.door_open_available,
+        is_on_fn=lambda self: self.coordinator.get_model().stat_flag.door_open if self.coordinator.get_model().stat_flag.door_open_available else self.coordinator.get_model().home_flag.door_open_available,
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.DOOR_SENSOR),
     ),
     BambuLabBinarySensorEntityDescription(

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -209,6 +209,11 @@ class Home_Flag_Values(IntEnum):
     SUPPORTED_PLUS                      = 0x08000000,
     # Gap
 
+class Stat_Flag_Values(IntEnum):
+    # Gap
+    DOOR_OPEN                           = 0x00800000,
+    # Gap
+
 class BambuUrl(IntEnum):
     LOGIN = 1,
     TFA_LOGIN = 2,

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -45,6 +45,7 @@ from .const import (
     Features,
     FansEnum,
     Home_Flag_Values,
+    Stat_Flag_Values,
     Printers,
     SPEED_PROFILE,
     GCODE_STATE_OPTIONS,
@@ -78,6 +79,7 @@ class Device:
         self.print_error = PrintError(client = client)
         self.camera = Camera(client = client)
         self.home_flag = HomeFlag(client=client)
+        self.stat_flag = StatusFlag(client=client)
         self.extruder = Extruder(client=client)
         self.extruder_tool = ExtruderTool(client=client)
         self.push_all_data = None
@@ -105,6 +107,7 @@ class Device:
         send_event = send_event | self.print_error.print_update(data = data)
         send_event = send_event | self.camera.print_update(data = data)
         send_event = send_event | self.home_flag.print_update(data = data)
+        send_event = send_event | self.stat_flag.print_update(data = data)
         send_event = send_event | self.extruder_tool.print_update(data = data)
 
         self._client.callback("event_printer_data_update")
@@ -115,6 +118,7 @@ class Device:
     def info_update(self, data):
         self.info.info_update(data = data)
         self.home_flag.info_update(data = data)
+        self.stat_flag.info_update(data = data)
         self.ams.info_update(data = data)
         if data.get("command") == "get_version":
             self.get_version_data = data
@@ -2688,6 +2692,52 @@ class HomeFlag:
     def p1s_upgrade_installed(self) -> bool:
         return (self._value & Home_Flag_Values.INSTALLED_PLUS) !=  0
 
+@dataclass
+class StatusFlag:
+    """Contains parsed _values from the 'stat' sensor"""
+    _value: int
+    _sw_ver: str
+    _device_type: str
+
+    def __init__(self, client):
+        self._value = 0
+        self._client = client
+        self._sw_ver = ""
+        self._device_type = ""
+
+    def info_update(self, data):
+        modules = data.get("module", [])
+        self._device_type = get_printer_type(modules, self._device_type)
+        self._sw_ver = get_sw_version(modules, self._sw_ver)
+
+    def print_update(self, data: dict) -> bool:
+        if "stat" not in data:
+            return False
+
+        old_data = f"{self.__dict__}"
+        try:
+            self._value = int(data.get("stat"), 16)
+        except (ValueError, TypeError):
+            LOGGER.warning("Failed to parse stat=%s", data.get("stat"))
+
+        return (old_data != f"{self.__dict__}")
+
+    @property
+    def door_open(self) -> bool | None:
+        if not self.door_open_available:
+            return None
+
+        return (self._value & Stat_Flag_Values.DOOR_OPEN) != 0
+
+    @property
+    def door_open_available(self) -> bool:
+        if not self._client._device.supports_feature(Features.DOOR_SENSOR):
+            return False
+
+        if (self._device_type in [Printers.X1, Printers.X1C] and version.parse(self._sw_ver) < version.parse("01.09.00.00")):
+            return False
+
+        return True
 
 @dataclass
 class FilamentInfo:


### PR DESCRIPTION
## Description

As part of the work for H2D support, Bambu Lab seems to have reorganized some of the status flags. The door open flag is in `stat` in the MQTT report message, based on differential analysis rather than any published source.

Add a dataclass to parse `stat` and favor this on the H2D. For the X1/X1C, I'm assuming that this moved at some point via firmware update. 1.09.00.00 is a guess based the [X1/X1C release notes](https://wiki.bambulab.com/en/x1/manual/X1-X1C-AMS-firmware-release-history) -- this version updates the user interface, adds support for AMS 2 Pro/AMS HT, and has a recommendation to update Bambu Studio to 2.0.3.54.


## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

Fixes #1421.

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

Manually verified with my H2D. I don't have an X1 series printer. Existing unit tests in pybambu/tests fail when I try to run them (Ubuntu 24.04, Python 3.12), and the run_tests.sh script seems meant only for adrian to run. If these tests are supposed to work I'd be happy to dig deeper.

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

Uncertain of the right design for this change -- would it be better to abstract the flags in pybambu to simplify the integration and any other callers, or is the model intended to follow the MQTT message schema?

I don't have access to an X1 series printer, so I'm also uncertain about the specific X1 version that might have changed this, or if this was always broken. The BambuStudio changes that make use of stat are made in June/July 2024 but committed in 2025 for the 2.0 software. [A message by hyperkick in the Bambu Lab Forums](https://forum.bambulab.com/t/mqtt-report-of-door-sensor-state/59955/4) implies that `home_flag` was incorrect for X1 series printers as of January 2025, but hyperkick may have been using prerelease firmware.  

There are other documented (used by BambuStudio) flags in stat and other new fields. I've tried to keep this PR focused on the bug, but happy to make this more complete in this PR or another.