### PR TITLE
Revert "chore(deps): bump softprops/action-gh-release from 2.4.1 to 2.4.2 in the updates group"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
           zip bambu_lab.zip -r ./
 
       - name: ☁️ Upload zip to release
-        uses: softprops/action-gh-release@v2.4.2
+        uses: softprops/action-gh-release@v2.4.1
         if: ${{ github.event_name == 'release' }}
         with:
           files: "${{ github.workspace }}/custom_components/bambu_lab/bambu_lab.zip"


### PR DESCRIPTION
Reverts greghesp/ha-bambulab#1677

50% failure in releasing probably since this change due to (incorrect) error that no release tag was set.