### PR TITLE
Fixed MQTT security detection, added H2D sound toggle, buzzer buttons, heatbed LED

### DIFF
--- a/custom_components/bambu_lab/button.py
+++ b/custom_components/bambu_lab/button.py
@@ -5,7 +5,7 @@ from homeassistant.helpers.entity import EntityCategory
 
 from .const import DOMAIN, LOGGER
 from .models import BambuLabEntity
-from .pybambu.commands import PAUSE, RESUME, STOP
+from .pybambu.commands import PAUSE, RESUME, STOP, BUZZER_SET_SILENT, BUZZER_SET_ALARM, BUZZER_SET_BEEPING
 from .pybambu.const import Features
 
 from homeassistant.components.button import (
@@ -40,6 +40,26 @@ FORCE_REFRESH_BUTTON_DESCRIPTION = ButtonEntityDescription(
     entity_category=EntityCategory.DIAGNOSTIC,
 )
 
+# There is no reliable way to obtain state of the buzzer, better to expose it as buttons
+BUZZER_SILENCE_BUTTON_DESCRIPTION = ButtonEntityDescription(
+    key="buzzer_silence",
+    icon="mdi:alarm-light-off-outline",
+    translation_key="buzzer_silence",
+    entity_category=EntityCategory.CONFIG,
+)
+BUZZER_FIRE_ALARM_BUTTON_DESCRIPTION = ButtonEntityDescription(
+    key="buzzer_fire_alarm",
+    icon="mdi:alarm-light",
+    translation_key="buzzer_fire_alarm",
+    entity_category=EntityCategory.CONFIG,
+)
+BUZZER_BEEPING_BUTTON_DESCRIPTION = ButtonEntityDescription(
+    key="buzzer_beeping",
+    icon="mdi:alarm-light-outline",
+    translation_key="buzzer_beeping",
+    entity_category=EntityCategory.CONFIG,
+)
+
 
 async def async_setup_entry(
         hass: HomeAssistant,
@@ -55,6 +75,13 @@ async def async_setup_entry(
         BambuLabStopButton(coordinator, entry),
         BambuLabRefreshButton(coordinator, entry)
     ]
+
+    if coordinator.get_model().supports_feature(Features.FIRE_ALARM_BUZZER):
+        buttons += [
+            BambuLabBuzzerSilenceButton(coordinator, entry),
+            BambuLabBuzzerFireAlarmButton(coordinator, entry),
+            BambuLabBuzzerBeepingButton(coordinator, entry)
+        ]
 
     async_add_entities(buttons)
 
@@ -137,3 +164,45 @@ class BambuLabRefreshButton(BambuLabButton):
     async def async_press(self) -> None:
         """ Force refresh MQTT info"""
         await self.coordinator.client.refresh()
+
+class BambuLabBuzzerSilenceButton(BambuLabButton):
+    """BambuLab Buzzer Silence Button"""
+
+    entity_description = BUZZER_SILENCE_BUTTON_DESCRIPTION
+
+    @property
+    def available(self) -> bool:
+        """Return if the button is available"""
+        return not self.coordinator.get_model().supports_feature(Features.MQTT_ENCRYPTION_ENABLED)
+
+    async def async_press(self) -> None:
+        """ Pause the Print on button press"""
+        self.coordinator.client.publish(BUZZER_SET_SILENT)
+
+class BambuLabBuzzerFireAlarmButton(BambuLabButton):
+    """BambuLab Buzzer Fire Alarm Button"""
+
+    entity_description = BUZZER_FIRE_ALARM_BUTTON_DESCRIPTION
+
+    @property
+    def available(self) -> bool:
+        """Return if the button is available"""
+        return not self.coordinator.get_model().supports_feature(Features.MQTT_ENCRYPTION_ENABLED)
+
+    async def async_press(self) -> None:
+        """ Pause the Print on button press"""
+        self.coordinator.client.publish(BUZZER_SET_ALARM)
+
+class BambuLabBuzzerBeepingButton(BambuLabButton):
+    """BambuLab Buzzer Beeping Button"""
+
+    entity_description = BUZZER_BEEPING_BUTTON_DESCRIPTION
+
+    @property
+    def available(self) -> bool:
+        """Return if the button is available"""
+        return not self.coordinator.get_model().supports_feature(Features.MQTT_ENCRYPTION_ENABLED)
+
+    async def async_press(self) -> None:
+        """ Pause the Print on button press"""
+        self.coordinator.client.publish(BUZZER_SET_BEEPING)

--- a/custom_components/bambu_lab/button.py
+++ b/custom_components/bambu_lab/button.py
@@ -40,7 +40,8 @@ FORCE_REFRESH_BUTTON_DESCRIPTION = ButtonEntityDescription(
     entity_category=EntityCategory.DIAGNOSTIC,
 )
 
-# There is no reliable way to obtain state of the buzzer, better to expose it as buttons
+# There is no reliable way to obtain state of the buzzer, so it is better to expose as buttons
+# Also, there are 3 possible states, therefore, it cannot be fully exposed by switch
 BUZZER_SILENCE_BUTTON_DESCRIPTION = ButtonEntityDescription(
     key="buzzer_silence",
     icon="mdi:alarm-light-off-outline",

--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -168,7 +168,8 @@ PRINTER_BINARY_SENSORS: tuple[BambuLabBinarySensorEntityDescription, ...] = (
         translation_key="developer_lan_mode",
         device_class=BinarySensorDeviceClass.RUNNING,
         entity_category=EntityCategory.DIAGNOSTIC,
-        is_on_fn=lambda self: self.coordinator.get_model().info.developer_lan_mode,
+        is_on_fn=lambda self: self.coordinator.get_model().supports_feature(Features.MQTT_ENCRYPTION_FIRMWARE)
+                          and not self.coordinator.get_model().supports_feature(Features.MQTT_ENCRYPTION_ENABLED),
     ),
     BambuLabBinarySensorEntityDescription(
         key="mqtt_encryption",

--- a/custom_components/bambu_lab/light.py
+++ b/custom_components/bambu_lab/light.py
@@ -23,6 +23,8 @@ async def async_setup_entry(
     entities_to_add: list = []
     if coordinator.data.supports_feature(Features.CHAMBER_LIGHT):
         entities_to_add.append(BambuLabChamberLight(coordinator, entry))
+    if coordinator.data.supports_feature(Features.HEATBED_LIGHT):
+        entities_to_add.append(BambuLabHeatbedLight(coordinator, entry))
     async_add_entities(entities_to_add)
 
 
@@ -68,3 +70,40 @@ class BambuLabChamberLight(BambuLabEntity, LightEntity):
     def turn_on(self) -> None:
         """ Turn on the power"""
         self.coordinator.get_model().lights.TurnChamberLightOn()
+
+class BambuLabHeatbedLight(BambuLabEntity, LightEntity):
+    """ Defined the Heatbed Light """
+
+    _attr_icon = "mdi:led-strip-variant"
+    _attr_color_mode = ColorMode.ONOFF
+    _attr_supported_color_modes = {ColorMode.ONOFF}
+
+    def __init__(
+            self,
+            coordinator: BambuDataUpdateCoordinator,
+            config_entry: ConfigEntry
+    ) -> None:
+        """Initialize the sensor."""
+
+        self._attr_unique_id = f"{config_entry.data['serial']}_heatbed_light"
+        self._attr_translation_key = "heatbed_light"
+
+        super().__init__(coordinator=coordinator)
+
+    @property
+    def available(self) -> bool:
+        """Is the light available"""
+        return True
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the state of the switch"""
+        return self.coordinator.get_model().lights.is_heatbed_light_on
+
+    def turn_off(self) -> None:
+        """ Turn off the power"""
+        self.coordinator.get_model().lights.TurnHeatbedLightOff()
+
+    def turn_on(self) -> None:
+        """ Turn on the power"""
+        self.coordinator.get_model().lights.TurnHeatbedLightOn()

--- a/custom_components/bambu_lab/number.py
+++ b/custom_components/bambu_lab/number.py
@@ -92,7 +92,7 @@ class BambuLabNumber(BambuLabEntity, NumberEntity):
     def available(self) -> bool:
         """Is the number available"""
         available = self.coordinator.get_model().supports_feature(Features.SET_TEMPERATURE)
-        available = available and not self.coordinator.get_model().print_fun.mqtt_signature_required()
+        available = available and not self.coordinator.get_model().supports_feature(Features.MQTT_ENCRYPTION_ENABLED)
         return available
     
     @property

--- a/custom_components/bambu_lab/number.py
+++ b/custom_components/bambu_lab/number.py
@@ -92,7 +92,7 @@ class BambuLabNumber(BambuLabEntity, NumberEntity):
     def available(self) -> bool:
         """Is the number available"""
         available = self.coordinator.get_model().supports_feature(Features.SET_TEMPERATURE)
-        available = available and not self.coordinator.get_model().supports_feature(Features.MQTT_ENCRYPTION_ENABLED)
+        available = available and not self.coordinator.get_model().print_fun.mqtt_signature_required()
         return available
     
     @property

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -610,6 +610,8 @@ class BambuClient:
                 elif json_data.get("info") and json_data.get("info").get("command") == "get_version":
                     LOGGER.debug("Got Version Data")
                     self._device.info_update(data=json_data.get("info"))
+                elif json_data.get("system") and json_data.get("system").get("command"):
+                    self._device.observe_system_command(data=json_data.get("system"))
 
 
         except Exception as e:
@@ -712,6 +714,7 @@ class BambuClient:
             if (json_data.get('print', {}).get('command', '') == 'push_status') and (json_data.get('print', {}).get('msg', 0) == 0):
                 self._device.print_update(data=json_data.get("print"))
                 self.received_push = True
+            # Observe system command is not needed here because it is not an initial message.
 
             if self.received_info and self.received_push:
                 result.put(True)

--- a/custom_components/bambu_lab/pybambu/commands.py
+++ b/custom_components/bambu_lab/pybambu/commands.py
@@ -109,6 +109,11 @@ EXTRUDER_GCODE = "M83 \nG0 E{distance}.0 F900\n"
 # X1 only currently
 GET_ACCESSORIES = {"system": {"sequence_id": "0", "command": "get_accessories", "accessory_type": "none"}}
 
-# A1 only
+# A1 and H2D only
 PROMPT_SOUND_ENABLE  = {"print" : {"sequence_id": "0", "command": "print_option", "sound_enable": True}}
 PROMPT_SOUND_DISABLE = {"print" : {"sequence_id": "0", "command": "print_option", "sound_enable": False}}
+
+# H2D only
+BUZZER_SET_SILENT  = {"print" : {"sequence_id": "0", "command": "buzzer_ctrl", "mode": 0, "reason": ""}}
+BUZZER_SET_ALARM   = {"print" : {"sequence_id": "0", "command": "buzzer_ctrl", "mode": 1, "reason": ""}}
+BUZZER_SET_BEEPING = {"print" : {"sequence_id": "0", "command": "buzzer_ctrl", "mode": 2, "reason": ""}}

--- a/custom_components/bambu_lab/pybambu/commands.py
+++ b/custom_components/bambu_lab/pybambu/commands.py
@@ -12,6 +12,13 @@ CHAMBER_LIGHT_2_OFF = {
     "system": {"sequence_id": "0", "command": "ledctrl", "led_node": "chamber_light2", "led_mode": "off",
                "led_on_time": 500, "led_off_time": 500, "loop_times": 0, "interval_time": 0}}
 
+HEATBED_LIGHT_ON = {
+    "system": {"sequence_id": "0", "command": "ledctrl", "led_node": "heatbed_light", "led_mode": "on",
+               "led_on_time": 0, "led_off_time": 0, "loop_times": 0, "interval_time": 0}}
+HEATBED_LIGHT_OFF = {
+    "system": {"sequence_id": "0", "command": "ledctrl", "led_node": "heatbed_light", "led_mode": "off",
+               "led_on_time": 0, "led_off_time": 0, "loop_times": 0, "interval_time": 0}}
+
 SPEED_PROFILE_TEMPLATE = {"print": {"sequence_id": "0", "command": "print_speed", "param": ""}}
 
 GET_VERSION = {"info": {"sequence_id": "0", "command": "get_version"}}

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -209,6 +209,11 @@ class Home_Flag_Values(IntEnum):
     SUPPORTED_PLUS                      = 0x08000000,
     # Gap
 
+class Print_Fun_Values(IntEnum):
+    # {"print":{"fun":"3EC1AFFF9CFF"}} <- dev mode disabled
+    # {"print":{"fun":"3EC18FFF9CFF"}} <- dev mode enabled
+    MQTT_SIGNATURE_REQUIRED             = 0x20000000
+
 class BambuUrl(IntEnum):
     LOGIN = 1,
     TFA_LOGIN = 2,

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -49,6 +49,7 @@ class Features(IntEnum):
     EXTRUDER_TOOL = 29,
     MQTT_ENCRYPTION_FIRMWARE = 30,
     MQTT_ENCRYPTION_ENABLED = 31,
+    FIRE_ALARM_BUZZER = 32,
 
 
 class FansEnum(IntEnum):

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -50,6 +50,7 @@ class Features(IntEnum):
     MQTT_ENCRYPTION_FIRMWARE = 30,
     MQTT_ENCRYPTION_ENABLED = 31,
     FIRE_ALARM_BUZZER = 32,
+    HEATBED_LIGHT = 33,
 
 
 class FansEnum(IntEnum):

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -58,7 +58,7 @@ from .commands import (
     CHAMBER_LIGHT_2_OFF,
     PROMPT_SOUND_ENABLE,
     PROMPT_SOUND_DISABLE,
-    SPEED_PROFILE_TEMPLATE,
+    SPEED_PROFILE_TEMPLATE, BUZZER_SET_SILENT, BUZZER_SET_ALARM, BUZZER_SET_BEEPING,
 )
 
 class Device:
@@ -250,6 +250,8 @@ class Device:
             return False
         elif feature == Features.MQTT_ENCRYPTION_ENABLED:
             return self.print_fun.mqtt_signature_required()
+        elif feature == Features.FIRE_ALARM_BUZZER:
+            return (self.info.device_type == Printers.H2D)
         return False
     
     def supports_sw_version(self, version: str) -> bool:
@@ -1833,6 +1835,16 @@ class Info:
             self._client.publish(PROMPT_SOUND_ENABLE)
         else:
             self._client.publish(PROMPT_SOUND_DISABLE)
+
+    def buzzer_silence(self):
+        self._client.publish(BUZZER_SET_SILENT)
+
+    def buzzer_fire_alarm(self):
+        self._client.publish(BUZZER_SET_ALARM)
+
+    def buzzer_attention_beep(self):
+        self._client.publish(BUZZER_SET_SILENT) # need to reset first for it to work properly
+        self._client.publish(BUZZER_SET_BEEPING)
        
 
 @dataclass

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -176,7 +176,7 @@ class Device:
         elif feature == Features.SET_TEMPERATURE:
             return self._supports_temperature_set()
         elif feature == Features.PROMPT_SOUND:
-            return self.info.device_type == Printers.A1 or self.info.device_type == Printers.A1MINI
+            return self.info.device_type == Printers.A1 or self.info.device_type == Printers.A1MINI or self.info.device_type == Printers.H2D
         elif feature == Features.FTP:
             return True
         elif feature == Features.TIMELAPSE:

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -58,7 +58,8 @@ from .commands import (
     CHAMBER_LIGHT_2_OFF,
     PROMPT_SOUND_ENABLE,
     PROMPT_SOUND_DISABLE,
-    SPEED_PROFILE_TEMPLATE, BUZZER_SET_SILENT, BUZZER_SET_ALARM, BUZZER_SET_BEEPING,
+    SPEED_PROFILE_TEMPLATE, BUZZER_SET_SILENT, BUZZER_SET_ALARM, BUZZER_SET_BEEPING, HEATBED_LIGHT_ON,
+    HEATBED_LIGHT_OFF,
 )
 
 class Device:
@@ -120,6 +121,10 @@ class Device:
         self.ams.info_update(data = data)
         if data.get("command") == "get_version":
             self.get_version_data = data
+
+    def observe_system_command(self, data):
+        if data.get("command") == "ledctrl" and data.get("led_node") == "heatbed_light":
+            self.lights.observe_system_command(data)
 
     def _supports_temperature_set(self):
         # When talking to the Bambu cloud mqtt, setting the temperatures is allowed.
@@ -252,6 +257,8 @@ class Device:
             return self.print_fun.mqtt_signature_required()
         elif feature == Features.FIRE_ALARM_BUZZER:
             return (self.info.device_type == Printers.H2D)
+        elif feature == Features.HEATBED_LIGHT:
+            return (self.info.device_type == Printers.H2D)
         return False
     
     def supports_sw_version(self, version: str) -> bool:
@@ -268,12 +275,14 @@ class Lights:
     chamber_light2: str
     chamber_light_override: str
     chamber_light2_override: str
+    heatbed_light: str
     work_light: str
 
     def __init__(self, client):
         self._client = client
         self.chamber_light = "unknown"
         self.chamber_light2 = "unknown"
+        self.heatbed_light = "unknown"
         self.work_light = "unknown"
         self.chamber_light_override = ""
         self.chamber_light2_override = ""
@@ -281,6 +290,12 @@ class Lights:
     @property
     def is_chamber_light_on(self):
         return self.chamber_light == "on" or self.chamber_light2 == "on"
+
+    @property
+    def is_heatbed_light_on(self) -> bool | None:
+        if self.heatbed_light == "unknown":
+            return None
+        return self.heatbed_light == "on"
 
     def print_update(self, data) -> bool:
         old_data = f"{self.__dict__}"
@@ -317,8 +332,18 @@ class Lights:
         self.work_light = \
             search(data.get("lights_report", []), lambda x: x.get('node', "") == "work_light",
                    {"mode": self.work_light}).get("mode")
-        
+
+        # Currently, the status of headbed light is not available (even switching it using printer UI shows an
+        #   error in MQTT: "did not find the valid led: heatbed_light"). Therefore, it is initially in an unknown state.
+
         return (old_data != f"{self.__dict__}")
+
+    def observe_system_command(self, data):
+        # State can be inferred from system->command = ledctrl, but the initial state is still not known.
+        # Even printer UI causes such a message to be sent as the "command execution result".
+        if data.get("led_node") == "heatbed_light":
+            self.heatbed_light = data.get("led_mode")
+        # Should be replaced with proper reading in print_update once fixed in the actual firmware
 
     def TurnChamberLightOn(self):
         self.chamber_light = "on"
@@ -335,6 +360,16 @@ class Lights:
         self._client.publish(CHAMBER_LIGHT_OFF)
         if self._client._device.supports_feature(Features.CHAMBER_LIGHT_2):
             self._client.publish(CHAMBER_LIGHT_2_OFF)
+
+    def TurnHeatbedLightOn(self):
+        self.heatbed_light = "on"
+        self._client.callback("event_light_update")
+        self._client.publish(HEATBED_LIGHT_ON)
+
+    def TurnHeatbedLightOff(self):
+        self.heatbed_light = "off"
+        self._client.callback("event_light_update")
+        self._client.publish(HEATBED_LIGHT_OFF)
 
 
 @dataclass

--- a/custom_components/bambu_lab/switch.py
+++ b/custom_components/bambu_lab/switch.py
@@ -250,7 +250,7 @@ class BambuLabPromptSoundSwitch(BambuLabSwitch):
     @property
     def icon(self) -> str:
         """Return the icon for the switch."""
-        return "mdi:volume-on" if self.is_on else "mdi:volume-off"
+        return "mdi:volume-high" if self.is_on else "mdi:volume-off"
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/bambu_lab/switch.py
+++ b/custom_components/bambu_lab/switch.py
@@ -240,6 +240,13 @@ class BambuLabPromptSoundSwitch(BambuLabSwitch):
 
     entity_description = PROMPT_SOUND_SWITCH_DESCRIPTION
 
+    def available(self) -> bool:
+        """Is the sound switch available"""
+        available = True
+        # Changing the sound involves sending a "print"-type command that may require signature
+        available = available and not self.coordinator.get_model().supports_feature(Features.MQTT_ENCRYPTION_ENABLED)
+        return available
+
     @property
     def icon(self) -> str:
         """Return the icon for the switch."""
@@ -251,11 +258,11 @@ class BambuLabPromptSoundSwitch(BambuLabSwitch):
         return self.coordinator.get_model().home_flag.xcam_prompt_sound
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Enable A1 sound."""
+        """Enable A1 / H2D sound."""
         self.coordinator.get_model().info.set_prompt_sound(True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Disable A1 sound."""
+        """Disable A1 / H2D sound."""
         self.coordinator.get_model().info.set_prompt_sound(False)
 
 

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -226,6 +226,15 @@
       },
       "dev": {
         "name": "Debug"
+      },
+      "buzzer_silence": {
+        "name": "Buzzer - Silence"
+      },
+      "buzzer_fire_alarm": {
+        "name": "Buzzer - Fire alarm"
+      },
+      "buzzer_beeping": {
+        "name": "Buzzer - Beeping"
       }
     },
     "fan": {

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -265,6 +265,9 @@
       },
       "camera_light": {
         "name": "Camera light"
+      },
+      "heatbed_light": {
+        "name": "Heatbed light"
       }
     },
     "number": {

--- a/docs/entities.mdx
+++ b/docs/entities.mdx
@@ -63,14 +63,17 @@ nextTitle: Device Triggers
 
 ## Controls
 
-| Lights              | Notes                                                      |
+| Control             | Notes                                                      |
 | ------------------- | ---------------------------------------------------------- |
 | Chamber Light       |                                                            |
+| Heatbed Light       | H2D only, initial state not known                          |
 | Pause               |                                                            |
 | Resume              |                                                            |
 | Stop                |                                                            |
 | Bed temperature     | On P1/A1 this is not available in hybrid connection mode\* |
 | Nozzle temperature  | On P1/A1 this is not available in hybrid connection mode\* |
+| Buzzer controls     | H2D only, allows to set one of 3 modes                     |
+| Allow Prompt Sound  | A1 and H2D only, enables startup, print start and end sounds |
 
 <Info>\* Hybrid connection mode is when you are connected to the local printer mqtt for a non-Lan Mode printer.</Info>
 <Warning>If you are running the latest X1 firmware with Bambu Authorisation, the only functional control is the Chamber Light</Warning>


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

This PR contains the following changes and bug fixes:
* Fixed developer mode detection, or, actually, "MQTT security mode flag" - that is, enforcement of signature for "print"-class commands. It now properly works even in real time (especially actual when attaching module, and it gets temporarily disabled automatically).
  * The "Developer mode" option in config becomes unused and should be carefully removed.
  * MQTT encryption firmware detection MAY also be not needed anymore - it is possible to reliably determine whether the printer requires signature or not - actually, Bambu Studio seems to rely on this flag - once Dev mode is deactivated, it immediately configures security certificate and starts signing messages, once Dev mode is activated it immediately stops signing them.
* Fixed sound configuration entity not appearing for H2D - in fact, xcam and toggle logic is identical to A1.
* Fixed activated sound configuration entity icon - it was pointing to non existent one.
* Added buttons to activate or silence H2D buzzer / siren.
  * Because it is not possible to properly obtain it's state, and it is quite not stateful (for example, beeping mode only beeps for about 10 seconds), it is implemented as buttons rather than switch. Tri-state nature of this variable (and, possibly, more in the future) also contribute to this.
* Added heatbed light control for the H2D.
  * This one is quite finnicky, everything works perfectly, however, it is not possible to obtain it's state due to bug in firmware. It is only possible to know our own changes, or observe changes by monitoring responses to commands (including printer UI), which I implemented.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

https://github.com/greghesp/ha-bambulab/issues/1447

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [x] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed
- [x] Tested on real devices (H2D, X1C, P1S)

N.B. Test script is not quite functional, it anchors to a specific absolute directory.
In theory tests may fail if they did not correctly replicate "fun" value in accordance to Developer mode setting.

## Additional Notes

"Developer mode" configuration option is not needed anymore after these changes, because now the state is properly tracked by analyzing information that is sent by the printer. Nevertheless, I was not sure how to correctly remove it without breaking anything - that is highly recommended to do.