### PR TITLE
feat: add Bambu Lab X2D printer support

### DIFF
--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -22,6 +22,7 @@ class Printers(StrEnum):
     X1E = "X1E"
     X1C = "X1C"
     X1 = "X1"
+    X2D = "X2D"
 
 class WikiPrinterTag(StrEnum):
     A1 = "a1"
@@ -36,6 +37,7 @@ class WikiPrinterTag(StrEnum):
     X1E = "x1"
     X1C = "x1"
     X1 = "x1"
+    X2D = "x2"
 
 class Features(IntEnum):
     AUX_FAN = 1,

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -166,7 +166,7 @@ class Device:
         # processing the mqtt payload and so may be called before full initialization is complete as it processes
         # the very first payload.
         if feature == Features.CAMERA_RTSP:
-            return model in (h2_printers | p2_printers | x1_printer | x1e_printer)
+            return model in (h2_printers | p2_printers | x1_printer | x1e_printer | {Printers.X2D})
         elif feature == Features.CAMERA_IMAGE:
             return model in (a1_printers | p1_printers)
         elif feature == Features.SUPPORTS_EARLY_FTP_DOWNLOAD:
@@ -186,7 +186,7 @@ class Device:
             # flag would largely be good though but not accessible here.
             return model not in a1_printers
         elif feature == Features.CHAMBER_TEMPERATURE:
-            return model in (h2_printers | p2_printers | x1_printer | x1e_printer)
+            return model in (h2_printers | p2_printers | x1_printer | x1e_printer | {Printers.X2D})
         elif feature == Features.AMS:
             return len(self.ams.data) != 0
         elif feature == Features.K_VALUE:

--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -294,6 +294,9 @@ def get_printer_type(modules, default):
     if len(search(modules, lambda x: x.get('product_name', "") == "Bambu Lab H2S")):
       return 'H2S'
 
+    if len(search(modules, lambda x: x.get('product_name', "") == "Bambu Lab X2D")):
+      return 'X2D'
+
     apNode = search(modules, lambda x: x.get('hw_ver', "").find("AP0") == 0)
     if len(apNode.keys()) > 1:
         hw_ver = apNode['hw_ver']
@@ -307,6 +310,8 @@ def get_printer_type(modules, default):
                 return 'P1P'
             if project_name == 'C12':
                 return 'P1S'
+            if project_name == '':
+                return 'X2D'  # X2D reports AP04 with empty project_name via local MQTT
         elif hw_ver == 'AP05':
             if project_name == 'N2S':
                 return 'A1'


### PR DESCRIPTION
## Summary

The Bambu Lab X2D was released in April 2026 and is not recognized by the integration. This PR adds the minimal changes needed for the X2D to connect and report data correctly.

### What breaks without this PR

When a user tries to add an X2D, the integration logs `UNKNOWN DEVICE: hw_ver='AP04' / project_name=''` and the connection times out after 10 seconds. The printer cannot be added at all.

### Changes

**`pybambu/const.py`**
- Add `X2D = "X2D"` to the `Printers` enum
- Add `X2D = "x2"` to the `WikiPrinterTag` enum

**`pybambu/utils.py`** — two detection paths in `get_printer_type()`:
1. **Cloud MQTT path**: The X2D's OTA module reports `product_name = "Bambu Lab X2D"`, so a product_name match is added alongside the existing H2S/H2D/etc. checks.
2. **Local MQTT path**: The X2D reports `hw_ver = "AP04"` with an empty `project_name` — the same hw_ver as P1P/P1S but distinguishable by the empty project_name field. A fallback is added inside the `elif hw_ver == 'AP04':` block.

**`pybambu/models.py`** — add X2D to two feature sets in `supports_feature()`:
- `CAMERA_RTSP`: X2D has a camera (though see note below on BRTC)
- `CHAMBER_TEMPERATURE`: X2D has a chamber temperature sensor

### Camera note

The X2D sends `"rtsp_url": "disable"` alongside `"brtc_service": "enable"` in its MQTT push data — identical to the P2S and H2C. Enabling "LAN Only Liveview" on the printer does not change this. The X2D camera uses the BRTC protocol exclusively and will not produce a camera entity until BRTC support is added to the integration. This is a known limitation shared with P2S and H2C.

### SSL note

The X2D uses a self-signed certificate for local MQTT. Users connecting via local MQTT will need to enable **Disable SSL Verify** in the integration's Advanced options.

### Tested with

- Physical X2D (serial `20P9AJ611401532`) connecting via Bambu Cloud MQTT
- Integration version 2.2.21, Home Assistant 2026.4.x
- All 63 entities (sensors, binary sensors, AMS, external spool, lights, switches, images) confirmed working after connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)