### PR TITLE
feat: add options for retry/done loading filament

### DIFF
--- a/custom_components/bambu_lab/__init__.py
+++ b/custom_components/bambu_lab/__init__.py
@@ -404,6 +404,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "move_axis": SupportsResponse.NONE,
         "unload_filament": SupportsResponse.NONE,
         "load_filament": SupportsResponse.NONE,
+        "retry_load_filament": SupportsResponse.NONE,
+        "done_load_filament": SupportsResponse.NONE,
         "extrude_retract": SupportsResponse.ONLY,
         "set_filament": SupportsResponse.NONE,
         "get_filament_data": SupportsResponse.ONLY,

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -57,6 +57,8 @@ from .pybambu.commands import (
     AMS_READ_RFID_TEMPLATE,
     AMS_READ_RFID_GCODE,
     AMS_FILAMENT_DRYING_TEMPLATE,
+    RETRY_LOAD_FILAMENT_TEMPLATE,
+    DONE_LOAD_FILAMENT_TEMPLATE
 )
 
 class BambuDataUpdateCoordinator(DataUpdateCoordinator):
@@ -272,6 +274,10 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
                 result = self._service_call_extrude_retract(data)
             case "load_filament":
                 result = self._service_call_load_filament(data)
+            case "retry_load_filament":
+                result = self._service_call_retry_load_filament(data)
+            case "done_load_filament":
+                result = self._service_call_done_load_filament(data)
             case "unload_filament":
                 result = self._service_call_unload_filament(data)
             case "set_filament":
@@ -573,6 +579,14 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
                 combined_data[filament_id] = filament_data
         
         return combined_data
+
+    def _service_call_retry_load_filament(self, data: dict):
+        command = RETRY_LOAD_FILAMENT_TEMPLATE
+        self.client.publish(command)
+    
+    def _service_call_done_load_filament(self, data: dict):
+        command = DONE_LOAD_FILAMENT_TEMPLATE
+        self.client.publish(command)
 
     def _service_call_load_filament(self, data: dict):
         ams_device, entity_id = self._get_ams_device_and_tray(data)

--- a/custom_components/bambu_lab/pybambu/commands.py
+++ b/custom_components/bambu_lab/pybambu/commands.py
@@ -85,6 +85,23 @@ SKIP_OBJECTS_TEMPLATE = {
     }
 }
 
+RETRY_LOAD_FILAMENT_TEMPLATE = {
+    "print": {
+        "sequence_id": "0",
+        "command": "ams_control",
+        "param": "resume"
+    }
+}
+
+
+DONE_LOAD_FILAMENT_TEMPLATE = {
+    "print": {
+        "sequence_id": "0",
+        "command": "ams_control",
+        "param": "done"
+    }
+}
+
 SWITCH_AMS_TEMPLATE = {
     "print": {
         "command": "ams_change_filament",

--- a/custom_components/bambu_lab/services.yaml
+++ b/custom_components/bambu_lab/services.yaml
@@ -174,6 +174,14 @@ extrude_retract:
       selector:
         boolean:
 
+retry_load_filament:
+  name: Retry loading external filament
+  description: Retry loading external filament
+
+done_load_filament:
+  name: Finish loading external filament
+  description: Once loading external filament is done, use this action to signal that to the printer.
+
 unload_filament:
   name: Unload filament
   description: Unload the filament currently loaded into the extruder

--- a/docs/actions.mdx
+++ b/docs/actions.mdx
@@ -167,6 +167,30 @@ Prints 3MF file stored on SD card. 3MF file must be stored on SD card root and i
   </Accordion>
 </Property>
 
+## Retry loading filament from external spool
+
+<Property name="action" type="bambu_lab.retry_load_filament" required>
+  Retry loading filament from external spool.
+
+    ```yaml
+    action: bambu_lab.retry_load_filament
+    data:
+      device_id: a1b2c3d4e5f6g7h8i9j0
+    ```
+</Property>
+
+## Finish loading filament from external spool
+
+<Property name="action" type="bambu_lab.done_load_filament" required>
+  Once loading filemant from external spool is finished, use this action to tell the printer you are done. Otherwise it will go into error mode.
+
+    ```yaml
+    action: bambu_lab.done_load_filament
+    data:
+      device_id: a1b2c3d4e5f6g7h8i9j0
+    ```
+</Property>
+
 ## Unload Filament
 
 <Property name="action" type="bambu_lab.unload_filament" required>


### PR DESCRIPTION
## Description

This solves #1041
Two new actions are provided. One for retry loading filament and one for finish loading filament.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->
#1041 

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [X] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
