### PR TITLE
Fix join of Watchdog thread on disconnect

### DIFF
--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -570,7 +570,8 @@ class BambuClient:
         if self._watchdog is not None:
             LOGGER.debug("Stopping watchdog thread")
             self._watchdog.stop()
-            self._watchdog.join()
+            if self._watchdog is not threading.current_thread():
+                self._watchdog.join()
         self.stop_camera()
 
     def _on_watchdog_fired(self):


### PR DESCRIPTION
## Description

Fixes a buggy join of the Watchdog thread on MQTT disconnect.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

https://github.com/greghesp/ha-bambulab/issues/2021

## Documentation

- [x] No documentation updates were necessary for this change

## Testing

I was not able to reproduce the issue.
Have been running the patched version of the integration and the issue appears to be fixed.

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

## Additional Notes

N/A
