### PR TITLE
Fix bed/nozzle temperatures to be unavailable when mqtt encryption is enabled unless in developer lan mode.

### DIFF
--- a/custom_components/bambu_lab/fan.py
+++ b/custom_components/bambu_lab/fan.py
@@ -86,9 +86,7 @@ class BambuLabFan(BambuLabEntity, FanEntity):
     @property
     def available(self) -> bool:
         """Is the fan available"""
-        available = True
-        available = available and not self.coordinator.get_model().print_fun.mqtt_signature_required
-        return available
+        return not self.coordinator.get_model().print_fun.mqtt_signature_required
     
     @property
     def is_on(self) -> bool:

--- a/custom_components/bambu_lab/number.py
+++ b/custom_components/bambu_lab/number.py
@@ -104,3 +104,8 @@ class BambuLabNumber(BambuLabEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         await self.entity_description.set_value_fn(self, round(value))
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.entity_description.available_fn(self)

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -1383,7 +1383,6 @@ class PrintJob:
 
         dir_path = Path(directory)
         if not dir_path.is_dir():
-            LOGGER.debug(f"{directory} is not a valid directory")
             return
         
         LOGGER.debug(f"{dir_path}")
@@ -1400,7 +1399,6 @@ class PrintJob:
         # Files to delete: those beyond the 'keep' most recent
         old_files = matching_files[keep:]
 
-        LOGGER.debug(f"{matching_files} {old_files}")
         LOGGER.debug(f"Keeping {keep} files. Deleting {len(old_files)} files.")
         
         for primary_file in old_files:

--- a/custom_components/bambu_lab/pybambu/tests/MOCK-P2S.json
+++ b/custom_components/bambu_lab/pybambu/tests/MOCK-P2S.json
@@ -1,0 +1,602 @@
+{
+  "pushall": {
+      "print": {
+        "3D": {
+          "layer_num": 170,
+          "total_layer_num": 305
+        },
+        "ams": {
+          "ams": [
+            {
+              "dry_time": 0,
+              "humidity": "5",
+              "humidity_raw": "16",
+              "id": "0",
+              "info": "1003",
+              "temp": "38.4",
+              "tray": [
+                {
+                  "bed_temp": "35",
+                  "bed_temp_type": "1",
+                  "cali_idx": -1,
+                  "cols": [
+                    "FFFFFFFF"
+                  ],
+                  "ctype": 0,
+                  "drying_temp": "55",
+                  "drying_time": "8",
+                  "id": "0",
+                  "nozzle_temp_max": "230",
+                  "nozzle_temp_min": "190",
+                  "remain": 41,
+                  "state": 11,
+                  "tag_uid": "8A41A5A600000100",
+                  "total_len": 330000,
+                  "tray_color": "FFFFFFFF",
+                  "tray_diameter": "1.75",
+                  "tray_id_name": "A01-W2",
+                  "tray_info_idx": "GFA01",
+                  "tray_sub_brands": "PLA Matte",
+                  "tray_type": "PLA",
+                  "tray_uuid": "C234B32CD1C14E0587B0CF6BF8753D0F",
+                  "tray_weight": "1000",
+                  "xcam_info": "D007D007E803E8030000803F"
+                },
+                {
+                  "bed_temp": "0",
+                  "bed_temp_type": "0",
+                  "cali_idx": -1,
+                  "cols": [
+                    "000000FF"
+                  ],
+                  "ctype": 0,
+                  "drying_temp": "55",
+                  "drying_time": "8",
+                  "id": "1",
+                  "nozzle_temp_max": "230",
+                  "nozzle_temp_min": "190",
+                  "remain": 39,
+                  "state": 11,
+                  "tag_uid": "6AB846EA00000100",
+                  "total_len": 330000,
+                  "tray_color": "000000FF",
+                  "tray_diameter": "1.75",
+                  "tray_id_name": "A01-K1",
+                  "tray_info_idx": "GFA01",
+                  "tray_sub_brands": "PLA Matte",
+                  "tray_type": "PLA",
+                  "tray_uuid": "15A8808C6AC140F2B84FBAE990AD9E43",
+                  "tray_weight": "1000",
+                  "xcam_info": "A4388813E803E803CDCC4C3F"
+                },
+                {
+                  "bed_temp": "0",
+                  "bed_temp_type": "0",
+                  "cali_idx": -1,
+                  "cols": [
+                    "000000FF"
+                  ],
+                  "ctype": 0,
+                  "drying_temp": "0",
+                  "drying_time": "0",
+                  "id": "2",
+                  "nozzle_temp_max": "240",
+                  "nozzle_temp_min": "190",
+                  "remain": -1,
+                  "state": 11,
+                  "tag_uid": "0000000000000000",
+                  "total_len": 330000,
+                  "tray_color": "000000FF",
+                  "tray_diameter": "1.75",
+                  "tray_id_name": "",
+                  "tray_info_idx": "GFL99",
+                  "tray_sub_brands": "",
+                  "tray_type": "PLA",
+                  "tray_uuid": "00000000000000000000000000000000",
+                  "tray_weight": "0",
+                  "xcam_info": "000000000000000000000000"
+                },
+                {
+                  "bed_temp": "0",
+                  "bed_temp_type": "0",
+                  "cali_idx": -1,
+                  "cols": [
+                    "FFFFFFFF"
+                  ],
+                  "ctype": 0,
+                  "drying_temp": "0",
+                  "drying_time": "0",
+                  "id": "3",
+                  "nozzle_temp_max": "270",
+                  "nozzle_temp_min": "220",
+                  "remain": -1,
+                  "state": 11,
+                  "tag_uid": "0000000000000000",
+                  "total_len": 330000,
+                  "tray_color": "FFFFFFFF",
+                  "tray_diameter": "1.75",
+                  "tray_id_name": "",
+                  "tray_info_idx": "GFG99",
+                  "tray_sub_brands": "",
+                  "tray_type": "PETG",
+                  "tray_uuid": "00000000000000000000000000000000",
+                  "tray_weight": "0",
+                  "xcam_info": "000000000000000000000000"
+                }
+              ]
+            }
+          ],
+          "ams_exist_bits": "1",
+          "ams_exist_bits_raw": "1",
+          "cali_id": 255,
+          "cali_stat": 0,
+          "insert_flag": true,
+          "power_on_flag": false,
+          "tray_exist_bits": "f",
+          "tray_is_bbl_bits": "f",
+          "tray_now": "3",
+          "tray_pre": "3",
+          "tray_read_done_bits": "f",
+          "tray_reading_bits": "0",
+          "tray_tar": "3",
+          "unbind_ams_stat": 0,
+          "version": 282
+        },
+        "ams_rfid_status": 0,
+        "ams_status": 768,
+        "ap_err": 0,
+        "aux": "2801004",
+        "aux_part_fan": false,
+        "batch_id": 0,
+        "bed_target_temper": 70.0,
+        "bed_temper": 70.0,
+        "big_fan1_speed": "0",
+        "big_fan2_speed": "0",
+        "cali_version": 0,
+        "canvas_id": 0,
+        "care": [
+          {
+            "id": "ss",
+            "info": "641864"
+          },
+          {
+            "id": "ls",
+            "info": "82F1861"
+          }
+        ],
+        "cfg": "10017DAB9",
+        "command": "push_status",
+        "cooling_fan_speed": "10",
+        "design_id": "1527213",
+        "device": {
+          "airduct": {
+            "modeCur": 0,
+            "modeFunc": 0,
+            "modeList": [
+              {
+                "ctrl": [
+                  16,
+                  32,
+                  160
+                ],
+                "modeId": 0,
+                "off": []
+              },
+              {
+                "ctrl": [
+                  16,
+                  32
+                ],
+                "modeId": 1,
+                "off": [
+                  160
+                ]
+              }
+            ],
+            "modeVisable": 7,
+            "parts": [
+              {
+                "func": 0,
+                "id": 16,
+                "range": 6553600,
+                "state": 90
+              },
+              {
+                "func": 6,
+                "id": 32,
+                "range": 6553600,
+                "state": 0
+              }
+            ],
+            "subFunc": 0,
+            "subMode": 0,
+            "subVisable": 7,
+            "version": 1
+          },
+          "bed": {
+            "info": {
+              "temp": 4587590
+            },
+            "state": 2
+          },
+          "bed_temp": 4587590,
+          "cam": {
+            "laser": {
+              "cond": 252,
+              "state": 0
+            },
+            "timelapse_path": ""
+          },
+          "ctc": {
+            "info": {
+              "temp": 47
+            },
+            "state": 0
+          },
+          "ext_tool": {
+            "calib": 2,
+            "low_prec": true,
+            "mount": 0,
+            "mount_3d": 0,
+            "th_temp": 0,
+            "type": ""
+          },
+          "extruder": {
+            "info": [
+              {
+                "filam_bak": [],
+                "hnow": 0,
+                "hpre": 0,
+                "htar": 0,
+                "id": 0,
+                "info": 78,
+                "snow": 3,
+                "spre": 3,
+                "star": 3,
+                "stat": 197376,
+                "temp": 16711934
+              }
+            ],
+            "state": 1
+          },
+          "fan": 414976,
+          "holder": null,
+          "laser": {
+            "power": 0
+          },
+          "nozzle": {
+            "exist": 1,
+            "info": [
+              {
+                "color_m": "00000000",
+                "diameter": 0.4,
+                "fila_id": "",
+                "id": 0,
+                "sn": "**REDACTED**",
+                "stat": 0,
+                "tm": 0,
+                "type": "HS01",
+                "wear": 0.0
+              }
+            ],
+            "src_id": 0,
+            "state": 0,
+            "tar_id": 0
+          },
+          "plate": {
+            "base": 0,
+            "cali2d_id": "",
+            "cur_id": "00000",
+            "mat": 0,
+            "tar_id": ""
+          },
+          "type": 1
+        },
+        "err": "0",
+        "fail_reason": "0",
+        "fan_gear": 142,
+        "file": "/data/Metadata/plate_1.gcode",
+        "force_upgrade": false,
+        "fun": "60029FD1A3FF9CB7",
+        "fun2": "1",
+        "gcode_file": "/data/Metadata/plate_1.gcode",
+        "gcode_file_prepare_percent": "100",
+        "gcode_state": "RUNNING",
+        "heatbreak_fan_speed": "15",
+        "hms": [],
+        "home_flag": -1067100737,
+        "hw_switch_state": 3,
+        "info": {
+          "temp": 47
+        },
+        "ipcam": {
+          "agora_service": "disable",
+          "brtc_service": "enable",
+          "bs_state": 0,
+          "cap_pic_enable": "enable",
+          "ipcam_dev": "1",
+          "ipcam_record": "enable",
+          "laser_preview_res": 7,
+          "mode_bits": 2,
+          "resolution": "1080p",
+          "rtsp_url": "disable",
+          "timelapse": "enable",
+          "tl_store_hpd_type": 2,
+          "tl_store_path_type": 2,
+          "tutk_server": "disable"
+        },
+        "job": {
+          "cur_stage": {
+            "idx": 0,
+            "state": 2
+          },
+          "stage": [
+            {
+              "clock_in": false,
+              "color": [
+                ""
+              ],
+              "diameter": [
+                0.4000000059604645
+              ],
+              "est_time": 0,
+              "heigh": 0.0,
+              "idx": 0,
+              "platform": "",
+              "print_then": false,
+              "proc_list": [],
+              "tool": [
+                "HS01"
+              ],
+              "type": 2
+            }
+          ]
+        },
+        "job_attr": 18,
+        "job_id": "0",
+        "lan_task_id": "0",
+        "layer_num": 170,
+        "lights_report": [
+          {
+            "mode": "on",
+            "node": "chamber_light"
+          },
+          {
+            "mode": "flashing",
+            "node": "work_light"
+          }
+        ],
+        "mapping": [
+          3
+        ],
+        "mc_action": 0,
+        "mc_err": 0,
+        "mc_percent": 64,
+        "mc_print_error_code": "0",
+        "mc_print_stage": "2",
+        "mc_print_sub_stage": 0,
+        "mc_remaining_time": 62,
+        "mc_stage": 2,
+        "model_id": "USc92b336e987a46",
+        "msg": 0,
+        "net": {
+          "conf": 16,
+          "info": [
+            {
+              "ip": 3003295936,
+              "mask": 16777215
+            },
+            {
+              "ip": 0,
+              "mask": 0
+            }
+          ]
+        },
+        "nozzle_diameter": "0.4",
+        "nozzle_target_temper": 255.0,
+        "nozzle_temper": 254.0,
+        "nozzle_type": "HS01",
+        "online": {
+          "ahb": true,
+          "version": 6
+        },
+        "percent": 64,
+        "plate_cnt": 1,
+        "plate_id": 1,
+        "plate_idx": 1,
+        "prepare_per": 100,
+        "print_error": 0,
+        "print_gcode_action": 0,
+        "print_real_action": 0,
+        "print_type": "local",
+        "profile_id": "",
+        "project_id": "0",
+        "queue": 0,
+        "queue_est": 0,
+        "queue_number": 0,
+        "queue_sts": 0,
+        "queue_total": 0,
+        "remain_time": 62,
+        "s_obj": [],
+        "sdcard": true,
+        "sequence_id": "6191",
+        "spd_lvl": 2,
+        "spd_mag": 100,
+        "stat": "10002080F0",
+        "state": 4,
+        "stg": [
+          29,
+          2,
+          13,
+          11,
+          4,
+          8,
+          14,
+          3,
+          54,
+          1,
+          255,
+          51
+        ],
+        "stg_cd": 0,
+        "stg_cur": 0,
+        "subtask_id": "",
+        "subtask_name": "Rear Dry Pod AMS 2 PRO ",
+        "t_utc": 1760863314320,
+        "task_id": "6456",
+        "total_layer_num": 305,
+        "upgrade_state": {
+          "ahb_new_version_number": "",
+          "ams_new_version_number": "",
+          "consistency_request": false,
+          "dis_state": 0,
+          "err_code": 0,
+          "ext_new_version_number": "",
+          "force_upgrade": false,
+          "idx": 6,
+          "idx2": 1929307258,
+          "lower_limit": "00.00.00.00",
+          "message": "",
+          "module": "",
+          "new_version_state": 2,
+          "ota_new_version_number": "",
+          "progress": "0",
+          "sequence_id": 0,
+          "sn": "**REDACTED**",
+          "status": "IDLE"
+        },
+        "upload": {
+          "file_size": 0,
+          "finish_size": 0,
+          "message": "Good",
+          "oss_url": "",
+          "progress": 0,
+          "sequence_id": "0903",
+          "speed": 0,
+          "status": "idle",
+          "task_id": "",
+          "time_remaining": 0,
+          "trouble_id": ""
+        },
+        "ver": "20010",
+        "vir_slot": [
+          {
+            "bed_temp": "0",
+            "bed_temp_type": "0",
+            "cali_idx": -1,
+            "cols": [
+              "00000000"
+            ],
+            "ctype": 0,
+            "drying_temp": "0",
+            "drying_time": "0",
+            "id": "255",
+            "nozzle_temp_max": "0",
+            "nozzle_temp_min": "0",
+            "remain": 0,
+            "tag_uid": "0000000000000000",
+            "total_len": 330000,
+            "tray_color": "00000000",
+            "tray_diameter": "1.75",
+            "tray_id_name": "",
+            "tray_info_idx": "",
+            "tray_sub_brands": "",
+            "tray_type": "",
+            "tray_uuid": "00000000000000000000000000000000",
+            "tray_weight": "0",
+            "xcam_info": "000000000000000000000000"
+          }
+        ],
+        "wifi_signal": "-68dBm",
+        "xcam": {
+          "allow_skip_parts": false,
+          "buildplate_marker_detector": true,
+          "cfg": 748983,
+          "first_layer_inspector": true,
+          "halt_print_sensitivity": "medium",
+          "print_halt": true,
+          "printing_monitor": true,
+          "spaghetti_detector": true
+        },
+        "xcam_status": "0"
+      }
+    },
+    "get_version": {
+      "info": {
+        "command": "get_version",
+        "module": [
+          {
+            "flag": 3,
+            "hw_ver": "N/A",
+            "loader_ver": "00.00.00.00",
+            "name": "ota",
+            "product_name": "Bambu Lab P2S",
+            "sn": "MOCK-P2S",
+            "sw_ver": "01.01.00.00",
+            "visible": true
+          },
+          {
+            "flag": 0,
+            "hw_ver": "N3F05",
+            "loader_ver": "00.00.00.00",
+            "name": "n3f/0",
+            "product_name": "AMS 2 Pro (1)",
+            "sn": "MOCK-P2S-AMS-",
+            "sw_ver": "03.00.21.29",
+            "visible": true
+          },
+          {
+            "flag": 0,
+            "hw_ver": "AHB-N703",
+            "loader_ver": "00.00.05.29",
+            "name": "ahb",
+            "product_name": "Filament Buffer - for P2",
+            "sn": "**REDACTED**",
+            "sw_ver": "01.00.11.61",
+            "visible": true
+          },
+          {
+            "flag": 0,
+            "hw_ver": "TH03",
+            "loader_ver": "00.00.00.10",
+            "name": "th",
+            "product_name": "",
+            "sn": "**REDACTED**",
+            "sw_ver": "02.00.20.82",
+            "visible": false
+          },
+          {
+            "flag": 0,
+            "hw_ver": "SMC01",
+            "loader_ver": "00.00.06.03",
+            "name": "smc",
+            "product_name": "",
+            "sn": "**REDACTED**",
+            "sw_ver": "02.00.13.93",
+            "visible": false
+          },
+          {
+            "flag": 0,
+            "hw_ver": "MC06",
+            "loader_ver": "00.01.02.07",
+            "name": "mc",
+            "product_name": "",
+            "sn": "**REDACTED**",
+            "sw_ver": "01.00.69.85",
+            "visible": false
+          },
+          {
+            "flag": 0,
+            "hw_ver": "AP04",
+            "loader_ver": "00.00.01.11",
+            "name": "ap",
+            "product_name": "",
+            "sn": "**REDACTED**",
+            "sw_ver": "00.00.69.32",
+            "visible": false
+          }
+        ],
+        "sequence_id": "0"
+      }
+    }
+}


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
