### PR TITLE
Use both cloud and local ftp to access cover image and ams data

### DIFF
--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -437,9 +437,6 @@ class BambuClient:
     def ftp_enabled(self):
         return self._device.supports_feature(Features.FTP) and self._enable_ftp
 
-    def set_ftp_enabled(self, enable):
-        self._enable_ftp = enable
-        
     @property
     def local_tls_context(self):
         if self._disable_ssl_verify:

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -1409,10 +1409,9 @@ class PrintJob:
         if self._client._test_mode:
             return
         
+        self._download_task_data_from_cloud()
         if self._client.ftp_enabled:
             self._download_task_data_from_printer()
-        else:
-            self._download_task_data_from_cloud()
 
     def _download_task_data_from_printer(self):
         if self._ftpThread is None:


### PR DESCRIPTION
## Description

In v2.2.0 I enabled the use of ftp to cache models for everyone. But this turned off use of cloud for cover image and AMS data. For people that don't have working FTP/local printer access this breaks the cover image. Try out allowing both data retrieval approaches to work simultaneously.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
