### PR TITLE
Fix door sensor on X1 series

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -2095,20 +2095,18 @@ class Info:
         self.nozzle_diameter = float(data.get("nozzle_diameter", self.nozzle_diameter))
         self.nozzle_type = data.get("nozzle_type", self.nozzle_type)
 
-        # Door status may be provided in two places depending on printer model and firmware version.
-        # Old example:
+        # Door status may be provided in two places depending on printer model.
+        # X1 example:
         #   "home_flag": -1066934785,   # closed
         #   "home_flag": -1058546177,   # open
-        # New example:
+        # H2 example:
         #   "stat": "46258008",  # closed
         #   "stat": "46A58008",  # open
         if self._client._device.supports_feature(Features.DOOR_SENSOR):
-            if (self.device_type in [Printers.X1, Printers.X1C] and version.parse(self.sw_ver) < version.parse("01.09.00.00")):
-                # Old (home_flag)
+            if self.device_type in [Printers.X1, Printers.X1C]:
                 if "home_flag" in data:
                     self.door_open = (data["home_flag"] & Home_Flag_Values.DOOR_OPEN) != 0
             elif "stat" in data:
-                # New (stat)
                 stat_value = int(data["stat"], 16)
                 self.door_open = (stat_value & Stat_Flag_Values.DOOR_OPEN) != 0
 


### PR DESCRIPTION

## Description

#1436 assumed that the door sensor moved to the `stat` flag for newer X1 and X1C, but #1548 shows that's inaccurate. Revert the behavior change from #1436 for X1/X1C, so that 'stat' is only used for H2 series and `home_flag` is used for all X1/X1C.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

#1548 

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

Ran existing tests, and re-verified behavior with my H2D (LAN only, developer mode enabled).

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

## Additional Notes

Apologies for creating a regression. Lesson learned- don't fix what ain't broke.

This is the most likely fix given what is now known. I've also considered:
* using `stat` for X1 series == 1.09.00.00 and `home_flag` for X1 >= 1.10 (no solid evidence that `stat` is correct for that one firmware version or that Bambu is in the habit of reverting changes like this)
* allowing either flag to mean that the door is open on any printer with a door (could have false positives)
* somehow learning the right flag to use (could be messy, could have false positives or negatives)
* making the door sensor source user-configurable (unnecessary complexity for users, need to handle upgrades, etc.)
