### PR TITLE
Fix pybambu test runner (no Home Assistant required)

### DIFF
--- a/custom_components/bambu_lab/pybambu/run_tests.sh
+++ b/custom_components/bambu_lab/pybambu/run_tests.sh
@@ -9,11 +9,33 @@ source "$SCRIPT_DIR/venv/bin/activate"
 # Install dependencies
 pip install -r "$SCRIPT_DIR/tests/requirements.txt"
 
-# Change to the parent directory of pybambu (bambu_lab directory)
-cd "$(dirname "$SCRIPT_DIR")"
+# Change to repository root
+cd "$(dirname "$(dirname "$(dirname "$SCRIPT_DIR")")")"
 
-# Run tests with PYTHONPATH set to include the parent directory
-PYTHONPATH="$(pwd)" python3 -m unittest pybambu.tests.test_models pybambu.tests.test_error_lookup -v
+# Run tests.
+# NOTE: Preload the stdlib 'select' module before importing anything from
+# Home Assistant's integration tree to avoid shadowing by platform files like
+# custom_components/bambu_lab/select.py.
+python3 - <<'PY'
+import os
+import sys
+import unittest
+
+import select  # noqa: F401
+
+repo_root = os.getcwd()
+sys.path.insert(0, os.path.join(repo_root, "custom_components", "bambu_lab"))
+
+suite = unittest.defaultTestLoader.loadTestsFromNames(
+	[
+		"pybambu.tests.test_models",
+		"pybambu.tests.test_error_lookup",
+		"pybambu.tests.test_utils",
+	]
+)
+result = unittest.TextTestRunner(verbosity=2).run(suite)
+sys.exit(0 if result.wasSuccessful() else 1)
+PY
 
 # Deactivate virtual environment
 deactivate


### PR DESCRIPTION
## Description

Fix pybambu’s _run_tests.sh_ so the unit tests can be run locally without Home Assistant installed.  

This addresses a common import failure caused by Python stdlib module shadowing (e.g., the integration’s platform file select.py can shadow stdlib select during imports). 
The test runner now ensures stdlib select is loaded first and loads tests as the pybambu.tests.* package so relative imports work.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

N/A

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

Testing performed:

`bash custom_components/bambu_lab/pybambu/run_tests.sh` (29 tests)

## Additional Notes

This change is intentionally limited to developer tooling (test runner behavior only) and does not change runtime integration behavior in Home Assistant.

