### PR TITLE
Improve nozzle type and diameter for H2D

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -557,13 +557,49 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         suggested_display_precision=1,
         device_class=SensorDeviceClass.DISTANCE,
         icon="mdi:printer-3d-nozzle",
-        value_fn=lambda self: self.coordinator.get_model().info.nozzle_diameter
+        value_fn=lambda self: self.coordinator.get_model().info.active_nozzle_diameter
     ),
     BambuLabSensorEntityDescription(
         key="nozzle_type",
         translation_key="nozzle_type",
         icon="mdi:printer-3d-nozzle",
-        value_fn=lambda self: self.coordinator.get_model().info.nozzle_type
+        value_fn=lambda self: self.coordinator.get_model().info.active_nozzle_type
+    ),
+    BambuLabSensorEntityDescription(
+        key="left_nozzle_diameter",
+        translation_key="left_nozzle_diameter",
+        native_unit_of_measurement=UnitOfLength.MILLIMETERS,
+        suggested_unit_of_measurement=UnitOfLength.MILLIMETERS,
+        suggested_display_precision=1,
+        device_class=SensorDeviceClass.DISTANCE,
+        icon="mdi:printer-3d-nozzle",
+        value_fn=lambda self: self.coordinator.get_model().info.left_nozzle_diameter,
+        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.DUAL_NOZZLES),
+    ),
+    BambuLabSensorEntityDescription(
+        key="left_nozzle_type",
+        translation_key="left_nozzle_type",
+        icon="mdi:printer-3d-nozzle",
+        value_fn=lambda self: self.coordinator.get_model().info.left_nozzle_type,
+        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.DUAL_NOZZLES),
+    ),
+    BambuLabSensorEntityDescription(
+        key="right_nozzle_diameter",
+        translation_key="right_nozzle_diameter",
+        native_unit_of_measurement=UnitOfLength.MILLIMETERS,
+        suggested_unit_of_measurement=UnitOfLength.MILLIMETERS,
+        suggested_display_precision=1,
+        device_class=SensorDeviceClass.DISTANCE,
+        icon="mdi:printer-3d-nozzle",
+        value_fn=lambda self: self.coordinator.get_model().info.right_nozzle_diameter,
+        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.DUAL_NOZZLES),
+    ),
+    BambuLabSensorEntityDescription(
+        key="right_nozzle_type",
+        translation_key="right_nozzle_type",
+        icon="mdi:printer-3d-nozzle",
+        value_fn=lambda self: self.coordinator.get_model().info.right_nozzle_type,
+        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.DUAL_NOZZLES),
     ),
     BambuLabSensorEntityDescription(
         key="ip_address",

--- a/custom_components/bambu_lab/pybambu/tests/H2D.json
+++ b/custom_components/bambu_lab/pybambu/tests/H2D.json
@@ -391,7 +391,7 @@
               "diameter": 0.4,
               "id": 1,
               "tm": 0,
-              "type": "HS01",
+              "type": "HH01",
               "wear": 0
             }
           ],
@@ -694,6 +694,35 @@
     },
     "push_door_opened": {
         "stat": "46A58008"
+    },
+    "push_left_extruder": {
+        "device": {
+          "extruder": {"state": 274}
+        }
+    },
+    "push_alt_nozzle_info": {
+      "device": {
+        "nozzle": {
+          "exist": 3,
+          "info": [
+            {
+              "diameter": 0.2,
+              "id": 0,
+              "tm": 0,
+              "type": "HS00",
+              "wear": 0
+            },
+            {
+              "diameter": 0.6,
+              "id": 1,
+              "tm": 0,
+              "type": "HX05",
+              "wear": 0
+            }
+          ],
+          "state": 0
+        }
+      }
     },
     "get_version": {
       "command": "get_version",

--- a/custom_components/bambu_lab/translations/ca.json
+++ b/custom_components/bambu_lab/translations/ca.json
@@ -492,7 +492,11 @@
         "name": "Tipus de broquet",
         "state": {
           "hardened_steel": "Acer endurit",
-          "stainless_steel": "Acer inoxidable"
+          "stainless_steel": "Acer inoxidable",
+          "tungsten_carbide": "Carbur de tungstè",
+          "high_flow_hardened_steel": "Acer endurit amb un gran flux",
+          "high_flow_stainless_steel": "Acer inoxidable amb un gran flux",
+          "high_flow_tungsten_carbide": "Carbur de tungstè amb gran flux"
         }
       },
       "humidity_index": {
@@ -758,6 +762,34 @@
           "normal": "Normal",
           "abnormal": "Anormal",
           "readonly": "Llegiu només"
+        }
+      },
+      "left_nozzle_diameter": {
+        "name": "Mida de la boquilla esquerra"
+      },
+      "left_nozzle_type": {
+        "name": "Tipus de la boquilla esquerra",
+        "state": {
+          "hardened_steel": "Acer endurit",
+          "stainless_steel": "Acer inoxidable",
+          "tungsten_carbide": "Carbur de tungstè",
+          "high_flow_hardened_steel": "Acer endurit amb un gran flux",
+          "high_flow_stainless_steel": "Acer inoxidable amb un gran flux",
+          "high_flow_tungsten_carbide": "Carbur de tungstè amb gran flux"
+        }
+      },
+      "right_nozzle_diameter": {
+        "name": "Mida de la boquilla dreta"
+      },
+      "right_nozzle_type": {
+        "name": "Tipus de boquilla dreta",
+        "state": {
+          "hardened_steel": "Acer endurit",
+          "stainless_steel": "Acer inoxidable",
+          "tungsten_carbide": "Carbur de tungstè",
+          "high_flow_hardened_steel": "Acer endurit amb un gran flux",
+          "high_flow_stainless_steel": "Acer inoxidable amb un gran flux",
+          "high_flow_tungsten_carbide": "Carbur de tungstè amb gran flux"
         }
       }
     },

