### PR TITLE
Fix false positive authentication failure issue

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -186,7 +186,7 @@ PRINTER_BINARY_SENSORS: tuple[BambuLabBinarySensorEntityDescription, ...] = (
         translation_key="airduct_mode",
         device_class=BinarySensorDeviceClass.OPENING,
         entity_category=EntityCategory.DIAGNOSTIC,
-        is_on_fn=lambda self: self.coordinator.get_model().info.airduct_mode == False,
+        is_on_fn=lambda self: self.coordinator.get_model().info.airduct_mode == 0,
         exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.AIRDUCT_MODE),
     ),
     BambuLabBinarySensorEntityDescription(


### PR DESCRIPTION
## Description

This was actually caused by Cloudflare passing invalid Brotli encoded data:
```
Received response with content-encoding: br, but failed to decode it.', error("brotli: decoder process called with data when 'can_accept_more_data()' is False")
```
Switched to requesting gzp/deflate compression instead to avoid this cloudflare bug.

Also cleaned up some model data processing that was making unnecessary calls to determine if a printer supported a feature before we had finished the initial version payload acquisition. We don't need to check for the feature being supported to process the mqtt payload - the entities will check if the feature is supported and, if not, it doesn't matter if we saw the related payload or note.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
