### PR TITLE
Fix disable SSL verify option in config flow

### DIFF
--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -351,6 +351,7 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         'local_mqtt': True,
                         'region': self.region,
                         'serial': device['dev_id'],
+                        'disable_ssl_verify': user_input['advanced']['disable_ssl_verify'],
                     }
                     bambu = BambuClient(config)
                     result = await bambu.try_connection()
@@ -462,6 +463,7 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 'serial': user_input['serial'],
                 'host': user_input['host'],
                 'local_mqtt': True,
+                'disable_ssl_verify': user_input['advanced']['disable_ssl_verify'],
             }
             bambu = BambuClient(config)
             result = await bambu.try_connection()
@@ -782,6 +784,7 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
                                 'host': user_input['host'],
                                 'local_mqtt': True,
                                 'serial': self._config_entry.data['serial'],
+                                'disable_ssl_verify': user_input['advanced']['disable_ssl_verify'],
                             }
                             bambu = BambuClient(config)
                             result = await bambu.try_connection()


### PR DESCRIPTION
## Description
As I mentioned in #1596 SSL verified failed when adding P2S. Even if the "Disable SSL verification" option is checked, it does not work. Below are the identified reasons:
Every “Try local MQTT” block built a config dict without `disable_ssl_verify`, so the MQTT client still used the default strict TLS context during the connection test, even if the user had checked the advanced option. By adding the flag to those local-test configs, the flow now builds the insecure SSL context immediately, and the option behaves as expected throughout setup.

After the above modifications, my local test shows that checking the "Disable SSL verification" option allows for the normal addition of P2S to the integration.

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

In beta5 adding a "Skip local mqtt connection test" button, already can add P2S. But by this way, camera doesn`s work.
This PR can normal add P2S, and also **camera can work**.

<!-- Add any additional information that reviewers should know -->
