### PR TITLE
Reduce excessive caching

### DIFF
--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -8,7 +8,6 @@ import socket
 import re
 
 from datetime import datetime, timedelta, timezone
-from functools import cache
 from urllib3.exceptions import ReadTimeoutError
 from bs4 import BeautifulSoup
 from pathlib import Path


### PR DESCRIPTION
## Description

Caching the entire error file in memory is excessive. And caching an unbounded number of error texts indefinitely when errors are rare and change infrequently is also inappropriate for a rare scenario. Simply caching of the last 8 observed errors is more than enough to avoid repetitive lookups of the same error while a printer is in an error state.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
