### PR TITLE
Update unload_filament to take in entity_id instead of device_id to f…

### DIFF
--- a/custom_components/bambu_lab/services.yaml
+++ b/custom_components/bambu_lab/services.yaml
@@ -178,7 +178,7 @@ unload_filament:
   name: Unload filament
   description: Unload the filament currently loaded into the extruder
   fields:
-    device_id:
+    entity_id:
       name: AMS or External Spool device
       required: true
       selector:


### PR DESCRIPTION
…ix regression from November

## Description

Fix to unload filament from when it was swapped to entity_id, but the definition was not updated

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
