### PR TITLE
Fix lookup for printer-specific wiki URLs

### DIFF
--- a/custom_components/bambu_lab/pybambu/tests/test_models.py
+++ b/custom_components/bambu_lab/pybambu/tests/test_models.py
@@ -285,6 +285,7 @@ class TestHms(unittest.TestCase):
         self.assertTrue(result)
         self.client.callback.assert_called_once_with("event_printer_error")
         self.assertEqual(1, self.hms.error_count)
+
         self.assertDictEqual(self.hms.errors, {
             "Count": 1,
             "1-Code": "HMS_0300_0200_0001_0001",
@@ -352,6 +353,7 @@ class TestHms(unittest.TestCase):
         self.client._device.info.device_type = Printers.A1
         self.client.user_language = "en"
         data = {"hms": [{"attr": 50331904, "code": 65543}, {"attr": 134180864, "code": 131075}]}
+
         result = self.hms.print_update(data)
         self.assertTrue(result)
         self.client.callback.assert_called_once_with("event_printer_error")

--- a/custom_components/bambu_lab/pybambu/tests/test_models.py
+++ b/custom_components/bambu_lab/pybambu/tests/test_models.py
@@ -211,6 +211,7 @@ class TestHms(unittest.TestCase):
     def setUp(self):
         self.client = MagicMock()
         self.hms = HMSList(self.client)
+        self.maxDiff = None  # show entire dict on failure
 
     def test_no_errors(self):
         """When the HMS list is empty, no errors should be reported."""
@@ -284,8 +285,6 @@ class TestHms(unittest.TestCase):
         self.assertTrue(result)
         self.client.callback.assert_called_once_with("event_printer_error")
         self.assertEqual(1, self.hms.error_count)
-        self.maxDiff = None
-
         self.assertDictEqual(self.hms.errors, {
             "Count": 1,
             "1-Code": "HMS_0300_0200_0001_0001",
@@ -294,13 +293,65 @@ class TestHms(unittest.TestCase):
             "1-Severity": "fatal"
             })
 
+    def test_error_model_specific_url(self):
+        """When the wiki has a printer-specific troubleshooting URL, this is presented."""
+        self.client._device.info.device_type = Printers.X2D
+        self.client.user_language = "en"
+        data = {"hms": [{"attr": 50331904, "code": 65543}]}
+
+        result = self.hms.print_update(data)
+        self.assertTrue(result)
+        self.client.callback.assert_called_once_with("event_printer_error")
+        self.assertEqual(1, self.hms.error_count)
+        self.assertDictEqual(self.hms.errors, {
+            "Count": 1,
+            "1-Code": "HMS_0300_0100_0001_0007",
+            "1-Error": "The heatbed temperature is abnormal; the sensor may have an open circuit.",
+            "1-Wiki": "https://wiki.bambulab.com/en/x2d/troubleshooting/hmscode/0300_0100_0001_0007",
+            "1-Severity": "fatal"
+            })
+
+    def test_error_synonym_url_1(self):
+        """When the wiki treats an HMS code as a synonym, the correct URL is presented (main entry)."""
+        self.client._device.info.device_type = Printers.H2D
+        self.client.user_language = "en"
+        data = {"hms": [{"attr": 117440768, "code": 131088}]}  
+
+        result = self.hms.print_update(data)
+        self.assertTrue(result)
+        self.client.callback.assert_called_once_with("event_printer_error")
+        self.assertEqual(1, self.hms.error_count)
+        self.assertDictEqual(self.hms.errors, {
+            "Count": 1,
+            "1-Code": "HMS_0700_0100_0002_0010",
+            "1-Error": "AMS A The assist motor resistance is abnormal. The assist motor may be faulty.",
+            "1-Wiki": "https://wiki.bambulab.com/en/h2/troubleshooting/hmscode/0700_0100_0002_0010",
+            "1-Severity": "serious"
+            })
+
+    def test_error_synonym_url_2(self):
+        """When the wiki treats an HMS code as a synonym, the correct URL is presented (synonym)."""
+        self.client._device.info.device_type = Printers.H2D
+        self.client.user_language = "en"
+        data = {"hms": [{"attr": 117571840, "code": 131088}]}  
+
+        result = self.hms.print_update(data)
+        self.assertTrue(result)
+        self.client.callback.assert_called_once_with("event_printer_error")
+        self.assertEqual(1, self.hms.error_count)
+        self.assertDictEqual(self.hms.errors, {
+            "Count": 1,
+            "1-Code": "HMS_0702_0100_0002_0010",
+            "1-Error": "AMS C The assist motor resistance is abnormal. The assist motor may be faulty.",
+            "1-Wiki": "https://wiki.bambulab.com/en/h2/troubleshooting/hmscode/0700_0100_0002_0010",
+            "1-Severity": "serious"
+            })
 
     def test_error_multiple(self):
         """When there are multiple HMS errors, all are reported in the user language."""
         self.client._device.info.device_type = Printers.A1
         self.client.user_language = "en"
         data = {"hms": [{"attr": 50331904, "code": 65543}, {"attr": 134180864, "code": 131075}]}
-
         result = self.hms.print_update(data)
         self.assertTrue(result)
         self.client.callback.assert_called_once_with("event_printer_error")
@@ -313,13 +364,13 @@ class TestHms(unittest.TestCase):
             "1-Severity": "fatal",
             "2-Code": "HMS_07FF_7000_0002_0003",
             "2-Error": "Please check if the filament is coming out of the nozzle. If not, gently push the material and try to extrude again.",
-            "2-Wiki": "https://wiki.bambulab.com/en/p2s/troubleshooting/hmscode/07FF_7000_0002_0003",
+            "2-Wiki": "https://wiki.bambulab.com/en/h2/troubleshooting/hmscode/07FE_7000_0002_0003",
             "2-Severity": "serious"
             })
 
     def test_error_ignored(self):
         """When an HMS error has empty text, it is ignored."""
-        self.client._device.info.device_type = Printers.A1
+        self.client._device.info.device_type = Printers.P2S
         self.client.user_language = "en"
         data = {"hms": [{"attr": 201326848, "code": 131086}, {"attr": 134180864, "code": 131075}]}
 

--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -434,16 +434,19 @@ def safe_json_loads(raw_bytes):
 @functools.lru_cache(maxsize=8)
 def get_wiki_url_for_hms_error(hms_code: str, device_type: Printers):
 
+    default_url = "https://wiki.bambulab.com/en/hms/home"
     error_code = hms_code.replace("_", "")
     wiki_data = _load_compressed_json("wiki_links.json.gz")
     code_entry = wiki_data.get(error_code)
     if not code_entry:
-        return "https://wiki.bambulab.com/en/hms/home"
+        return default_url
 
     # Pick message matching device_type or default (empty list)
     for wiki_path, models in code_entry.items():
-        if not models or str(device_type) in models:
+        if str(device_type) in models:
             return f"https://wiki.bambulab.com{wiki_path}"
+        if not models:
+            default_url = f"https://wiki.bambulab.com{wiki_path}"
 
-    return "https://wiki.bambulab.com/en/hms/home"
+    return default_url
 


### PR DESCRIPTION

## Description

When the default (most common) wiki URL for an HMS code is listed first, this was returned even when a printer-specific URL is available. Fix pybambu.utils.get_wiki_url_for_hms_error() to track the default URL, and only return early when there is a match for the printer model.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

n/a

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

## Additional Notes

<!-- Add any additional information that reviewers should know -->
