### PR TITLE
Defer dead entity cleanup a little

### DIFF
--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -755,7 +755,13 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         await self.hass.config_entries.async_forward_entry_setups(self.config_entry, PLATFORMS)
         LOGGER.debug("_reinitialize_sensors DONE")
 
+        # Allow HA entity platform to finish adding entities before we try to delete dead ones.
+        # Needs to delay two event loop ticks as entity addition is doubly async.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
         # Check for dead entities and clean them up
+        LOGGER.debug("Checking for dead entities to remove")
         self._remove_dead_entities()
 
         # Versions may have changed so update those now that the device and sensors are ready.


### PR DESCRIPTION
## Description

Entity addition is async so I could detect entities as dead before they were properly re-added. There are some very complex ways to try and guarantee ordering. This approach might work and is hugely simpler.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
