### PR TITLE
Fix: Robust version comparison to handle non-numeric suffixes

### DIFF
--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -320,12 +320,24 @@ def get_sw_version(modules, default):
         return ota.get("sw_ver")
     return default
 
+def safe_int(part):
+    """Safely convert a version string segment to an integer."""
+    try:
+        return int(part)
+    except ValueError:
+        # Extract leading digits for version parts like '0b1' or '1a2'
+        match = re.match(r'^\d+', part)
+        if match:
+            return int(match.group(0))
+        return 0
+
+
 def compare_version(version_max, version_min):
     if version_max == "unknown":
         # Happens unavoidably during startup when we don't yet know the current printer firmware version.
         return False
-    maxver = list(map(int, version_max.split('.')))
-    minver = list(map(int, version_min.split('.')))
+    maxver = list(map(safe_int, version_max.split('.')))
+    minver = list(map(safe_int, version_min.split('.')))
 
     # Returns 1 if max > min, -1 if max < min, 0 if equal
     return (maxver > minver) - (maxver < minver)


### PR DESCRIPTION
## Description

Fixes an issue where Home Assistant beta versions caused a ValueError during version comparison in the custom component's setup, by ensuring version segments are safely parsed as integers.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

https://github.com/greghesp/ha-bambulab/issues/1866

## Documentation

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

## Additional Notes
