### PR TITLE
Fix secondary_aux_fan_speed: read airduct .state, fix override bugs

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -651,14 +651,20 @@ class Fans:
                 self._cooling_fan_speed_override_time = None
         self._heatbreak_fan_speed = data.get("heatbreak_fan_speed", self._heatbreak_fan_speed)
         self._heatbreak_fan_speed_percentage = fan_percentage(self._heatbreak_fan_speed)
-        if data.get('device') and data["device"].get('airduct') and data["device"]["airduct"].get('parts') and next((item for item in data["device"]["airduct"]["parts"] if item["id"] == 160), None):
-            fan_part = next(item for item in data["device"]["airduct"]["parts"] if item["id"] == 160)
-            self._secondary_aux_fan_speed = fan_part.get("value", self._secondary_aux_fan_speed)
-            self._secondary_aux_fan_speed_percentage = fan_percentage(self._secondary_aux_fan_speed)
+        airduct_parts = data.get("device", {}).get("airduct", {}).get("parts")
+        if airduct_parts:
+            fan_part = next((item for item in airduct_parts if item.get("id") == 160), None)
+            if fan_part is not None:
+                # airduct.parts[].state is already a percentage (0-100); write
+                # it directly into the percentage field. fan_percentage()
+                # expects a raw 0-15 PWM value and would multiply by ~6.67.
+                self._secondary_aux_fan_speed_percentage = fan_part.get(
+                    "state", self._secondary_aux_fan_speed_percentage
+                )
         if self._secondary_aux_fan_speed_override_time is not None:
             delta = datetime.now() - self._secondary_aux_fan_speed_override_time
             if delta.seconds > 5:
-                self._cooling_fan_speed_override_time = None
+                self._secondary_aux_fan_speed_override_time = None
 
         return (old_data != f"{self.__dict__}")
 
@@ -705,8 +711,8 @@ class Fans:
             return self._heatbreak_fan_speed_percentage
         elif fan == FansEnum.SECONDARY_AUXILIARY:
             if self._secondary_aux_fan_speed_override_time is not None:
-                return self._chamber_fan_speed_override
-            return self._chamber_fan_speed_percentage
+                return self._secondary_aux_fan_speed_override
+            return self._secondary_aux_fan_speed_percentage
 
 @dataclass
 class Upgrade:

--- a/custom_components/bambu_lab/pybambu/tests/test_models.py
+++ b/custom_components/bambu_lab/pybambu/tests/test_models.py
@@ -9,8 +9,8 @@ import json
 # Add the parent directory to the Python path to find pybambu
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
-from pybambu.models import PrintJob, Info, AMSList, Extruder, HMSList, PrintError, Temperature
-from pybambu.const import Printers
+from pybambu.models import PrintJob, Info, AMSList, Extruder, Fans, HMSList, PrintError, Temperature
+from pybambu.const import FansEnum, Printers
 
 class TestPrintJob(unittest.TestCase):
     def setUp(self):
@@ -575,6 +575,69 @@ class TestH2D(unittest.TestCase):
         self.assertEqual(self.temperature.left_nozzle_target_temperature, 0)
 
 