--- a/custom_components/bambu_lab/translations/da.json
+++ b/custom_components/bambu_lab/translations/da.json
@@ -492,7 +492,11 @@
         "name": "Dysens type",
         "state": {
           "hardened_steel": "Hærdet stål",
-          "stainless_steel": "Rustfrit stål"
+          "stainless_steel": "Rustfrit stål",
+          "tungsten_carbide": "Wolframcarbid",
+          "high_flow_hardened_steel": "hærdet stål med stor strømning",
+          "high_flow_stainless_steel": "rustfrit stål med stor strømning",
+          "high_flow_tungsten_carbide": "wolframcarbid med stor strømning"
         }
       },
       "humidity_index": {
@@ -758,6 +762,34 @@
           "normal": "Normal",
           "abnormal": "Abnorm",
           "readonly": "Læs kun"
+        }
+      },
+      "left_nozzle_diameter": {
+        "name": "Efterladt dysestørrelse"
+      },
+      "left_nozzle_type": {
+        "name": "Efterladt dysetype",
+        "state": {
+          "hardened_steel": "Hærdet stål",
+          "stainless_steel": "Rustfrit stål",
+          "tungsten_carbide": "Wolframcarbid",
+          "high_flow_hardened_steel": "hærdet stål med stor strømning",
+          "high_flow_stainless_steel": "rustfrit stål med stor strømning",
+          "high_flow_tungsten_carbide": "wolframcarbid med stor strømning"
+        }
+      },
+      "right_nozzle_diameter": {
+        "name": "Højre dysestørrelse"
+      },
+      "right_nozzle_type": {
+        "name": "Højre dysetype",
+        "state": {
+          "hardened_steel": "Hærdet stål",
+          "stainless_steel": "Rustfrit stål",
+          "tungsten_carbide": "Wolframcarbid",
+          "high_flow_hardened_steel": "hærdet stål med stor strømning",
+          "high_flow_stainless_steel": "rustfrit stål med stor strømning",
+          "high_flow_tungsten_carbide": "wolframcarbid med stor strømning"
         }
       }
     },

--- a/custom_components/bambu_lab/translations/de.json
+++ b/custom_components/bambu_lab/translations/de.json
@@ -495,7 +495,11 @@
         "name": "Düsentyp",
         "state": {
           "hardened_steel": "Gehärteter Stahl",
-          "stainless_steel": "Edelstahl"
+          "stainless_steel": "Edelstahl",
+          "tungsten_carbide": "Wolfram -Carbid",
+          "high_flow_hardened_steel": "hartem Stahl mit großem Fluss",
+          "high_flow_stainless_steel": "Edelstahl mit großem Fluss",
+          "high_flow_tungsten_carbide": "Wolframkarbid mit großem Fluss"
         }
       },
       "humidity_index": {
@@ -758,6 +762,34 @@
           "normal": "Normal",
           "abnormal": "Abnormal",
           "readonly": "Nur lesen"
+        }
+      },
+      "left_nozzle_diameter": {
+        "name": "Linke Düsengröße"
+      },
+      "left_nozzle_type": {
+        "name": "Linke Düsentyp",
+        "state": {
+          "hardened_steel": "Ausgehärteter Stahl",
+          "stainless_steel": "Edelstahl",
+          "tungsten_carbide": "Wolfram -Carbid",
+          "high_flow_hardened_steel": "hartem Stahl mit großem Fluss",
+          "high_flow_stainless_steel": "Edelstahl mit großem Fluss",
+          "high_flow_tungsten_carbide": "Wolframkarbid mit großem Fluss"
+        }
+      },
+      "right_nozzle_diameter": {
+        "name": "Rechte Düsengröße"
+      },
+      "right_nozzle_type": {
+        "name": "Rechte Düsentyp",
+        "state": {
+          "hardened_steel": "Ausgehärteter Stahl",
+          "stainless_steel": "Edelstahl",
+          "tungsten_carbide": "Wolfram -Carbid",
+          "high_flow_hardened_steel": "hartem Stahl mit großem Fluss",
+          "high_flow_stainless_steel": "Edelstahl mit großem Fluss",
+          "high_flow_tungsten_carbide": "Wolframkarbid mit großem Fluss"
         }
       }
     },

