### PR TITLE
Revise 3MF printing instructions and file path

### DIFF
--- a/docs/actions.mdx
+++ b/docs/actions.mdx
@@ -43,13 +43,12 @@ or not so before invoking this action, you should check the printer state to ens
 ## Print 3MF project file
 
 <Property name="action" type="bambu_lab.print_project_file" required>
-Prints 3MF file stored on SD card. 3MF file must be stored on SD card root and it must contain gcode (e.g., "Export sliced file" from slicer)
-
-    ```yaml
+Prints 3MF file stored on SD card. 3MF file must be stored on SD card root and it must contain gcode (e.g., "Export sliced file" from Bambu Studio). Note: Bambu Studio outputs files with the extension ".gcode.3mf" both for local export and when sending via LAN mode.
+```yaml
     action: bambu_lab.print_project_file
     data:
       device_id: a1b2c3d4e5f6g7h8i9j0
-      filepath: cache/filename.3mf
+      filepath: filename.gcode.3mf
       plate: 1
       timelapse: true
       bed_leveling: false


### PR DESCRIPTION
Updated description for printing 3MF files and corrected file path.

## Description

1.Removed "cache/" from the filepath - The file is at the SD card root, not in a cache folder.
2.Changed the file extension from ".3mf" to ".gcode.3mf" - Bambu Studio actually exports files with the ".gcode.3mf" extension, both for local export and when sending to printer in LAN mode.
3.Added an explanatory note - Clarified that Bambu Studio outputs ".gcode.3mf" files in both export scenarios.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

## Documentation

- [x] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed


