### PR TITLE
Handle malformed json payloads

### DIFF
--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -34,6 +34,7 @@ from .commands import (
     START_PUSH,
 )
 from .tests import MockMQTTClient
+from .utils import safe_json_loads
 
 class WatchdogThread(threading.Thread):
 
@@ -578,12 +579,7 @@ class BambuClient:
                 clean_msg = re.sub(r"False", "false", str(clean_msg))
                 LOGGER.debug(f"Received data: {clean_msg}")
 
-            try:
-                json_data = json.loads(message.payload)
-            except json.JSONDecodeError as e:
-                LOGGER.error(f"Failed to decode JSON message: '{message.payload}'")
-                raise
-            
+            json_data = safe_json_loads(message.payload)
             if json_data.get("event"):
                 # These are events from the bambu cloud mqtt feed and allow us to detect when a local
                 # device has connected/disconnected (e.g. turned on/off)
@@ -725,7 +721,8 @@ class BambuClient:
                     self.client = None
 
         def try_on_message(client, userdata, message):
-            json_data = json.loads(message.payload)
+            json_data = safe_json_loads.loads(message.payload)
+
             # X1 mqtt payload is inconsistent. Adjust it for consistent logging.
             clean_msg = re.sub(r"\\n *", "", str(message.payload))
             # And adjust all payload to be meet proper json syntax instead of being pythonized so I can feed it directly into an online json prettifier

--- a/custom_components/bambu_lab/pybambu/tests/test_utils.py
+++ b/custom_components/bambu_lab/pybambu/tests/test_utils.py
@@ -7,6 +7,7 @@ from typing import Dict, Any, Callable, Optional
 from ..const import (
     LOGGER,
 )
+from ..utils import safe_json_loads
 
 class MqttMessageInfo:
     """Mock MQTT message info object."""
@@ -38,8 +39,9 @@ class MockMQTTClient:
         """Load test payload asynchronously."""
         file_path = os.path.join(os.path.dirname(__file__), f"{mock}.json")
         LOGGER.debug(f"Loading test payload from {mock}.json")
-        with open(file_path, 'r') as f:
-            self._test_payload = json.load(f)
+        with open(file_path, 'rb') as f:
+            raw_bytes = f.read()
+            self._test_payload = safe_json_loads(raw_bytes)
                 
     def connect(self, host: str, port: int = 1883, keepalive: int = 60) -> None:
         """Simulate connecting to an MQTT broker."""

--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -393,3 +393,25 @@ def upgrade_template(url: str) -> dict:
     )
     template["upgrade"]["version"] = version
     return template
+
+def safe_json_loads(raw_bytes):
+
+    # First try to decode it normally for efficiency.
+    try:
+        json_data = json.loads(raw_bytes)
+        return json_data
+    except json.JSONDecodeError as e:
+        pass
+
+    # Double up all backslashes to make JSON valid. Decode as non-utf8 to avoid errors and
+    # the content being modified.
+    text = raw_bytes.decode('latin-1')
+    text = text.replace('\\', '\\\\')
+
+    try:
+        json_data = json.loads(text)
+        return json_data
+    except json.JSONDecodeError as e:
+        LOGGER.error(f"Failed to decode JSON payload: '{text}'")
+        LOGGER.error(f"Exception. Type: {type(e)} Args: {e}")
+        raise


### PR DESCRIPTION
## Description

Sometimes the filament identity has a backslash in it followed by characters that make it an illegal unicode escape sequence and causes the json parsing to fail. Escape errant slashes if we hit that case. AFAIK we can get away with the simple global / -> // replace.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