--- a/custom_components/bambu_lab/translations/el.json
+++ b/custom_components/bambu_lab/translations/el.json
@@ -492,7 +492,11 @@
         "name": "Τύπος ακροφυσίου",
         "state": {
           "hardened_steel": "Σκληρυμένος χάλυβας",
-          "stainless_steel": "Ανοξείδωτος χάλυβας"
+          "stainless_steel": "Ανοξείδωτος χάλυβας",
+          "tungsten_carbide": "Καρβίδιο βολφραμίου",
+          "high_flow_hardened_steel": "σκληρυμένος χάλυβας με μεγάλη ροή",
+          "high_flow_stainless_steel": "από ανοξείδωτο χάλυβα με μεγάλη ροή",
+          "high_flow_tungsten_carbide": "καρβίδιο βολφραμίου με μεγάλη ροή"
         }
       },
       "humidity_index": {
@@ -758,6 +762,34 @@
           "normal": "Κανονικός",
           "abnormal": "Ανώμαλος",
           "readonly": "Μόνο διαβάστε"
+        }
+      },
+      "left_nozzle_diameter": {
+        "name": "Μέγεθος ακροφυσίου αριστερού"
+      },
+      "left_nozzle_type": {
+        "name": "Αριστερά τύπου ακροφυσίου",
+        "state": {
+          "hardened_steel": "Χαλύβδινο χαλύβδινο",
+          "stainless_steel": "Από ανοξείδωτο χάλυβα",
+          "tungsten_carbide": "Καρβίδιο βολφραμίου",
+          "high_flow_hardened_steel": "σκληρυμένος χάλυβας με μεγάλη ροή",
+          "high_flow_stainless_steel": "από ανοξείδωτο χάλυβα με μεγάλη ροή",
+          "high_flow_tungsten_carbide": "καρβίδιο βολφραμίου με μεγάλη ροή"
+        }
+      },
+      "right_nozzle_diameter": {
+        "name": "Μέγεθος δεξιού ακροφυσίου"
+      },
+      "right_nozzle_type": {
+        "name": "Τύπος δεξιού ακροφυσίου",
+        "state": {
+          "hardened_steel": "Χαλύβδινο χαλύβδινο",
+          "stainless_steel": "Από ανοξείδωτο χάλυβα",
+          "tungsten_carbide": "Καρβίδιο βολφραμίου",
+          "high_flow_hardened_steel": "σκληρυμένος χάλυβας με μεγάλη ροή",
+          "high_flow_stainless_steel": "από ανοξείδωτο χάλυβα με μεγάλη ροή",
+          "high_flow_tungsten_carbide": "καρβίδιο βολφραμίου με μεγάλη ροή"
         }
       }
     },

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -531,7 +531,39 @@
         "name": "Nozzle type",
         "state": {
           "hardened_steel": "Hardened steel",
-          "stainless_steel": "Stainless steel"
+          "stainless_steel": "Stainless steel",
+          "tungsten_carbide": "Tungsten carbide",
+          "high_flow_hardened_steel": "High flow hardened steel",
+          "high_flow_stainless_steel": "High flow stainless steel",
+          "high_flow_tungsten_carbide": "High flow tungsten carbide"
+        }
+      },
+      "left_nozzle_diameter": {
+        "name": "Left nozzle size"
+      },
+      "left_nozzle_type": {
+        "name": "Left nozzle type",
+        "state": {
+          "hardened_steel": "Hardened steel",
+          "stainless_steel": "Stainless steel",
+          "tungsten_carbide": "Tungsten carbide",
+          "high_flow_hardened_steel": "High flow hardened steel",
+          "high_flow_stainless_steel": "High flow stainless steel",
+          "high_flow_tungsten_carbide": "High flow tungsten carbide"
+        }
+      },
+      "right_nozzle_diameter": {
+        "name": "Right nozzle size"
+      },
+      "right_nozzle_type": {
+        "name": "Right nozzle type",
+        "state": {
+          "hardened_steel": "Hardened steel",
+          "stainless_steel": "Stainless steel",
+          "tungsten_carbide": "Tungsten carbide",
+          "high_flow_hardened_steel": "High flow hardened steel",
+          "high_flow_stainless_steel": "High flow stainless steel",
+          "high_flow_tungsten_carbide": "High flow tungsten carbide"
         }
       },
       "ip_address": {

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -533,9 +533,9 @@
           "hardened_steel": "Hardened steel",
           "stainless_steel": "Stainless steel",
           "tungsten_carbide": "Tungsten carbide",
-          "high_flow_hardened_steel": "hardened steel with large flow",
-          "high_flow_stainless_steel": "stainless steel with large flow",
-          "high_flow_tungsten_carbide": "tungsten carbide with large flow"
+          "high_flow_hardened_steel": "High flow hardened steel",
+          "high_flow_stainless_steel": "High flow stainless steel",
+          "high_flow_tungsten_carbide": "High flow tungsten carbide"
         }
       },
       "left_nozzle_diameter": {
@@ -547,9 +547,9 @@
           "hardened_steel": "Hardened steel",
           "stainless_steel": "Stainless steel",
           "tungsten_carbide": "Tungsten carbide",
-          "high_flow_hardened_steel": "hardened steel with large flow",
-          "high_flow_stainless_steel": "stainless steel with large flow",
-          "high_flow_tungsten_carbide": "tungsten carbide with large flow"
+          "high_flow_hardened_steel": "High flow hardened steel",
+          "high_flow_stainless_steel": "High flow stainless steel",
+          "high_flow_tungsten_carbide": "High flow tungsten carbide"
         }
       },
       "right_nozzle_diameter": {
@@ -561,9 +561,9 @@
           "hardened_steel": "Hardened steel",
           "stainless_steel": "Stainless steel",
           "tungsten_carbide": "Tungsten carbide",
-          "high_flow_hardened_steel": "hardened steel with large flow",
-          "high_flow_stainless_steel": "stainless steel with large flow",
-          "high_flow_tungsten_carbide": "tungsten carbide with large flow"
+          "high_flow_hardened_steel": "High flow hardened steel",
+          "high_flow_stainless_steel": "High flow stainless steel",
+          "high_flow_tungsten_carbide": "High flow tungsten carbide"
         }
       },
       "ip_address": {

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -533,9 +533,9 @@
           "hardened_steel": "Hardened steel",
           "stainless_steel": "Stainless steel",
           "tungsten_carbide": "Tungsten carbide",
-          "high_flow_hardened_steel": "High flow hardened steel",
-          "high_flow_stainless_steel": "High flow stainless steel",
-          "high_flow_tungsten_carbide": "High flow tungsten carbide"
+          "high_flow_hardened_steel": "hardened steel with large flow",
+          "high_flow_stainless_steel": "stainless steel with large flow",
+          "high_flow_tungsten_carbide": "tungsten carbide with large flow"
         }
       },
       "left_nozzle_diameter": {
@@ -547,9 +547,9 @@
           "hardened_steel": "Hardened steel",
           "stainless_steel": "Stainless steel",
           "tungsten_carbide": "Tungsten carbide",
-          "high_flow_hardened_steel": "High flow hardened steel",
-          "high_flow_stainless_steel": "High flow stainless steel",
-          "high_flow_tungsten_carbide": "High flow tungsten carbide"
+          "high_flow_hardened_steel": "hardened steel with large flow",
+          "high_flow_stainless_steel": "stainless steel with large flow",
+          "high_flow_tungsten_carbide": "tungsten carbide with large flow"
         }
       },
       "right_nozzle_diameter": {
@@ -561,9 +561,9 @@
           "hardened_steel": "Hardened steel",
           "stainless_steel": "Stainless steel",
           "tungsten_carbide": "Tungsten carbide",
-          "high_flow_hardened_steel": "High flow hardened steel",
-          "high_flow_stainless_steel": "High flow stainless steel",
-          "high_flow_tungsten_carbide": "High flow tungsten carbide"
+          "high_flow_hardened_steel": "hardened steel with large flow",
+          "high_flow_stainless_steel": "stainless steel with large flow",
+          "high_flow_tungsten_carbide": "tungsten carbide with large flow"
         }
       },
       "ip_address": {

--- a/custom_components/bambu_lab/translations/es.json
+++ b/custom_components/bambu_lab/translations/es.json
@@ -492,7 +492,11 @@
         "name": "Tipo de boquilla",
         "state": {
           "hardened_steel": "Acero endurecido",
-          "stainless_steel": "Acero inoxidable"
+          "stainless_steel": "Acero inoxidable",
+          "tungsten_carbide": "Carburo de tungsteno",
+          "high_flow_hardened_steel": "acero endurecido con flujo grande",
+          "high_flow_stainless_steel": "acero inoxidable con flujo grande",
+          "high_flow_tungsten_carbide": "Carburo de tungsteno con gran flujo"
         }
       },
       "humidity_index": {
@@ -758,6 +762,34 @@
           "normal": "Normal",
           "abnormal": "Anormal",
           "readonly": "Solo lectura"
+        }
+      },
+      "left_nozzle_diameter": {
+        "name": "Tamaño de la boquilla izquierda"
+      },
+      "left_nozzle_type": {
+        "name": "Tipo de boquilla izquierda",
+        "state": {
+          "hardened_steel": "Acero endurecido",
+          "stainless_steel": "Acero inoxidable",
+          "tungsten_carbide": "Carburo de tungsteno",
+          "high_flow_hardened_steel": "acero endurecido con flujo grande",
+          "high_flow_stainless_steel": "acero inoxidable con flujo grande",
+          "high_flow_tungsten_carbide": "Carburo de tungsteno con gran flujo"
+        }
+      },
+      "right_nozzle_diameter": {
+        "name": "Tamaño de la boquilla derecha"
+      },
+      "right_nozzle_type": {
+        "name": "Tipo de boquilla derecha",
+        "state": {
+          "hardened_steel": "Acero endurecido",
+          "stainless_steel": "Acero inoxidable",
+          "tungsten_carbide": "Carburo de tungsteno",
+          "high_flow_hardened_steel": "acero endurecido con flujo grande",
+          "high_flow_stainless_steel": "acero inoxidable con flujo grande",
+          "high_flow_tungsten_carbide": "Carburo de tungsteno con gran flujo"
         }
       }
     },

