### PR TITLE
Fixes for hybrid mqtt mode

### DIFF
--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -256,11 +256,6 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
                 self._report_encryption_enabled_issue(True)
                 return False
 
-            if self.get_model().info.is_hybrid_mode_blocking:
-                LOGGER.error("Printer is in hybrid connection mode. All control actions sent to local mqtt are blocked.")
-                self._report_hybrid_mode_blocking_issue(True)
-                return False
-
         future = self._hass.data[DOMAIN]['service_call_future']
         if future is None:
             LOGGER.error("Future is None")
@@ -515,7 +510,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
 
         if entity_unique_id.endswith('_external_spool'):
             ams_index = 255
-            tray_index = 254
+            tray_index = 0
         elif not self.get_model().supports_feature(Features.AMS):
             LOGGER.error(f"AMS not available")
             return False
@@ -960,7 +955,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         if force:
             # Delete issue so we can re-create it but only ever have one in the list.
             if existing_issue is not None:
-                registry.async_delete_issue(domain=DOMAIN, issue_id=issue_id)
+                issue_registry.async_delete_issue(domain=DOMAIN, issue_id=issue_id)
         else:
             if existing_issue is not None:
                 # Issue already exists, no need to create it again

--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -80,6 +80,8 @@ def to_whole(number):
 
 def get_filament_name(idx, custom_filaments: dict):
     """Converts a filament idx to a human-readable name"""
+    if idx == "":
+        return "Empty"
     result = FILAMENT_NAMES.get(idx, "unknown")
     if result == "unknown" and idx != "":
         custom = custom_filaments.get(idx, None)


### PR DESCRIPTION
## Description

- Fixes for hybrid connection mode as some control is still allowed
- Add a placeholder ! image if the rtsp feed fails as HA will ask for a static image and log errors if told it's unsupported.
- Fix handling of print spool updates when delta mqtt payloads are seen in local mqtt mode
- Fix syntax errors when mid-nozzle switch on H2 printers.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