+
+
+class TestFans(unittest.TestCase):
+    """Regression tests for the SECONDARY_AUXILIARY fan path.
+
+    The X2D's right auxiliary fan reports its speed in
+    device.airduct.parts[id=160].state (already a percentage). Live
+    capture used in this test mirrors that payload.
+    """
+
+    AIRDUCT_DATA = {
+        "device": {
+            "airduct": {
+                "parts": [
+                    {"func": 0, "id": 16,  "state": 20, "tar_state": 20},
+                    {"func": 5, "id": 32,  "state": 40, "tar_state": 40},
+                    {"func": 6, "id": 160, "state": 30, "tar_state": 30},
+                    {"func": 2, "id": 48,  "state": 10, "tar_state": 10},
+                ],
+            },
+        },
+    }
+
+    def setUp(self):
+        self.client = MagicMock()
+        self.fans = Fans(self.client)
+
+    def test_secondary_aux_reads_airduct_state(self):
+        # Field is read from .state (not the non-existent .value), and is
+        # written directly into _percentage rather than being run back
+        # through fan_percentage() which expects a 0-15 PWM value.
+        self.fans.print_update(self.AIRDUCT_DATA)
+        self.assertEqual(self.fans._secondary_aux_fan_speed_percentage, 30)
+        self.assertEqual(
+            self.fans.get_fan_speed(FansEnum.SECONDARY_AUXILIARY), 30
+        )
+
+    def test_secondary_aux_override_expiry_clears_correct_field(self):
+        # An expired override on the secondary aux fan must clear its
+        # own override-time. The buggy version cleared
+        # _cooling_fan_speed_override_time instead, so this exercise
+        # specifically asserts the secondary_aux field is the one
+        # nulled out.
+        from datetime import timedelta
+        self.fans._secondary_aux_fan_speed_override = 70
+        self.fans._secondary_aux_fan_speed_override_time = (
+            datetime.now() - timedelta(seconds=6)
+        )
+
+        self.fans.print_update(self.AIRDUCT_DATA)
+
+        self.assertIsNone(self.fans._secondary_aux_fan_speed_override_time)
+
+    def test_get_fan_speed_returns_secondary_override_not_chamber(self):
+        # While an override is fresh, get_fan_speed must return the
+        # secondary aux override value (not the chamber fan's override).
+        self.fans._secondary_aux_fan_speed_override = 70
+        self.fans._chamber_fan_speed_override = 99  # decoy
+        self.fans._secondary_aux_fan_speed_override_time = datetime.now()
+
+        self.assertEqual(
+            self.fans.get_fan_speed(FansEnum.SECONDARY_AUXILIARY), 70
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

The X2D's right auxiliary fan reports its speed in
`device.airduct.parts[id=160].state` (already as a percentage), but four
bugs in the `Fans` model and `Fans.get_fan_speed` prevented any value
from surfacing — `secondary_aux_fan_speed_percentage` was always `0` and
HA writes via `set_fan_speed(SECONDARY_AUXILIARY, …)` never read back.

### Bug 1 — wrong key on the airduct part
`models.py:656` (line numbers against `upstream/main` at `15ed3408`):
```python
self._secondary_aux_fan_speed = fan_part.get("value", self._secondary_aux_fan_speed)
```
Airduct part dicts have `state` and `tar_state`; there is no `value`
field, so the lookup always returned the default. Live capture from an
X2D in cooling mode with right-aux at 30%:
```json
{"func": 6, "id": 160, "state": 30, "tar_state": 30, "range": 6553600}
```

### Bug 2 — running fan_percentage() on an already-percentage value
`models.py:657` then ran the (broken) read through `fan_percentage()`,
which divides by 15 because it expects a raw `0–15` PWM value. Even if
`.value` had been a real number, the result would have been wildly
wrong (e.g. raw 30 → percentage 200).

The fix writes airduct's `.state` directly into `_percentage`,
bypassing the conversion since the field is already in `0–100` units.

### Bug 3 — override-time expiry clears the wrong fan
`models.py:661`:
```python
if delta.seconds > 5:
    self._cooling_fan_speed_override_time = None  # should be _secondary_aux_…
```
Latent cross-fan bug: when a user overrode the secondary aux fan via HA,
the 5 s expiry handler cleared the **part-cooling** fan's
`_cooling_fan_speed_override_time` instead of its own. Means the
secondary aux override never aged out, and the cooling fan's override
was being silently dropped on every secondary-aux update.

### Bug 4 — get_fan_speed returns the wrong fan's fields
`models.py:715-717`:
```python
elif fan == FansEnum.SECONDARY_AUXILIARY:
    if self._secondary_aux_fan_speed_override_time is not None:
        return self._chamber_fan_speed_override         # <- should be secondary_aux_
    return self._chamber_fan_speed_percentage           # <- should be secondary_aux_
```
Copy-paste from the chamber-fan branch. Reads always returned the
chamber fan's value, regardless of what the secondary-aux fan actually
held.

### End-to-end verification

Patched `models.py` deployed to a live X2D running heating mode with
right-filter set to 30% via the printer touchscreen. After HA Core
restart, the integration's diagnostics dump reads:

```
data.device_state.fans._secondary_aux_fan_speed_percentage = 30
data.feature_support.SECONDARY_AUX_FAN = True
```

— matching the printer's setting exactly. With the unpatched code on
the same hardware and same printer state, the field read `0`.

### Out of scope (separate follow-ups)

- No `sensor.secondary_aux_fan_speed` description in `definitions.py`,
  so the corrected model state still doesn't surface in HA UI.
- The `mqtt_signature_required` gate in `fan.py` blocks all `fan.*`
  entities on X2D — orthogonal to this fix.
- `chamber_fan_speed` on X2D is actually the rear exhaust (sourced
  from rounding-prone `big_fan2_speed`); cleaner mapping is
  `airduct.parts[id=48].state`.
- `fan_percentage()` uses `round()` while the parallel `fan_to_percent`
  in `definitions.py` uses `ceil()` — the inconsistency causes a live
  10%↔20% oscillation on `cooling_fan_speed`/`chamber_fan_speed` when
  the printer's raw PWM value alternates between adjacent quantized
  levels.
- `docs/entities.mdx:19` lists Secondary aux as `"P2S only"`, but the
  feature gate has been `p2_printers | x2_printers` for some time;
  pre-existing mismatch this PR makes more visible — best updated
  alongside the sensor-surface PR.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

No matching open issue found.

## Documentation

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

Three new regression tests added in `pybambu/tests/test_models.py`
covering each behavioural surface:

- `test_secondary_aux_reads_airduct_state` — fixed code yields 30 from
  `airduct.parts[id=160].state = 30`; buggy code yields 0.
- `test_secondary_aux_override_expiry_clears_correct_field` — fixed
  code clears `_secondary_aux_fan_speed_override_time`; buggy code
  leaves it set.
- `test_get_fan_speed_returns_secondary_override_not_chamber` — with
  override=70 and chamber decoy=99, fixed returns 70; buggy returns 99.

Verified red→green: ran the full `pybambu/tests/` suite against the
deployed buggy `models.py` (the 3 new tests fail with the expected
mismatch messages, all others pass), then against the patched version
(**35/35 tests pass**: 26 existing in `test_models.py` + 6 in
`test_utils.py` + 3 new).

- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

## Additional Notes

The four bugs are entangled — fixing only one or two would still leave
`get_fan_speed(SECONDARY_AUXILIARY)` returning the chamber fan's value
or the override never expiring. The diff is small (+13/-7 in
`models.py`, +65 in `test_models.py`) but reviewing them as a unit is
recommended.

The patched `print_update` no longer writes to the *raw*
`_secondary_aux_fan_speed` field — it writes
`_secondary_aux_fan_speed_percentage` directly, since
`airduct.parts[].state` is already in percentage units and running it
through `fan_percentage()` would garble it. The raw field has no other
readers in the codebase. Left declared on the dataclass for symmetry
with the other fans; happy to remove the declaration too if you
prefer.