--- a/custom_components/bambu_lab/translations/fr.json
+++ b/custom_components/bambu_lab/translations/fr.json
@@ -492,7 +492,11 @@
         "name": "Type de buse",
         "state": {
           "hardened_steel": "Acier trempé",
-          "stainless_steel": "Acier inoxydable"
+          "stainless_steel": "Acier inoxydable",
+          "tungsten_carbide": "Carbure de tungstène",
+          "high_flow_hardened_steel": "Acier durci avec un grand débit",
+          "high_flow_stainless_steel": "acier inoxydable avec un grand débit",
+          "high_flow_tungsten_carbide": "carbure de tungstène avec un grand débit"
         }
       },
       "humidity_index": {
@@ -758,6 +762,34 @@
           "normal": "Normale",
           "abnormal": "Anormal",
           "readonly": "Lire uniquement"
+        }
+      },
+      "left_nozzle_diameter": {
+        "name": "Taille de la buse gauche"
+      },
+      "left_nozzle_type": {
+        "name": "Type de buse gauche",
+        "state": {
+          "hardened_steel": "Acier durci",
+          "stainless_steel": "Acier inoxydable",
+          "tungsten_carbide": "Carbure de tungstène",
+          "high_flow_hardened_steel": "Acier durci avec un grand débit",
+          "high_flow_stainless_steel": "acier inoxydable avec un grand débit",
+          "high_flow_tungsten_carbide": "carbure de tungstène avec un grand débit"
+        }
+      },
+      "right_nozzle_diameter": {
+        "name": "Taille de la buse droite"
+      },
+      "right_nozzle_type": {
+        "name": "Type de buse droit",
+        "state": {
+          "hardened_steel": "Acier durci",
+          "stainless_steel": "Acier inoxydable",
+          "tungsten_carbide": "Carbure de tungstène",
+          "high_flow_hardened_steel": "Acier durci avec un grand débit",
+          "high_flow_stainless_steel": "acier inoxydable avec un grand débit",
+          "high_flow_tungsten_carbide": "carbure de tungstène avec un grand débit"
         }
       }
     },

