### PR TITLE
fan_percentage: use math.ceil to stop fan-speed entities flipping between 10% buckets

### DIFF
--- a/custom_components/bambu_lab/pybambu/tests/test_utils.py
+++ b/custom_components/bambu_lab/pybambu/tests/test_utils.py
@@ -1,3 +1,4 @@
+import unittest
 from unittest.mock import MagicMock
 import json
 import os
@@ -7,7 +8,49 @@ from typing import Dict, Any, Callable, Optional
 from ..const import (
     LOGGER,
 )
-from ..utils import safe_json_loads
+from ..utils import safe_json_loads, fan_percentage
+
+
+class TestFanPercentage(unittest.TestCase):
+    """Regression tests for the fan_percentage round->ceil fix.
+
+    The printer reports an instantaneous raw 0-15 PWM value that
+    oscillates between adjacent integers when serving a target whose
+    exact 0-15 representation isn't an integer. round() picks
+    different buckets either side of the midpoint, so HA fan-speed
+    entities flip between adjacent 10% values on every push.
+    """
+
+    def test_zero_speed_returns_zero(self):
+        self.assertEqual(fan_percentage(0), 0)
+        self.assertEqual(fan_percentage("0"), 0)
+        self.assertEqual(fan_percentage(None), 0)
+
+    def test_full_speed_returns_one_hundred(self):
+        self.assertEqual(fan_percentage(15), 100)
+        self.assertEqual(fan_percentage("15"), 100)
+
+    def test_oscillation_between_raw_2_and_3_pins_to_same_bucket(self):
+        # Live capture: with user setting at 20% the printer alternates
+        # big_fan2_speed between '2' and '3' across consecutive print
+        # pushes. Both must round to the same 10% bucket so HA doesn't
+        # flip on every message.
+        speed_for_raw_2 = fan_percentage(2)
+        speed_for_raw_3 = fan_percentage(3)
+        self.assertEqual(
+            speed_for_raw_2, speed_for_raw_3,
+            f"raw 2 -> {speed_for_raw_2} but raw 3 -> {speed_for_raw_3}; "
+            "values disagree => HA will flip on every MQTT push"
+        )
+
+    def test_low_speeds_round_up_to_nearest_ten(self):
+        # raw 1 -> 6.67%, raw 2 -> 13.33%, raw 4 -> 26.67%
+        # All should round up so the reported value is never lower
+        # than the actual fan output.
+        self.assertEqual(fan_percentage(1), 10)
+        self.assertEqual(fan_percentage(2), 20)
+        self.assertEqual(fan_percentage(4), 30)
+        self.assertEqual(fan_percentage(5), 40)
 
 class MqttMessageInfo:
     """Mock MQTT message info object."""

--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -37,11 +37,20 @@ def search(lst, predicate, default={}):
 
 
 def fan_percentage(speed):
-    """Converts a fan speed to percentage"""
+    """Converts a fan speed to percentage.
+
+    Bambu fans report a raw 0-15 PWM-step value. The user-facing
+    setting moves in 10% increments, but the printer's reported
+    instantaneous value naturally oscillates between adjacent raw
+    integers when delivering an effective duty cycle (e.g. raw 2 and
+    raw 3 both serve a target around 20%). math.ceil keeps the
+    reported value pinned to the upper bucket so HA fan entities
+    don't flip 10% <-> 20% on every push.
+    """
     if not speed:
         return 0
     percentage = (int(speed) / 15) * 100
-    return round(percentage / 10) * 10
+    return math.ceil(percentage / 10) * 10
 
 
 def fan_percentage_to_gcode(fan: FansEnum, percentage: int):


### PR DESCRIPTION
## Description

`pybambu/utils.py:39` `fan_percentage()` bucketed raw 0–15 PWM values
to 10% steps using `round()`. The printer reports an instantaneous
raw value that naturally alternates between adjacent integers when
serving a target whose exact 0–15 representation isn't an integer
(e.g. raw 2 and raw 3 both serve a duty cycle around 20%). With
`round()`, HA fan-speed entities flipped between adjacent 10% buckets
on every MQTT push:

