### PR TITLE
fix crash when HMS error fires before device is registered (X2D)

### DIFF
--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -734,6 +734,12 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
     def _update_printer_error(self):
         dev_reg = device_registry.async_get(self._hass)
         hadevice = dev_reg.async_get_device(identifiers={(DOMAIN, self.get_model().info.serial)})
+        if hadevice is None:
+            # Device not in the registry yet (HMS error can arrive during the initial
+            # connect, before the device entry exists). Skip this cycle to avoid
+            # AttributeError on hadevice.id.
+            LOGGER.debug("_update_printer_error: device not registered yet, skipping")
+            return
         device = self.get_model()
         if device.hms.error_count == 0:
             event_data = {
@@ -758,6 +764,9 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
     def _update_print_error(self):
         dev_reg = device_registry.async_get(self._hass)
         hadevice = dev_reg.async_get_device(identifiers={(DOMAIN, self.get_model().info.serial)})
+        if hadevice is None:
+            LOGGER.debug("_update_print_error: device not registered yet, skipping")
+            return
 
         device = self.get_model()
         if device.print_error.on == 0:


### PR DESCRIPTION
ran into this on my X2D. when it throws an HMS code right as HA is connecting, `_update_printer_error` blows up because the device isn't in the registry yet so `hadevice` is None:

```
File "/config/custom_components/bambu_lab/coordinator.py", line 748, in _update_printer_error
    "device_id": hadevice.id,
                 ^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'id'
```

`_update_print_error` has the same `hadevice.id` pattern so i added a guard there too. if the device lookup comes back None i just log + return and let the next cycle handle it once it's registered. error's gone for me after this.

timing thing mostly, my X2D had a pending HMS code (0300_2E00_...) on startup so it hit every reconnect. didn't dig into why the X2D specifically registers later than the error arrives but the None guard seemed like the safe fix regardless of model.

lmk if you'd rather handle it differently but wanted to take a stab at helping :) 