--- a/custom_components/bambu_lab/translations/it.json
+++ b/custom_components/bambu_lab/translations/it.json
@@ -492,7 +492,11 @@
         "name": "Tipo di Ugello",
         "state": {
           "hardened_steel": "Acciaio Temprato",
-          "stainless_steel": "Acciaio Inossidabile"
+          "stainless_steel": "Acciaio Inossidabile",
+          "tungsten_carbide": "Carburo di tungsteno",
+          "high_flow_hardened_steel": "acciaio temprato con grande flusso",
+          "high_flow_stainless_steel": "acciaio inossidabile con grande flusso",
+          "high_flow_tungsten_carbide": "Carburo di tungsteno con grande flusso"
         }
       },
       "humidity_index": {
@@ -758,6 +762,34 @@
           "normal": "Normale",
           "abnormal": "Anormale",
           "readonly": "Solo lettura"
+        }
+      },
+      "left_nozzle_diameter": {
+        "name": "Dimensione dell'ugello sinistro"
+      },
+      "left_nozzle_type": {
+        "name": "Tipo di ugello sinistro",
+        "state": {
+          "hardened_steel": "Acciaio temprato",
+          "stainless_steel": "Acciaio inossidabile",
+          "tungsten_carbide": "Carburo di tungsteno",
+          "high_flow_hardened_steel": "acciaio temprato con grande flusso",
+          "high_flow_stainless_steel": "acciaio inossidabile con grande flusso",
+          "high_flow_tungsten_carbide": "Carburo di tungsteno con grande flusso"
+        }
+      },
+      "right_nozzle_diameter": {
+        "name": "Dimensione giusta dell'ugello"
+      },
+      "right_nozzle_type": {
+        "name": "Tipo di ugello giusto",
+        "state": {
+          "hardened_steel": "Acciaio temprato",
+          "stainless_steel": "Acciaio inossidabile",
+          "tungsten_carbide": "Carburo di tungsteno",
+          "high_flow_hardened_steel": "acciaio temprato con grande flusso",
+          "high_flow_stainless_steel": "acciaio inossidabile con grande flusso",
+          "high_flow_tungsten_carbide": "Carburo di tungsteno con grande flusso"
         }
       }
     },

--- a/custom_components/bambu_lab/translations/ko.json
+++ b/custom_components/bambu_lab/translations/ko.json
@@ -492,7 +492,11 @@
         "name": "노즐 유형",
         "state": {
           "hardened_steel": "경화 강철",
-          "stainless_steel": "스테인리스 강"
+          "stainless_steel": "스테인리스 강",
+          "tungsten_carbide": "텅스텐 카바이드",
+          "high_flow_hardened_steel": "큰 흐름이있는 강화 강철",
+          "high_flow_stainless_steel": "큰 흐름이있는 스테인레스 스틸",
+          "high_flow_tungsten_carbide": "큰 흐름이있는 텅스텐 카바이드"
         }
       },
       "humidity_index": {
@@ -758,6 +762,34 @@
           "normal": "정상",
           "abnormal": "이상",
           "readonly": "만 읽으십시오"
+        }
+      },
+      "left_nozzle_diameter": {
+        "name": "왼쪽 노즐 크기"
+      },
+      "left_nozzle_type": {
+        "name": "왼쪽 노즐 유형",
+        "state": {
+          "hardened_steel": "강화 된 강철",
+          "stainless_steel": "스테인레스 스틸",
+          "tungsten_carbide": "텅스텐 카바이드",
+          "high_flow_hardened_steel": "큰 흐름이있는 강화 강철",
+          "high_flow_stainless_steel": "큰 흐름이있는 스테인레스 스틸",
+          "high_flow_tungsten_carbide": "큰 흐름이있는 텅스텐 카바이드"
+        }
+      },
+      "right_nozzle_diameter": {
+        "name": "오른쪽 노즐 크기"
+      },
+      "right_nozzle_type": {
+        "name": "오른쪽 노즐 유형",
+        "state": {
+          "hardened_steel": "강화 된 강철",
+          "stainless_steel": "스테인레스 스틸",
+          "tungsten_carbide": "텅스텐 카바이드",
+          "high_flow_hardened_steel": "큰 흐름이있는 강화 강철",
+          "high_flow_stainless_steel": "큰 흐름이있는 스테인레스 스틸",
+          "high_flow_tungsten_carbide": "큰 흐름이있는 텅스텐 카바이드"
         }
       }
     },

