### PR TITLE
fix: prevent print-job entities from showing as unavailable when idle

### DIFF
--- a/custom_components/bambu_lab/button.py
+++ b/custom_components/bambu_lab/button.py
@@ -138,7 +138,7 @@ class BambuLabResumeButton(BambuLabButton):
         return False
 
     async def async_press(self) -> None:
-        """ Pause the Print on button press"""
+        """ Resume the Print on button press"""
         self.coordinator.client.publish(RESUME)
 
 

--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -477,7 +477,7 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         translation_key="start_time",
         icon="mdi:clock",
         device_class=SensorDeviceClass.TIMESTAMP,
-        available_fn=lambda self: self._start_time_avail_fn(),
+        available_fn=lambda self: True,
         value_fn=lambda self: self._start_time_value_fn(),
         is_restoring=True,
     ),
@@ -496,8 +496,8 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         translation_key="end_time",
         icon="mdi:clock",
         device_class=SensorDeviceClass.TIMESTAMP,
-        available_fn=lambda self: self.coordinator.get_model().print_job.end_time is not None,
-        value_fn=lambda self: dt_util.as_utc(self.coordinator.get_model().print_job.end_time),
+        available_fn=lambda self: True,
+        value_fn=lambda self: dt_util.as_utc(self.coordinator.get_model().print_job.end_time) if self.coordinator.get_model().print_job.end_time is not None else None,
     ),
     BambuLabSensorEntityDescription(
         key="total_usage_hours",
@@ -528,15 +528,15 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
     BambuLabSensorEntityDescription(
         key="gcode_file",
         translation_key="gcode_file",
-        available_fn=lambda self: self.coordinator.get_model().print_job.gcode_file != "",
-        value_fn=lambda self: self.coordinator.get_model().print_job.gcode_file,
+        available_fn=lambda self: True,
+        value_fn=lambda self: self.coordinator.get_model().print_job.gcode_file if self.coordinator.get_model().print_job.gcode_file != "" else None,
         icon_fn=lambda self: self.coordinator.get_model().print_job.file_type_icon
     ),
     BambuLabSensorEntityDescription(
         key="gcode_file_downloaded",
         translation_key="gcode_file_downloaded",
-        available_fn=lambda self: self.coordinator.get_model().print_job.gcode_file_downloaded != "",
-        value_fn=lambda self: self.coordinator.get_model().print_job.gcode_file_downloaded,
+        available_fn=lambda self: True,
+        value_fn=lambda self: self.coordinator.get_model().print_job.gcode_file_downloaded if self.coordinator.get_model().print_job.gcode_file_downloaded != "" else None,
         icon_fn=lambda self: self.coordinator.get_model().print_job.file_type_icon
     ),
     BambuLabSensorEntityDescription(


### PR DESCRIPTION
## Description

Fixes several entities becoming `unavailable` in Home Assistant when the printer is idle or a print finishes. Entities now remain available at all times, with safety guards added to prevent commands being sent when the printer isn't in the correct state.

**Buttons (Pause / Resume / Stop) - `button.py`:**
- Remove `available()` overrides so buttons inherit `CoordinatorEntity.available` (still correctly returns `False` when MQTT/connectivity is lost)
- Add state guards inside `async_press()` - commands are only published when the printer is in the correct gcode state; ignored presses log a warning

**Printing Speed Select - `select.py`:**
- Remove `available()` override that restricted the select to `gcode_state == 'RUNNING'`
- Add state guard inside `async_select_option()` checking for `RUNNING` or `PAUSE` before applying speed changes

**Print-job Sensors - `definitions.py`:**
- `start_time`: Set `available_fn` to always return `True`; existing `_start_time_value_fn()` already safely returns `None`
- `end_time`: Set `available_fn` to always return `True`; add null guard to `value_fn` to prevent `dt_util.as_utc(None)` raising an `AttributeError`
- `gcode_file` / `gcode_file_downloaded`: Set `available_fn` to always return `True`; return `None` instead of empty string when no file is set

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Documentation

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

## Additional Notes

Claude was used to assist with these fixes and I have tested on my P1S with AMS.  I verified the entities remain available when idle, show `unavailable` only when the printer is genuinely offline, and buttons/speed select still function correctly during a print.