### PR TITLE
Surface secondary_aux_fan_speed as a sensor entity

### DIFF
--- a/custom_components/bambu_lab/definitions.py
+++ b/custom_components/bambu_lab/definitions.py
@@ -396,6 +396,15 @@ PRINTER_SENSORS: tuple[BambuLabSensorEntityDescription, ...] = (
         value_fn=lambda self: self.coordinator.get_model().fans.get_fan_speed(FansEnum.HEATBREAK)
     ),
     BambuLabSensorEntityDescription(
+        key="secondary_aux_fan_speed",
+        translation_key="secondary_aux_fan_speed",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:fan",
+        value_fn=lambda self: self.coordinator.get_model().fans.get_fan_speed(FansEnum.SECONDARY_AUXILIARY),
+        exists_fn=lambda coordinator: coordinator.get_model().supports_feature(Features.SECONDARY_AUX_FAN),
+    ),
+    BambuLabSensorEntityDescription(
         key="model_download_percentage",
         translation_key="model_download_percentage",
         native_unit_of_measurement=PERCENTAGE,

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -397,6 +397,9 @@
       "heatbreak_fan_speed": {
         "name": "Heatbreak fan speed"
       },
+      "secondary_aux_fan_speed": {
+        "name": "Secondary aux fan speed"
+      },
       "model_download_percentage": {
         "name": "Model download"
       },

--- a/docs/entities.mdx
+++ b/docs/entities.mdx
@@ -16,7 +16,7 @@ nextTitle: Device Triggers
 | Aux           |                   |
 | Chamber       | Not on A1/A1 Mini |
 | Cooling       |                   |
-| Secondary aux | P2S only          |
+| Secondary aux | P2S, X2D          |
 
 ## Temperatures
 


### PR DESCRIPTION
## What this changes

Adds a `BambuLabSensorEntityDescription` for `secondary_aux_fan_speed`, gated on `Features.SECONDARY_AUX_FAN` (currently `p2_printers | x2_printers`). Also fixes one stale line in `docs/entities.mdx` that still says "P2S only".

## Why

PR #2000 plumbed the secondary aux fan value from `airduct.parts[id=160].state` into the model's `_secondary_aux_fan_speed_percentage` field, fixing the data-correctness side. But the only existing entity reading that field was the writable `fan.<printer>_secondary_aux_fan` (in `fan.py`), which:

- **Doesn't exist at all on X2D** — `fan.py:71` gates all fan platform setup on `not mqtt_signature_required`, which is `True` on X2D in production mode. X2D users currently have no entity exposing this value.
- **On P2S in dev mode**, the writable fan entity exists and its `percentage` attribute exposes the value, but `fan` entities don't carry `state_class: measurement`, so the value can't be picked up by the Long-Term Statistics card and is awkward to reference in dashboards built around sensor entities.

This PR adds a sibling `sensor.<printer>_secondary_aux_fan_speed` — read-only, with `state_class: measurement` — matching the maintainer's established pattern of pairing a writable `fan.*` entity with a read-only `sensor.*_fan_speed` companion for `aux`, `chamber`, `cooling`, and `heatbreak`.

The new sensor mirrors the gated pattern used by `aux_fan_speed` and `chamber_fan_speed` (which have `exists_fn` gates). `cooling_fan_speed` and `heatbreak_fan_speed` are ungated in the existing code, so they're not direct templates for this one.

## Diff size

+13 / -1 across 3 files:
- `custom_components/bambu_lab/definitions.py` — new entity description (+9)
- `custom_components/bambu_lab/translations/en.json` — new translation string (+3)
- `docs/entities.mdx` — stale "P2S only" → "P2S, X2D" (+1 / -1)

## Tested

Verified live on an X2D running `v2.2.23-beta1`:

1. Deployed the diff (definitions.py, en.json, entities.mdx) to a live HA instance and restarted Home Assistant Core.
2. Set all four user-controllable fans on the X2D via the Bambu Handy app — part=20%, left aux=30%, right aux=40%, exhaust=10% — then queried each corresponding sensor entity via `GET /api/states/sensor.x2d_<sn>_<key>`. Results:

   | Entity | State | Matches Handy setting |
   |---|---|---|
   | `sensor.x2d_<sn>_cooling_fan_speed` (part) | 20 | ✓ |
   | `sensor.x2d_<sn>_aux_fan_speed` (left aux) | 30 | ✓ |
   | `sensor.x2d_<sn>_secondary_aux_fan_speed` (right aux, **new**) | 40 | ✓ |
   | `sensor.x2d_<sn>_chamber_fan_speed` (exhaust on X2D — see note) | 10 | ✓ |
   | `sensor.x2d_<sn>_heatbreak_fan_speed` | 0 | ✓ (not user-controlled) |

   New entity attributes: `state_class: "measurement"`, `unit_of_measurement: "%"`, `friendly_name: "X2D_<sn> Secondary aux fan speed"`.

**Note on `chamber_fan_speed` on X2D**: this entity reads `big_fan2_speed`, which on X2D firmware carries the external exhaust fan value (matching the user's 10% exhaust setting above). This is pre-existing behavior, unaffected by PR 2.

### What was NOT directly verified

- **P2S was not tested.** I don't have a P2S; the feature gate `p2_printers | x2_printers` already exists in the integration and the writable `fan.<printer>_secondary_aux_fan` is reportedly working there per issue #1878, but the new sensor's behavior on P2S is inferred from code paths, not observed.

## Compatibility

Additive change gated on `Features.SECONDARY_AUX_FAN`, which already returns `True` only for `p2_printers | x2_printers`. All other Bambu models get no new entity.

Read-only sensor — does not interact with `mqtt_signature_required` write gating. Sits alongside the existing writable `fan.<printer>_secondary_aux_fan` entity (which is itself unaffected) — same pattern as `aux_fan` ↔ `aux_fan_speed`, `chamber_fan` ↔ `chamber_fan_speed`, etc.
