### PR TITLE
Fixes for H2D support

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -291,9 +291,9 @@ class Device:
                 return self.supports_sw_version("01.08.50.32")
             return True
         elif feature == Features.FIRE_ALARM_BUZZER:
-            return model in (h2_printers | x2_printers)
+            return model in h2_printers
         elif feature == Features.HEATBED_LIGHT:
-            return model in (h2_printers | x2_printers)
+            return model in h2_printers
         elif feature == Features.SECONDARY_AUX_FAN:
             return model in (p2_printers | x2_printers)
         elif feature == Features.HOTEND_RACK:


### PR DESCRIPTION
## Description

Doesn't support fire alarm or heatbed light - those are H2 only.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
