### PR TITLE
Less aggressive dead entity cleanup

### DIFF
--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -780,7 +780,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
 
         for entity in entities:
             state = self.hass.states.get(entity.entity_id)
-            if state is None or state.attributes.get("restored") is True:
+            if state is not None and state.attributes.get("restored") is True:
                 LOGGER.debug(f"{entity.entity_id} is DEAD. Removing it.")
                 entity_registry.async_remove(entity.entity_id)
         


### PR DESCRIPTION
## Description

Plausible that on new installs the state is still None after we just added the printer. This is also the case for *really* stale dead entities but that's less important to cleanup that entities that come/go as you make configuration changes or entities I might remove going forward.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
