### PR TITLE
Ignore AMS sensors data when out of range

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -2618,14 +2618,20 @@ class AMSList:
                 if index not in self.data:
                     self.data[index] = AMSInstance(self._client, "Unknown", index)
 
-                if self.data[index].humidity_index != int(ams['humidity']):
-                    self.data[index].humidity_index = int(ams['humidity'])
+                # Sometimes when the AMS is being powered on it may send bogus humidity and temperature values.
+                # So ignore these values if they are out of a sensible range.
 
-                if self.data[index].humidity != int(ams.get("humidity_raw", 0)):
-                    self.data[index].humidity = int(ams.get("humidity_raw", 0))
+                humidity_index = int(ams['humidity'])
+                if 1 <= humidity_index <= 5 and self.data[index].humidity_index != humidity_index:
+                    self.data[index].humidity_index = humidity_index
 
-                if self.data[index].temperature != float(ams['temp']):
-                    self.data[index].temperature = float(ams['temp'])
+                humidity = int(ams.get("humidity_raw", 0))
+                if 1 <= humidity <= 100 and self.data[index].humidity != humidity:
+                    self.data[index].humidity = humidity
+
+                temperature = float(ams['temp'])
+                if 0 <= temperature <= 100 and self.data[index].temperature != temperature:
+                    self.data[index].temperature = temperature
 
                 if self.data[index].remaining_drying_time != int(ams.get('dry_time', 0)):
                     self.data[index].remaining_drying_time = int(ams.get('dry_time', 0))


### PR DESCRIPTION
## Description

On some printers, when the AMS is being powered on (or cable re-connects) the initial update may report bogus data on the sensors, I had a couple printers that reported 6000ºC, this cause HA graphs to go out of scale.

This PR just ignore the value if it goes outside a sensible range, ex: humidity can't go over 100%,  temperature it should be between 1ºC and 100ºC (AMS HT goes up to 85ºC).

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [X] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

## Additional Notes

I have been using this feature on for months without any issue.