--- a/custom_components/bambu_lab/translations/nl.json
+++ b/custom_components/bambu_lab/translations/nl.json
@@ -495,7 +495,11 @@
         "name": "Nozzle-type",
         "state": {
           "hardened_steel": "Gehard staal",
-          "stainless_steel": "Roestvast staal"
+          "stainless_steel": "Roestvast staal",
+          "tungsten_carbide": "Wolfraamcarbide",
+          "high_flow_hardened_steel": "gehard staal met grote stroom",
+          "high_flow_stainless_steel": "roestvrij staal met grote stroom",
+          "high_flow_tungsten_carbide": "wolfraamcarbide met grote stroom"
         }
       },
       "ip_address": {
@@ -758,6 +762,34 @@
           "normal": "Normaal",
           "abnormal": "Abnormaal",
           "readonly": "Alleen lezen"
+        }
+      },
+      "left_nozzle_diameter": {
+        "name": "Linker mondstukformaat"
+      },
+      "left_nozzle_type": {
+        "name": "Linker mondstuktype",
+        "state": {
+          "hardened_steel": "Gehard staal",
+          "stainless_steel": "Roestvrij staal",
+          "tungsten_carbide": "Wolfraamcarbide",
+          "high_flow_hardened_steel": "gehard staal met grote stroom",
+          "high_flow_stainless_steel": "roestvrij staal met grote stroom",
+          "high_flow_tungsten_carbide": "wolfraamcarbide met grote stroom"
+        }
+      },
+      "right_nozzle_diameter": {
+        "name": "Juiste mondstukformaat"
+      },
+      "right_nozzle_type": {
+        "name": "Rechter mondstuktype",
+        "state": {
+          "hardened_steel": "Gehard staal",
+          "stainless_steel": "Roestvrij staal",
+          "tungsten_carbide": "Wolfraamcarbide",
+          "high_flow_hardened_steel": "gehard staal met grote stroom",
+          "high_flow_stainless_steel": "roestvrij staal met grote stroom",
+          "high_flow_tungsten_carbide": "wolfraamcarbide met grote stroom"
         }
       }
     },

--- a/custom_components/bambu_lab/translations/pl.json
+++ b/custom_components/bambu_lab/translations/pl.json
@@ -501,7 +501,11 @@
         "name": "Typ dyszy",
         "state": {
           "hardened_steel": "Stal hartowana",
-          "stainless_steel": "Stal nierdzewna"
+          "stainless_steel": "Stal nierdzewna",
+          "tungsten_carbide": "Węglenie wolframowe",
+          "high_flow_hardened_steel": "stalowa stal z dużym przepływem",
+          "high_flow_stainless_steel": "stal nierdzewna z dużym przepływem",
+          "high_flow_tungsten_carbide": "Węglenie wolframowe z dużym przepływem"
         }
       },
       "ip_address": {
@@ -758,6 +762,34 @@
           "normal": "Obecna, OK",
           "abnormal": "Nieprawidłowy",
           "readonly": "Tylko do odczytu"
+        }
+      },
+      "left_nozzle_diameter": {
+        "name": "Lewy rozmiar dyszy"
+      },
+      "left_nozzle_type": {
+        "name": "Lewy typ dyszy",
+        "state": {
+          "hardened_steel": "Stalowa stal",
+          "stainless_steel": "Stal nierdzewna",
+          "tungsten_carbide": "Węglenie wolframowe",
+          "high_flow_hardened_steel": "stalowa stal z dużym przepływem",
+          "high_flow_stainless_steel": "stal nierdzewna z dużym przepływem",
+          "high_flow_tungsten_carbide": "Węglenie wolframowe z dużym przepływem"
+        }
+      },
+      "right_nozzle_diameter": {
+        "name": "Właściwy rozmiar dyszy"
+      },
+      "right_nozzle_type": {
+        "name": "Rzeczy typu dyszy",
+        "state": {
+          "hardened_steel": "Stalowa stal",
+          "stainless_steel": "Stal nierdzewna",
+          "tungsten_carbide": "Węglenie wolframowe",
+          "high_flow_hardened_steel": "stalowa stal z dużym przepływem",
+          "high_flow_stainless_steel": "stal nierdzewna z dużym przepływem",
+          "high_flow_tungsten_carbide": "Węglenie wolframowe z dużym przepływem"
         }
       }
     },

--- a/custom_components/bambu_lab/translations/pt-br.json
+++ b/custom_components/bambu_lab/translations/pt-br.json
@@ -492,7 +492,11 @@
         "name": "Tipo do bico",
         "state": {
           "hardened_steel": "Aço endurecido",
-          "stainless_steel": "Aço inoxidável"
+          "stainless_steel": "Aço inoxidável",
+          "tungsten_carbide": "Carboneto de tungstênio",
+          "high_flow_hardened_steel": "Aço endurecido com grande fluxo",
+          "high_flow_stainless_steel": "Aço inoxidável com grande fluxo",
+          "high_flow_tungsten_carbide": "carboneto de tungstênio com grande fluxo"
         }
       },
       "humidity_index": {
@@ -758,6 +762,34 @@
           "normal": "Normal",
           "abnormal": "Anormal",
           "readonly": "Somente leitura"
+        }
+      },
+      "left_nozzle_diameter": {
+        "name": "Tamanho do bico esquerdo"
+      },
+      "left_nozzle_type": {
+        "name": "Tipo de bico esquerdo",
+        "state": {
+          "hardened_steel": "Aço endurecido",
+          "stainless_steel": "Aço inoxidável",
+          "tungsten_carbide": "Carboneto de tungstênio",
+          "high_flow_hardened_steel": "Aço endurecido com grande fluxo",
+          "high_flow_stainless_steel": "Aço inoxidável com grande fluxo",
+          "high_flow_tungsten_carbide": "carboneto de tungstênio com grande fluxo"
+        }
+      },
+      "right_nozzle_diameter": {
+        "name": "Tamanho do bico direito"
+      },
+      "right_nozzle_type": {
+        "name": "Tipo de bico direito",
+        "state": {
+          "hardened_steel": "Aço endurecido",
+          "stainless_steel": "Aço inoxidável",
+          "tungsten_carbide": "Carboneto de tungstênio",
+          "high_flow_hardened_steel": "Aço endurecido com grande fluxo",
+          "high_flow_stainless_steel": "Aço inoxidável com grande fluxo",
+          "high_flow_tungsten_carbide": "carboneto de tungstênio com grande fluxo"
         }
       }
     },

