### PR TITLE
Fix empty tray detection for real-time updates

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -2696,24 +2696,11 @@ class AMSTray:
     def print_update(self, data) -> bool:
         old_data = f"{self.__dict__}"
 
-        self.idx = data.get('tray_info_idx', self.idx)
-        self.name = get_filament_name(self.idx, self._client.slicer_settings.custom_filaments)
-        self.type = data.get('tray_type', self.type)
-        if self.name == "unknown":
-            # Fallback to the type if the name is unknown
-            self.name = self.type
-        self.sub_brands = data.get('tray_sub_brands', self.sub_brands)
-        self.color = data.get('tray_color', self.color)
-        self.nozzle_temp_min = data.get('nozzle_temp_min', self.nozzle_temp_min)
-        self.nozzle_temp_max = data.get('nozzle_temp_max', self.nozzle_temp_max)
-        self._remain = data.get('remain', self._remain)
-        self.tag_uid = data.get('tag_uid', self.tag_uid)
-        self.tray_uuid = data.get('tray_uuid', self.tray_uuid)
-        self.k = data.get('k', self.k)
-        self.tray_weight = data.get('tray_weight', self.tray_weight)
+        # Check for empty tray FIRST, before processing other fields.
+        # Empty trays lack filament information (no tray_type, no tray_info_idx).
+        # They typically only contain 'id' and 'state' fields.
+        self.empty = ('tray_type' not in data) and ('tray_info_idx' not in data)
 
-        # If the data is just the id, then the tray is empty.
-        self.empty = (len(data) == 1) and ('id' in data)
         if self.empty:
             self.idx = ""
             self.name = "Empty"
@@ -2727,6 +2714,22 @@ class AMSTray:
             self.tray_uuid = ""
             self.k = 0
             self.tray_weight = 0
+        else:
+            self.idx = data.get('tray_info_idx', self.idx)
+            self.name = get_filament_name(self.idx, self._client.slicer_settings.custom_filaments)
+            self.type = data.get('tray_type', self.type)
+            if self.name == "unknown":
+                # Fallback to the type if the name is unknown
+                self.name = self.type
+            self.sub_brands = data.get('tray_sub_brands', self.sub_brands)
+            self.color = data.get('tray_color', self.color)
+            self.nozzle_temp_min = data.get('nozzle_temp_min', self.nozzle_temp_min)
+            self.nozzle_temp_max = data.get('nozzle_temp_max', self.nozzle_temp_max)
+            self._remain = data.get('remain', self._remain)
+            self.tag_uid = data.get('tag_uid', self.tag_uid)
+            self.tray_uuid = data.get('tray_uuid', self.tray_uuid)
+            self.k = data.get('k', self.k)
+            self.tray_weight = data.get('tray_weight', self.tray_weight)
 
         return (old_data != f"{self.__dict__}")
 


### PR DESCRIPTION
## Description

The v2.2.20-beta1 fix for empty tray detection works on integration reload but not during real-time MQTT updates.                                                        
                                                                                                                                                                           
Root cause: The current check (len(data) == 1) and ('id' in data) fails because empty trays send 2 fields (id and state), not 1. Additionally, data.get('field', self.field) fallbacks retain stale filament data when trays become empty.

MQTT evidence - Empty tray message from printer:
{"id": "3", "state": 10}                                                                                                                                                 
                                                                                                                                                                         
This fix:                                                                                                                                                                
1. Detects empty by checking for absence of filament data: ('tray_type' not in data) and ('tray_info_idx' not in data)                                                   
2. Processes empty check FIRST before other field updates                                                                                                                
3. Explicitly resets all fields to empty defaults when tray is empty                                                                                                     
4. Only updates filament fields in the else branch when tray contains a spool

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

https://github.com/greghesp/ha-bambulab/issues/1848

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

 Manually tested on X1C in cloud mode:                                                                                                                                    
  - Physically removed spool → tray immediately shows "Empty" in HA (real-time)                                                                                            
  - Inserted spool → tray correctly populates filament info (real-time)                                                                                                    
  - Integration reload → correct state preserved                                                                                                                           
  - No regressions observed

## Additional Notes

<!-- Add any additional information that reviewers should know -->

The reason reload worked but real-time didn't: On reload, AMSTray objects are re-created with empty defaults in __init__, so stale data wasn't an issue. During real-time MQTT updates, existing objects retained previous values due to the data.get('field', self.field) fallback pattern. 
