### PR TITLE
Fix broken card registration with 2026.2

### DIFF
--- a/custom_components/bambu_lab/frontend/__init__.py
+++ b/custom_components/bambu_lab/frontend/__init__.py
@@ -20,9 +20,11 @@ class BambuLabCardRegistration:
         self.hass = hass
 
     @property
-    def lovelace_mode(self):
+    def lovelace_resource_mode(self):
         ha_version = parse(__version__)
-        if (ha_version.major >= 2026) or ((ha_version.major == 2025) and (ha_version.minor >= 2)):
+        if (ha_version.major >= 2026) and (ha_version.minor >= 2):
+            return self.hass.data["lovelace"].resource_mode
+        elif (ha_version.major >= 2026) or ((ha_version.major == 2025) and (ha_version.minor >= 2)):
             return self.hass.data["lovelace"].mode
         else:
             return self.hass.data["lovelace"]["mode"]
@@ -37,7 +39,7 @@ class BambuLabCardRegistration:
 
     async def async_register(self):
         await self.async_register_bambu_path()
-        if self.lovelace_mode == "storage":
+        if self.lovelace_resource_mode == "storage":
             await self.async_wait_for_lovelace_resources()
 
     # install card 
@@ -114,7 +116,7 @@ class BambuLabCardRegistration:
 
     async def async_unregister(self):
         # Unload lovelace module resource
-        if self.lovelace_mode == "storage":
+        if self.lovelace_resource_mode == "storage":
             for card in BAMBU_LAB_CARDS:
                 url = f"{URL_BASE}/{card.get("filename")}"
                 bambu_resources = [


### PR DESCRIPTION
## Description

In 2026.2, the parameter has been renamed to `resource_mode` as it now only have effect on the resources as the default yaml dashboard configuration is gone.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

I tested on my instance using 2026.2.0b1 version.

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
