### PR TITLE
Document new 'Store Sent Files on External Storage' option

### DIFF
--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -30,7 +30,10 @@ If you fall into any of these categories, select the Lan Mode Configuration conn
 
 The serial number is in the form `a1b2c3d4e5f6a1b2`, not the `3DP-000-000` identifier shown for the printers name. 
 
-> Camera feeds for H2D / H2S - you must enable the "LAN Only Liveview" option in the LAN mode settings. It is not necessary to enable LAN mode generally to enable the "LAN Only Liveview" option. This simply enables the RTSP stream to be available locally. The camera feed will also continue to work via Bambu Studio / Bamby Handy remotely.
+Additional setup may be needed for specific entities to work:
+
+- Camera feeds for H2D / H2S - you must enable the "LAN Only Liveview" option in the LAN mode settings. It is not necessary to enable LAN mode generally to enable the "LAN Only Liveview" option. This simply enables the RTSP stream to be available locally. The camera feed will also continue to work via Bambu Studio / Bamby Handy remotely.
+- Cover image, Print weight, Print Bed Type - with newer firmware/printers (e.g. H2D 01.03.00.00, H2S 01.02.00.00, P2S), you must enable "Store Sent Files on External Storage" in the printer's "Print Options" settings, and use a USB drive/SD card (depending on the printer). These entities need to get the print file from the printer, but the internal storage doesn't seem to be exposed.
 
 #### Advanced options
 


### PR DESCRIPTION

## Description

Newer printer firmware can use internal storage for print files, but the internal storage isn't exposed over FTP; so the integration cannot retrieve the print file. Document the setting that is needed for cover image, print weight, and bed type to work.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

### Link to Issue

#1974 

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [x] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

n/a - doc

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed

## Additional Notes

I only have an H2D but assume this option exists for P2S and H2S. Feedback welcomed as to scope.
