### PR TITLE
Enable AMS drying settings for H2C

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -270,6 +270,8 @@ class Device:
         elif feature == Features.AMS_DRYING_SETTINGS:
             if model in p2_printers:
                 return self.supports_sw_version("01.01.50.40")
+            if model == Printers.H2C:
+                return self.supports_sw_version("01.01.50.00")
             return False
         elif feature == Features.CHAMBER_LIGHT_2:
             return model in (h2_printers | x2_printers)


### PR DESCRIPTION
## Description

Enable AMS drying settings for H2C. It has been added with the [H2C beta firmware V01.01.50.00](https://forum.bambulab.com/t/h2c-firmware-v01-01-50-00-now-in-public-beta/252462). 

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

## Additional Notes

I tested the change with my H2C.