--- a/custom_components/bambu_lab/translations/pt.json
+++ b/custom_components/bambu_lab/translations/pt.json
@@ -492,7 +492,11 @@
         "name": "Tipo de bico",
         "state": {
           "hardened_steel": "Aço endurecido",
-          "stainless_steel": "Aço inoxidável"
+          "stainless_steel": "Aço inoxidável",
+          "tungsten_carbide": "Carboneto de tungstênio",
+          "high_flow_hardened_steel": "Aço endurecido com grande fluxo",
+          "high_flow_stainless_steel": "Aço inoxidável com grande fluxo",
+          "high_flow_tungsten_carbide": "carboneto de tungstênio com grande fluxo"
         }
       },
       "humidity_index": {
@@ -758,6 +762,34 @@
           "normal": "Normal",
           "abnormal": "Anormal",
           "readonly": "Somente leitura"
+        }
+      },
+      "left_nozzle_diameter": {
+        "name": "Tamanho do bico esquerdo"
+      },
+      "left_nozzle_type": {
+        "name": "Tipo de bico esquerdo",
+        "state": {
+          "hardened_steel": "Aço endurecido",
+          "stainless_steel": "Aço inoxidável",
+          "tungsten_carbide": "Carboneto de tungstênio",
+          "high_flow_hardened_steel": "Aço endurecido com grande fluxo",
+          "high_flow_stainless_steel": "Aço inoxidável com grande fluxo",
+          "high_flow_tungsten_carbide": "carboneto de tungstênio com grande fluxo"
+        }
+      },
+      "right_nozzle_diameter": {
+        "name": "Tamanho do bico direito"
+      },
+      "right_nozzle_type": {
+        "name": "Tipo de bico direito",
+        "state": {
+          "hardened_steel": "Aço endurecido",
+          "stainless_steel": "Aço inoxidável",
+          "tungsten_carbide": "Carboneto de tungstênio",
+          "high_flow_hardened_steel": "Aço endurecido com grande fluxo",
+          "high_flow_stainless_steel": "Aço inoxidável com grande fluxo",
+          "high_flow_tungsten_carbide": "carboneto de tungstênio com grande fluxo"
         }
       }
     },

--- a/custom_components/bambu_lab/translations/sk.json
+++ b/custom_components/bambu_lab/translations/sk.json
@@ -492,7 +492,11 @@
         "name": "Typ trysky",
         "state": {
           "hardened_steel": "Tvrdená oceľ",
-          "stainless_steel": "Nerezová oceľ"
+          "stainless_steel": "Nerezová oceľ",
+          "tungsten_carbide": "Karbid volta",
+          "high_flow_hardened_steel": "kalená oceľ s veľkým prietokom",
+          "high_flow_stainless_steel": "nehrdzavejúca oceľ s veľkým prietokom",
+          "high_flow_tungsten_carbide": "karbid volfrámu s veľkým prietokom"
         }
       },
       "humidity_index": {
@@ -758,6 +762,34 @@
           "normal": "Normálny",
           "abnormal": "Neobvyklý",
           "readonly": "Čítať"
+        }
+      },
+      "left_nozzle_diameter": {
+        "name": "Veľkosť ľavej dýzy"
+      },
+      "left_nozzle_type": {
+        "name": "Typ ľavej trysky",
+        "state": {
+          "hardened_steel": "Zatvrdnutá oceľ",
+          "stainless_steel": "Nehrdzavejúca oceľ",
+          "tungsten_carbide": "Karbid volta",
+          "high_flow_hardened_steel": "kalená oceľ s veľkým prietokom",
+          "high_flow_stainless_steel": "nehrdzavejúca oceľ s veľkým prietokom",
+          "high_flow_tungsten_carbide": "karbid volfrámu s veľkým prietokom"
+        }
+      },
+      "right_nozzle_diameter": {
+        "name": "Pravá veľkosť dýzy"
+      },
+      "right_nozzle_type": {
+        "name": "Typ správnej dýzy",
+        "state": {
+          "hardened_steel": "Zatvrdnutá oceľ",
+          "stainless_steel": "Nehrdzavejúca oceľ",
+          "tungsten_carbide": "Karbid volta",
+          "high_flow_hardened_steel": "kalená oceľ s veľkým prietokom",
+          "high_flow_stainless_steel": "nehrdzavejúca oceľ s veľkým prietokom",
+          "high_flow_tungsten_carbide": "karbid volfrámu s veľkým prietokom"
         }
       }
     },

