### PR TITLE
Define stages 67-76

### DIFF
--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -151,6 +151,16 @@ CURRENT_STAGE_IDS = {
     64: "preparing_hotend",
     65: "calibrating_detection_nozzle_clumping",
     66: "purifying_chamber_air",
+    67: "measuring_rotary_attachment",
+    68: "moving_toolhead_above_purge_chute",
+    69: "cooling_nozzle",
+    70: "moving_toolhead_to_center_of_heatbed",
+    71: "active_arc_fitting",
+    72: "hotend_type_detection",
+    73: "build_plate_alignment_detection",
+    74: "heatbed_surface_foreign_object_detection",
+    75: "heatbed_underside_foreign_object_detection",
+    76: "pre_extrusion_before_printing",
     77: "preparing_ams",
     # X1 returns -1 for idle
     -1: "idle",  # DUPLICATED

--- a/custom_components/bambu_lab/translations/ca.json
+++ b/custom_components/bambu_lab/translations/ca.json
@@ -462,7 +462,17 @@
           "preparing_hotend": "Preparant hotend",
           "calibrating_detection_nozzle_clumping": "Calibració de la posició de detecció de l'aglomeració del broquet",
           "purifying_chamber_air": "Purificant l'aire de la cambra",
-          "preparing_ams": "Preparant AMS"
+          "preparing_ams": "Preparant AMS",
+          "measuring_rotary_attachment": "Acoblament rotatiu de mesura",
+          "moving_toolhead_above_purge_chute": "Cap d'eina en moviment per sobre del canal de purga",
+          "cooling_nozzle": "Broquet de refrigeració",
+          "moving_toolhead_to_center_of_heatbed": "Moveu el cap d'eina al centre del llit calent",
+          "active_arc_fitting": "Encaix d'arc actiu",
+          "hotend_type_detection": "Detecció de tipus hotend",
+          "build_plate_alignment_detection": "Construeix detecció d'alineació de plaques",
+          "heatbed_surface_foreign_object_detection": "Detecció d'objectes estranys a la superfície del llit calent",
+          "heatbed_underside_foreign_object_detection": "Detecció d'objectes estranys a la part inferior del llit calent",
+          "pre_extrusion_before_printing": "Pre-extrusió abans de la impressió"
         }
       },
       "print_progress": {

--- a/custom_components/bambu_lab/translations/cs.json
+++ b/custom_components/bambu_lab/translations/cs.json
@@ -477,7 +477,17 @@
           "preparing_hotend": "Příprava hotendu",
           "calibrating_detection_nozzle_clumping": "Kalibrace polohy detekce shlukování trysky",
           "purifying_chamber_air": "Čistící komorový vzduch",
-          "preparing_ams": "Příprava AMS"
+          "preparing_ams": "Příprava AMS",
+          "measuring_rotary_attachment": "Měřící otočný nástavec",
+          "moving_toolhead_above_purge_chute": "Přesouvání nástrojové hlavy nad čistící skluz",
+          "cooling_nozzle": "Chladicí tryska",
+          "moving_toolhead_to_center_of_heatbed": "Přesunutí nástrojové hlavy do středu vyhřívaného lože",
+          "active_arc_fitting": "Aktivní oblouková armatura",
+          "hotend_type_detection": "Detekce typu Hotend",
+          "build_plate_alignment_detection": "Detekce zarovnání desky sestavení",
+          "heatbed_surface_foreign_object_detection": "Detekce cizích předmětů na povrchu vyhřívané podložky",
+          "heatbed_underside_foreign_object_detection": "Detekce cizích předmětů na spodní straně vyhřívané podložky",
+          "pre_extrusion_before_printing": "Předběžné vytlačování před tiskem"
         }
       },
       "sdcard_status": {

--- a/custom_components/bambu_lab/translations/da.json
+++ b/custom_components/bambu_lab/translations/da.json
@@ -462,7 +462,17 @@
           "preparing_hotend": "Forbereder hotend",
           "calibrating_detection_nozzle_clumping": "Kalibrering af detekteringspositionen for dyseklumpning",
           "purifying_chamber_air": "Rensende kammerluft",
-          "preparing_ams": "Forberedelse af AMS"
+          "preparing_ams": "Forberedelse af AMS",
+          "measuring_rotary_attachment": "Måling af roterende tilbehør",
+          "moving_toolhead_above_purge_chute": "Bevægelse af værktøjshoved over skylleskakt",
+          "cooling_nozzle": "Kølemundstykke",
+          "moving_toolhead_to_center_of_heatbed": "Flytning af værktøjshovedet til midten af ​​heatbed",
+          "active_arc_fitting": "Aktiv lysbue fitting",
+          "hotend_type_detection": "Hotend type detektion",
+          "build_plate_alignment_detection": "Detektion af byggepladejustering",
+          "heatbed_surface_foreign_object_detection": "Detektering af fremmedlegemer på varmebedets overflade",
+          "heatbed_underside_foreign_object_detection": "Detektering af fremmedlegemer under varmebed",
+          "pre_extrusion_before_printing": "Præ-ekstrudering før trykning"
         }
       },
       "print_progress": {

--- a/custom_components/bambu_lab/translations/de.json
+++ b/custom_components/bambu_lab/translations/de.json
@@ -462,7 +462,17 @@
           "preparing_hotend": "Hotend wird vorbereitet",
           "calibrating_detection_nozzle_clumping": "Kalibrieren der Erkennungsposition der Düsenverklumpung",
           "purifying_chamber_air": "Kammerluft reinigen",
-          "preparing_ams": "AMS vorbereiten"
+          "preparing_ams": "AMS vorbereiten",
+          "measuring_rotary_attachment": "Messdrehaufsatz",
+          "moving_toolhead_above_purge_chute": "Beweglicher Werkzeugkopf über dem Spülschacht",
+          "cooling_nozzle": "Kühldüse",
+          "moving_toolhead_to_center_of_heatbed": "Bewegen des Werkzeugkopfes in die Mitte des Heizbetts",
+          "active_arc_fitting": "Aktive Lichtbogenanpassung",
+          "hotend_type_detection": "Erkennung des Hotend-Typs",
+          "build_plate_alignment_detection": "Erkennung der Ausrichtung der Bauplatte",
+          "heatbed_surface_foreign_object_detection": "Erkennung von Fremdkörpern auf der Heizbettoberfläche",
+          "heatbed_underside_foreign_object_detection": "Erkennung von Fremdkörpern an der Unterseite des Heizbetts",
+          "pre_extrusion_before_printing": "Vorextrusion vor dem Drucken"
         }
       },
       "print_progress": {

--- a/custom_components/bambu_lab/translations/el.json
+++ b/custom_components/bambu_lab/translations/el.json
@@ -462,7 +462,17 @@
           "preparing_hotend": "Προετοιμασία hotend",
           "calibrating_detection_nozzle_clumping": "Βαθμονόμηση της θέσης ανίχνευσης της συσσώρευσης ακροφυσίων",
           "purifying_chamber_air": "Καθαρισμός του αέρα του θαλάμου",
-          "preparing_ams": "Προετοιμασία AMS"
+          "preparing_ams": "Προετοιμασία AMS",
+          "measuring_rotary_attachment": "Περιστροφικό εξάρτημα μέτρησης",
+          "moving_toolhead_above_purge_chute": "Κινούμενη εργαλειοθήκη πάνω από τον αγωγό καθαρισμού",
+          "cooling_nozzle": "Ακροφύσιο ψύξης",
+          "moving_toolhead_to_center_of_heatbed": "Μετακίνηση εργαλειοκεφαλής στο κέντρο της θερμότητας",
+          "active_arc_fitting": "Εφαρμογή ενεργού τόξου",
+          "hotend_type_detection": "Ανίχνευση τύπου hotend",
+          "build_plate_alignment_detection": "Ανίχνευση ευθυγράμμισης πλακών κατασκευής",
+          "heatbed_surface_foreign_object_detection": "Ανίχνευση ξένων αντικειμένων επιφάνειας θερμότητας",
+          "heatbed_underside_foreign_object_detection": "Ανίχνευση ξένου αντικειμένου κάτω από την θέρμανση",
+          "pre_extrusion_before_printing": "Προεξώθηση πριν από την εκτύπωση"
         }
       },
       "print_progress": {

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -487,6 +487,16 @@
           "preparing_hotend": "Preparing hotend",
           "calibrating_detection_nozzle_clumping": "Calibrating the detection position of nozzle clumping",
           "purifying_chamber_air": "Purifying chamber air",
+          "measuring_rotary_attachment": "Measuring rotary attachment",
+          "moving_toolhead_above_purge_chute": "Moving toolhead above purge chute",
+          "cooling_nozzle": "Cooling nozzle",
+          "moving_toolhead_to_center_of_heatbed": "Moving toolhead to center of heatbed",
+          "active_arc_fitting": "Active arc fitting",
+          "hotend_type_detection": "Hotend type detection",
+          "build_plate_alignment_detection" : "Build plate alignment detection",
+          "heatbed_surface_foreign_object_detection": "Heatbed surface foreign object detection",
+          "heatbed_underside_foreign_object_detection": "Heatbed underside foreign object detection",
+          "pre_extrusion_before_printing": "Pre-extrusion before printing",
           "preparing_ams": "Preparing AMS",
           "idle": "Idle"
         }