```
raw 2 -> (2/15)*100 = 13.33 -> round(1.33)*10 = 10
raw 3 -> (3/15)*100 = 20.00 -> round(2.00)*10 = 20
```

Swap to `math.ceil` and both raw values land in the same bucket
(20%), eliminating the oscillation.

`definitions.py:49` already has a (currently unused) `fan_to_percent`
helper that uses `math.ceil` for the same conversion, so this matches
an existing convention in the codebase.

### Live evidence

Captured from an X2D with the exhaust fan set to 20% via the printer
touchscreen. `big_fan2_speed` (the raw value backing
`chamber_fan_speed` for X2D-style printers) across 13 consecutive
print pushes:

```
 #  big_fan2  airduct[id=48].state
 1     '2'         20
 2     '2'         20
 3     '3'         20
 4     '2'         20
 5     '3'         20
 ...   ...         ...
13     '3'         20
```

Pre-fix this stream flipped `sensor.x2d_…_chamber_fan_speed` between
10% and 20% on alternating messages. Post-fix, polled every 2 s for
16 s with the printer continuing to oscillate the raw value:

```
sensor.x2d_…_chamber_fan_speed = 20  (last_updated unchanged)
```

Diagnostic dump confirms the underlying parser still sees the raw
oscillation while the percentage stays stable:

```
raw=_chamber_fan_speed='2'   pct=_chamber_fan_speed_percentage=20
raw=_chamber_fan_speed='3'   pct=_chamber_fan_speed_percentage=20
raw=_chamber_fan_speed='3'   pct=_chamber_fan_speed_percentage=20
```

### Affected entities

All entities using `fan_percentage()` — i.e. all `*_fan_speed`
sensors via `Fans.print_update`:

- `aux_fan_speed`
- `chamber_fan_speed`
- `cooling_fan_speed`
- `heatbreak_fan_speed`

Not X2D-specific. Affects every model that reads fans through the
legacy `big_fan*_speed` / `cooling_fan_speed` / `heatbreak_fan_speed`
top-level fields.

### Trade-off

`math.ceil` causes the reported value to be `>=` the actual duty
cycle (e.g. raw 1 = 6.67% reported as 10%). `round()` could go either
way. Since the user-facing setpoint moves in 10% steps and the
printer's PWM resolution is coarser than the display, both choices
involve some lossiness; `ceil` is the choice that doesn't *flip* on
oscillation and never *under*-reports actual fan output.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

No matching open issue found.

## Documentation

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

Four new regression tests added in `pybambu/tests/test_utils.py`:

- `test_zero_speed_returns_zero` — boundary invariant
- `test_full_speed_returns_one_hundred` — boundary invariant
- `test_oscillation_between_raw_2_and_3_pins_to_same_bucket` — the
  core regression: fixed code yields same bucket for raw 2 and 3;
  buggy code yields 10 and 20 with a clear diagnostic message.
- `test_low_speeds_round_up_to_nearest_ten` — verifies `ceil`
  semantics across raw 1–5.

Verified red→green: ran against the deployed buggy `utils.py`
(2 of 4 fail with the expected mismatch, the 2 boundary tests pass
under both `round` and `ceil`); against the patched version 4/4 pass.

Full `pybambu/tests/` suite: **36/36 pass** against the patched code
(26 in `test_models.py` + 6 in `test_error_lookup.py` + 4 new in
`test_utils.py`).

End-to-end verification: patched `utils.py` deployed onto a running
HAOS instance and HA Core restarted (Python module cache means
`reload_config_entry` alone doesn't pick up the change). Polled
`sensor.x2d_…_chamber_fan_speed` every 2 s for 16 s while the
printer continued to alternate `big_fan2_speed` between '2' and '3' —
HA value held at 20% with no state-change updates emitted. Pre-patch
behaviour on the same hardware was the alternating 10%↔20% flip.

- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

## Additional Notes

The dead `fan_to_percent` in `definitions.py:49` (no callsites in the
codebase) already used `math.ceil` for what looks like the same
conversion, so a parallel maintainer view of "what should the
rounding be" already arrived at `ceil`. Happy to delete that dead
function in this PR or keep it for a tidy-up later — your call.