--- a/custom_components/bambu_lab/translations/th.json
+++ b/custom_components/bambu_lab/translations/th.json
@@ -498,7 +498,11 @@
         "name": "ชนิดหัวฉีด",
         "state": {
           "hardened_steel": "เหล็กแข็ง",
-          "stainless_steel": "สแตนเลส"
+          "stainless_steel": "สแตนเลส",
+          "tungsten_carbide": "ทังสเตนคาร์ไบด์",
+          "high_flow_hardened_steel": "เหล็กแข็งที่มีการไหลขนาดใหญ่",
+          "high_flow_stainless_steel": "สแตนเลสที่มีการไหลขนาดใหญ่",
+          "high_flow_tungsten_carbide": "ทังสเตนคาร์ไบด์ที่มีการไหลขนาดใหญ่"
         }
       },
       "ip_address": {
@@ -758,6 +762,34 @@
           "normal": "ปกติ",
           "abnormal": "ผิดปกติ",
           "readonly": "อ่านเท่านั้น"
+        }
+      },
+      "left_nozzle_diameter": {
+        "name": "ขนาดหัวฉีดซ้าย"
+      },
+      "left_nozzle_type": {
+        "name": "ประเภทหัวฉีดซ้าย",
+        "state": {
+          "hardened_steel": "เหล็กแข็ง",
+          "stainless_steel": "สแตนเลส",
+          "tungsten_carbide": "ทังสเตนคาร์ไบด์",
+          "high_flow_hardened_steel": "เหล็กแข็งที่มีการไหลขนาดใหญ่",
+          "high_flow_stainless_steel": "สแตนเลสที่มีการไหลขนาดใหญ่",
+          "high_flow_tungsten_carbide": "ทังสเตนคาร์ไบด์ที่มีการไหลขนาดใหญ่"
+        }
+      },
+      "right_nozzle_diameter": {
+        "name": "ขนาดหัวฉีดขวา"
+      },
+      "right_nozzle_type": {
+        "name": "ประเภทหัวฉีดขวา",
+        "state": {
+          "hardened_steel": "เหล็กแข็ง",
+          "stainless_steel": "สแตนเลส",
+          "tungsten_carbide": "ทังสเตนคาร์ไบด์",
+          "high_flow_hardened_steel": "เหล็กแข็งที่มีการไหลขนาดใหญ่",
+          "high_flow_stainless_steel": "สแตนเลสที่มีการไหลขนาดใหญ่",
+          "high_flow_tungsten_carbide": "ทังสเตนคาร์ไบด์ที่มีการไหลขนาดใหญ่"
         }
       }
     },

--- a/custom_components/bambu_lab/translations/zh-Hans.json
+++ b/custom_components/bambu_lab/translations/zh-Hans.json
@@ -492,7 +492,11 @@
         "name": "喷嘴类型",
         "state": {
           "hardened_steel": "硬化钢喷嘴",
-          "stainless_steel": "不锈钢喷嘴"
+          "stainless_steel": "不锈钢喷嘴",
+          "tungsten_carbide": "碳化钨",
+          "high_flow_hardened_steel": "硬化钢",
+          "high_flow_stainless_steel": "不锈钢有大流动",
+          "high_flow_tungsten_carbide": "碳化氢碳化物含量大"
         }
       },
       "humidity_index": {
@@ -758,6 +762,34 @@
           "normal": "普通的",
           "abnormal": "异常",
           "readonly": "只读"
+        }
+      },
+      "left_nozzle_diameter": {
+        "name": "左喷嘴大小"
+      },
+      "left_nozzle_type": {
+        "name": "左喷嘴类型",
+        "state": {
+          "hardened_steel": "硬化钢",
+          "stainless_steel": "不锈钢",
+          "tungsten_carbide": "碳化钨",
+          "high_flow_hardened_steel": "硬化钢",
+          "high_flow_stainless_steel": "不锈钢有大流动",
+          "high_flow_tungsten_carbide": "碳化氢碳化物含量大"
+        }
+      },
+      "right_nozzle_diameter": {
+        "name": "正确的喷嘴大小"
+      },
+      "right_nozzle_type": {
+        "name": "正确的喷嘴类型",
+        "state": {
+          "hardened_steel": "硬化钢",
+          "stainless_steel": "不锈钢",
+          "tungsten_carbide": "碳化钨",
+          "high_flow_hardened_steel": "硬化钢",
+          "high_flow_stainless_steel": "不锈钢有大流动",
+          "high_flow_tungsten_carbide": "碳化氢碳化物含量大"
         }
       }
     },

--- a/docs/entities.mdx
+++ b/docs/entities.mdx
@@ -19,13 +19,13 @@ nextTitle: Device Triggers
 
 ## Temperatures
 
-| Sensor        | Notes   |
-| ------------- | ------- |
-| Bed           |         |
-| Target Bed    |         |
-| Chamber       | X1 only |
-| Nozzle        |         |
-| Target Nozzle |         |
+| Sensor           | Notes   |
+| ---------------- | ------- |
+| Bed              |         |
+| Target Bed       |         |
+| Chamber          | X1 only |
+| Nozzle(s)        | Three on H2D (left, right, and active nozzle) |
+| Target Nozzle(s) | Three on H2D (left, right, and active nozzle) |
 
 ## Print Data and Progress
 
@@ -53,8 +53,8 @@ nextTitle: Device Triggers
 
 | Sensor                   | Notes |
 | ------------------------ | ----- |
-| Nozzle Diameters         |       |
-| Nozzle Type              |       |
+| Nozzle Diameter(s)       | Three on H2D (left, right, and active nozzle) |
+| Nozzle Type(s)           | Three on H2D (left, right, and active nozzle) |
 | Speed Profile            |       |
 | Timelapse Active         |       |
 | Extruder Filament Status |       |


### PR DESCRIPTION
## Description

On the H2D, the nozzle diameter and type are in `device["nozzle"]["info"]`, and the nozzle type is a code e.g. HS01. Update pybambu/models.py to parse nozzle info consistent with [Bambu Studio src/slic3r/GUI/DeviceCore/DevNozzleSystem.cpp](https://github.com/bambulab/BambuStudio/blob/v02.02.02.56/src/slic3r/GUI/DeviceCore/DevNozzleSystem.cpp) and add sensors for the left/right nozzles. Consistent with the nozzle temperature entities, the existing sensor names are now that of the active nozzle on H2D.

This is a bug fix for H2D, since the `nozzle_diameter` and `nozzle_type` properties are not accurate on this printer.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

n/a

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [x] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

Added unit tests, verified on H2D with various nozzle changes and left/right switches.

- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

## Additional Notes

New translations are generated with `auto_translate.py`, but I tailored the English strings to try to get a more technically accurate translation. I'm not a proficient speaker or reader of any other languages.