--- a/custom_components/bambu_lab/translations/es.json
+++ b/custom_components/bambu_lab/translations/es.json
@@ -462,7 +462,17 @@
           "preparing_hotend": "Preparando el hotend",
           "calibrating_detection_nozzle_clumping": "Calibración de la posición de detección de aglomeración de boquillas",
           "purifying_chamber_air": "Purificación del aire de la cámara",
-          "preparing_ams": "Preparando AMS"
+          "preparing_ams": "Preparando AMS",
+          "measuring_rotary_attachment": "Accesorio giratorio de medición",
+          "moving_toolhead_above_purge_chute": "Mover el cabezal de la herramienta por encima del conducto de purga",
+          "cooling_nozzle": "Boquilla de enfriamiento",
+          "moving_toolhead_to_center_of_heatbed": "Mover el cabezal de la herramienta al centro de la base térmica",
+          "active_arc_fitting": "Ajuste de arco activo",
+          "hotend_type_detection": "Detección de tipo de hotend",
+          "build_plate_alignment_detection": "Detección de alineación de la placa de construcción",
+          "heatbed_surface_foreign_object_detection": "Detección de objetos extraños en la superficie del lecho térmico",
+          "heatbed_underside_foreign_object_detection": "Detección de objetos extraños en la parte inferior de la base térmica",
+          "pre_extrusion_before_printing": "Preextrusión antes de imprimir"
         }
       },
       "print_progress": {

--- a/custom_components/bambu_lab/translations/fr.json
+++ b/custom_components/bambu_lab/translations/fr.json
@@ -470,7 +470,17 @@
           "preparing_hotend": "Préparation du hotend",
           "calibrating_detection_nozzle_clumping": "Calibrage de la position de détection de l'agglutination des buses",
           "purifying_chamber_air": "Purifier l'air de la chambre",
-          "preparing_ams": "Préparation de l'AMS"
+          "preparing_ams": "Préparation de l'AMS",
+          "measuring_rotary_attachment": "Accessoire rotatif de mesure",
+          "moving_toolhead_above_purge_chute": "Déplacement de la tête d'outil au-dessus de la goulotte de purge",
+          "cooling_nozzle": "Buse de refroidissement",
+          "moving_toolhead_to_center_of_heatbed": "Déplacer la tête d'outil au centre du lit chauffant",
+          "active_arc_fitting": "Raccord à arc actif",
+          "hotend_type_detection": "Détection du type de hotend",
+          "build_plate_alignment_detection": "Détection de l'alignement des plaques de construction",
+          "heatbed_surface_foreign_object_detection": "Détection de corps étrangers à la surface du lit chauffant",
+          "heatbed_underside_foreign_object_detection": "Détection de corps étrangers sous le lit chauffant",
+          "pre_extrusion_before_printing": "Pré-extrusion avant impression"
         }
       },
       "print_progress": {

--- a/custom_components/bambu_lab/translations/it.json
+++ b/custom_components/bambu_lab/translations/it.json
@@ -462,7 +462,17 @@
           "preparing_hotend": "Preparazione dell'hotend",
           "calibrating_detection_nozzle_clumping": "Calibrazione della posizione di rilevamento dell'aggregazione degli ugelli",
           "purifying_chamber_air": "Purificazione dell'aria della camera",
-          "preparing_ams": "Preparazione dell'AMS"
+          "preparing_ams": "Preparazione dell'AMS",
+          "measuring_rotary_attachment": "Dispositivo rotante di misurazione",
+          "moving_toolhead_above_purge_chute": "Spostamento della testa utensile sopra lo scivolo di spurgo",
+          "cooling_nozzle": "Ugello di raffreddamento",
+          "moving_toolhead_to_center_of_heatbed": "Spostamento della testa utensile al centro del piano riscaldato",
+          "active_arc_fitting": "Adattamento dell'arco attivo",
+          "hotend_type_detection": "Rilevamento del tipo di hotend",
+          "build_plate_alignment_detection": "Costruisci il rilevamento dell'allineamento della piastra",
+          "heatbed_surface_foreign_object_detection": "Rilevamento di oggetti estranei sulla superficie del piano riscaldato",
+          "heatbed_underside_foreign_object_detection": "Rilevamento di oggetti estranei nella parte inferiore del piano riscaldato",
+          "pre_extrusion_before_printing": "Pre-estrusione prima della stampa"
         }
       },
       "print_progress": {

--- a/custom_components/bambu_lab/translations/ko.json
+++ b/custom_components/bambu_lab/translations/ko.json
@@ -462,7 +462,17 @@
           "preparing_hotend": "핫엔드 준비 중",
           "calibrating_detection_nozzle_clumping": "노즐 뭉침 감지 위치 교정",
           "purifying_chamber_air": "챔버 공기 정화",
-          "preparing_ams": "AMS 준비"
+          "preparing_ams": "AMS 준비",
+          "measuring_rotary_attachment": "측정 회전식 부착물",
+          "moving_toolhead_above_purge_chute": "퍼지 슈트 위로 툴헤드 이동",
+          "cooling_nozzle": "냉각 노즐",
+          "moving_toolhead_to_center_of_heatbed": "툴헤드를 히트베드 중앙으로 이동",
+          "active_arc_fitting": "액티브 아크 피팅",
+          "hotend_type_detection": "핫엔드 유형 감지",
+          "build_plate_alignment_detection": "빌드 플레이트 정렬 감지",
+          "heatbed_surface_foreign_object_detection": "히트베드 표면 이물질 감지",
+          "heatbed_underside_foreign_object_detection": "히트베드 밑면 이물질 감지",
+          "pre_extrusion_before_printing": "인쇄 전 사전 압출"
         }
       },
       "print_progress": {

--- a/custom_components/bambu_lab/translations/nl.json
+++ b/custom_components/bambu_lab/translations/nl.json
@@ -462,7 +462,17 @@
           "preparing_hotend": "Hotend voorbereiden",
           "calibrating_detection_nozzle_clumping": "Kalibreren van de detectiepositie van klontvorming in de spuitmond",
           "purifying_chamber_air": "Kamerlucht zuiveren",
-          "preparing_ams": "AMS voorbereiden"
+          "preparing_ams": "AMS voorbereiden",
+          "measuring_rotary_attachment": "Roterend opzetstuk meten",
+          "moving_toolhead_above_purge_chute": "Bewegende gereedschapskop boven de zuiveringsgoot",
+          "cooling_nozzle": "Koelmondstuk",
+          "moving_toolhead_to_center_of_heatbed": "Gereedschapskop naar het midden van het verwarmingsbed verplaatsen",
+          "active_arc_fitting": "Actieve boogfitting",
+          "hotend_type_detection": "Detectie van hotend-type",
+          "build_plate_alignment_detection": "Detectie van uitlijning van bouwplaten",
+          "heatbed_surface_foreign_object_detection": "Detectie van vreemde voorwerpen op het verwarmingsbedoppervlak",
+          "heatbed_underside_foreign_object_detection": "Detectie van vreemde voorwerpen aan de onderkant van het verwarmingsbed",
+          "pre_extrusion_before_printing": "Pre-extrusie vóór het afdrukken"
         }
       },
       "print_progress": {

--- a/custom_components/bambu_lab/translations/pl.json
+++ b/custom_components/bambu_lab/translations/pl.json
@@ -462,7 +462,17 @@
           "preparing_hotend": "Przygotowanie hotendu",
           "calibrating_detection_nozzle_clumping": "Kalibracja pozycji wykrywania zlepiania się dysz",
           "purifying_chamber_air": "Oczyszczanie powietrza w komorze",
-          "preparing_ams": "Przygotowanie AMS-u"
+          "preparing_ams": "Przygotowanie AMS-u",
+          "measuring_rotary_attachment": "Pomiar mocowania obrotowego",
+          "moving_toolhead_above_purge_chute": "Ruchoma głowica narzędziowa nad rynną oczyszczającą",
+          "cooling_nozzle": "Dysza chłodząca",
+          "moving_toolhead_to_center_of_heatbed": "Przesuwanie głowicy narzędziowej na środek podgrzewanego stołu",
+          "active_arc_fitting": "Aktywne dopasowanie łuku",
+          "hotend_type_detection": "Wykrywanie typu hotendu",
+          "build_plate_alignment_detection": "Wykrywanie wyrównania płyty konstrukcyjnej",
+          "heatbed_surface_foreign_object_detection": "Wykrywanie ciał obcych na powierzchni podgrzewanego stołu",
+          "heatbed_underside_foreign_object_detection": "Wykrywanie ciał obcych pod podgrzewanym spodem stołu",
+          "pre_extrusion_before_printing": "Wstępne wytłaczanie przed drukiem"
         }
       },
       "print_progress": {

--- a/custom_components/bambu_lab/translations/pt-br.json
+++ b/custom_components/bambu_lab/translations/pt-br.json
@@ -462,7 +462,17 @@
           "preparing_hotend": "Preparando hotend",
           "calibrating_detection_nozzle_clumping": "Calibrando a posição de detecção de aglomeração de bico",
           "purifying_chamber_air": "Purificar o ar da câmara",
-          "preparing_ams": "Preparando AMS"
+          "preparing_ams": "Preparando AMS",
+          "measuring_rotary_attachment": "Medição de acessório rotativo",
+          "moving_toolhead_above_purge_chute": "Movendo o cabeçote acima da calha de purga",
+          "cooling_nozzle": "Bocal de resfriamento",
+          "moving_toolhead_to_center_of_heatbed": "Movendo o cabeçote para o centro da base térmica",
+          "active_arc_fitting": "Ajuste de arco ativo",
+          "hotend_type_detection": "Detecção de tipo de hotend",
+          "build_plate_alignment_detection": "Detecção de alinhamento de placa de construção",
+          "heatbed_surface_foreign_object_detection": "Detecção de objetos estranhos na superfície do colchão térmico",
+          "heatbed_underside_foreign_object_detection": "Detecção de objetos estranhos na parte inferior da cama térmica",
+          "pre_extrusion_before_printing": "Pré-extrusão antes da impressão"
         }
       },
       "print_progress": {

--- a/custom_components/bambu_lab/translations/pt.json
+++ b/custom_components/bambu_lab/translations/pt.json
@@ -488,7 +488,17 @@
           "calibrating_detection_nozzle_clumping": "A calibrar deteção de nozzle sujo",
           "purifying_chamber_air": "A purificar ar do compartimento",
           "preparing_ams": "A preparar AMS",
-          "idle": "Inativo"
+          "idle": "Inativo",
+          "measuring_rotary_attachment": "Medição de acessório rotativo",
+          "moving_toolhead_above_purge_chute": "Movendo o cabeçote acima da calha de purga",
+          "cooling_nozzle": "Bocal de resfriamento",
+          "moving_toolhead_to_center_of_heatbed": "Movendo o cabeçote para o centro da base térmica",
+          "active_arc_fitting": "Ajuste de arco ativo",
+          "hotend_type_detection": "Detecção de tipo de hotend",
+          "build_plate_alignment_detection": "Detecção de alinhamento de placa de construção",
+          "heatbed_surface_foreign_object_detection": "Detecção de objetos estranhos na superfície do colchão térmico",
+          "heatbed_underside_foreign_object_detection": "Detecção de objetos estranhos na parte inferior da cama térmica",
+          "pre_extrusion_before_printing": "Pré-extrusão antes da impressão"
         }
       },
       "sdcard_status": {

--- a/custom_components/bambu_lab/translations/sk.json
+++ b/custom_components/bambu_lab/translations/sk.json
@@ -462,7 +462,17 @@
           "preparing_hotend": "Príprava hotendu",
           "calibrating_detection_nozzle_clumping": "Kalibrácia polohy detekcie zhlukovania trysky",
           "purifying_chamber_air": "Čistiaci vzduch v komore",
-          "preparing_ams": "Príprava AMS"
+          "preparing_ams": "Príprava AMS",
+          "measuring_rotary_attachment": "Merací otočný nástavec",
+          "moving_toolhead_above_purge_chute": "Presúvanie nástrojovej hlavy nad čistiacim žľabom",
+          "cooling_nozzle": "Chladiaca tryska",
+          "moving_toolhead_to_center_of_heatbed": "Presúvanie nástrojovej hlavy do stredu vyhrievaného lôžka",
+          "active_arc_fitting": "Aktívne oblúkové kovanie",
+          "hotend_type_detection": "Detekcia typu Hotend",
+          "build_plate_alignment_detection": "Detekcia zarovnania doštičiek",
+          "heatbed_surface_foreign_object_detection": "Detekcia cudzích predmetov na povrchu vyhrievanej podložky",
+          "heatbed_underside_foreign_object_detection": "Detekcia cudzích predmetov na spodnej strane vyhrievacieho lôžka",
+          "pre_extrusion_before_printing": "Predtlačenie pred tlačou"
         }
       },
       "print_progress": {

--- a/custom_components/bambu_lab/translations/th.json
+++ b/custom_components/bambu_lab/translations/th.json
@@ -462,7 +462,17 @@
           "preparing_hotend": "กำลังเตรียมฮอตเอนด์",
           "calibrating_detection_nozzle_clumping": "การปรับเทียบตำแหน่งการตรวจจับการเกาะตัวของหัวฉีด",
           "purifying_chamber_air": "ฟอกอากาศในห้อง",
-          "preparing_ams": "เตรียมความพร้อมเอเอ็มเอส"
+          "preparing_ams": "เตรียมความพร้อมเอเอ็มเอส",
+          "measuring_rotary_attachment": "การวัดสิ่งที่แนบมาแบบหมุน",
+          "moving_toolhead_above_purge_chute": "การเคลื่อนย้ายหัวเครื่องมือเหนือรางล้าง",
+          "cooling_nozzle": "หัวฉีดระบายความร้อน",
+          "moving_toolhead_to_center_of_heatbed": "ย้ายหัวเครื่องมือไปที่กึ่งกลางของเตียงทำความร้อน",
+          "active_arc_fitting": "ข้อต่อส่วนโค้งที่ใช้งานอยู่",
+          "hotend_type_detection": "การตรวจจับประเภท Hotend",
+          "build_plate_alignment_detection": "สร้างการตรวจจับการจัดตำแหน่งแผ่น",
+          "heatbed_surface_foreign_object_detection": "การตรวจจับวัตถุแปลกปลอมบนพื้นผิวเตียงทำความร้อน",
+          "heatbed_underside_foreign_object_detection": "แผ่นทำความร้อนใต้การตรวจจับวัตถุแปลกปลอม",
+          "pre_extrusion_before_printing": "การอัดขึ้นรูปก่อนพิมพ์"
         }
       },
       "print_progress": {

--- a/custom_components/bambu_lab/translations/zh-Hans.json
+++ b/custom_components/bambu_lab/translations/zh-Hans.json
@@ -462,7 +462,17 @@
           "preparing_hotend": "准备热端",
           "calibrating_detection_nozzle_clumping": "校准喷嘴结块检测位置",
           "purifying_chamber_air": "净化室空气",
-          "preparing_ams": "准备AMS"
+          "preparing_ams": "准备AMS",
+          "measuring_rotary_attachment": "测量旋转附件",
+          "moving_toolhead_above_purge_chute": "将工具头移动到清理溜槽上方",
+          "cooling_nozzle": "冷却喷嘴",
+          "moving_toolhead_to_center_of_heatbed": "将工具头移至热床中心",
+          "active_arc_fitting": "主动弧形拟合",
+          "hotend_type_detection": "热端类型检测",
+          "build_plate_alignment_detection": "构建板对齐检测",
+          "heatbed_surface_foreign_object_detection": "热床表面异物检测",
+          "heatbed_underside_foreign_object_detection": "热床底部异物检测",
+          "pre_extrusion_before_printing": "印刷前预挤出"
         }
       },
       "print_progress": {


### PR DESCRIPTION

## Description

Bambu Studio has defined stages 67-76, add them to pybambu.const and translations. Stage names are lightly edited to be concise and consistent compared to the source (https://github.com/bambulab/BambuStudio/commit/0b7d074bb98dd4051cbc820487b6ffe0810ec9ad)

Translations are generated using scripts/auto_translate.py.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): Compatibility update

### Link to Issue

n/a
## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

Manual testing as this is additional definitions.

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

Some of the new stages appear to be for new features in H2D firmware 01.03.00.00.