### PR TITLE
Change start and end time sensor type to datetime

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -476,6 +476,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         key="start_time",
         translation_key="start_time",
         icon="mdi:clock",
+        device_class=SensorDeviceClass.TIMESTAMP,
         available_fn=lambda self: self._start_time_avail_fn(),
         value_fn=lambda self: self._start_time_value_fn(),
         is_restoring=True,
@@ -494,8 +495,9 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         key="end_time",
         translation_key="end_time",
         icon="mdi:clock",
+        device_class=SensorDeviceClass.TIMESTAMP,
         available_fn=lambda self: self.coordinator.get_model().print_job.end_time is not None,
-        value_fn=lambda self: dt_util.as_local(self.coordinator.get_model().print_job.end_time).replace(tzinfo=None),
+        value_fn=lambda self: dt_util.as_utc(self.coordinator.get_model().print_job.end_time),
     ),
     BambuLabSensorEntityDescription(
         key="total_usage_hours",

--- a/custom_components/bambu_lab/sensor.py
+++ b/custom_components/bambu_lab/sensor.py
@@ -135,23 +135,23 @@ class BambuLabRestoreSensor(BambuLabSensor, RestoreEntity):
         model = self.coordinator.get_model()
         live_value = model.print_job.start_time
         if live_value is not None:
-            return dt_util.as_local(live_value).replace(tzinfo=None)
+            return dt_util.as_utc(live_value)
         job = model.print_job
         is_printing = job.gcode_state.lower() in ("running", "pause")
         has_end_time = job.end_time is not None
         is_lan_mode = model.info.mqtt_mode == "local"
         if is_printing and is_lan_mode and has_end_time and self._restored_state is not None:
-            if isinstance(self._restored_state, str):
-                try:
-                    dt_value = dt_util.parse_datetime(self._restored_state)
-                    if dt_value.tzinfo is None:
-                        dt_value = dt_value.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
-                    job.start_time = dt_value
-                    LOGGER.debug(f"LAN Mode: Injected restored start_time into pybambu: {dt_value}")
-                except (ValueError, TypeError):
-                    LOGGER.error("Failed to parse restored start_time string for pybambu")
-                    return None
-            return self._restored_state
+            try:
+                dt_value = dt_util.parse_datetime(str(self._restored_state))
+                if dt_value.tzinfo is None:
+                    dt_value = dt_value.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+                dt_value = dt_util.as_utc(dt_value)
+                job.start_time = dt_value
+                LOGGER.debug(f"LAN Mode: Injected restored start_time into pybambu: {dt_value}")
+            except (ValueError, TypeError, AttributeError):
+                LOGGER.error("Failed to parse restored start_time string for pybambu")
+                return None
+            return dt_value
         return None
 
 


### PR DESCRIPTION
## Description

Using Codex, I changed the device class of the start time and end time entities to Timestamp. I tested it locally and the integration works the same, and the start and end times now properly display as relative time.

I marked the type of change as breaking, as it might break things that rely on the state being a string.

Note: I used Codex to make these modifications and I tried to keep the changes as small as possible to make review easier.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

[<!-- Provide a link to the Github issue if applicable -->](https://github.com/issues/created?issue=greghesp%7Cha-bambulab%7C1958)

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [X] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
