### PR TITLE
fix: add missing fields to ams_filament_drying command (#1997)

### DIFF
--- a/custom_components/bambu_lab/pybambu/commands.py
+++ b/custom_components/bambu_lab/pybambu/commands.py
@@ -148,6 +148,8 @@ AMS_FILAMENT_DRYING_TEMPLATE = {
     "humidity": 0,
     "mode": 0,
     "rotate_tray": False,
+    "filament": "",
+    "close_power_conflict": False,
   }
 }
 


### PR DESCRIPTION
## Description

Printer firmware 01.02.00.00+ silently ignores the ams_filament_drying command unless it includes the filament and close_power_conflict fields that Bambu Studio always sends (src/slic3r/GUI/DeviceCore/DevFilaSystemCtrl.cpp — CtrlAmsStartDryingHour / CtrlAmsStopDrying). Without them, start_filament_drying / stop_filament_drying publish the MQTT command with no error, but the AMS does not react. This adds both fields to AMS_FILAMENT_DRYING_TEMPLATE, using the same defaults Bambu Studio sends for stop (filament="", close_power_conflict=False).

Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

Link to Issue

Fixes #1997

Documentation

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

Testing

Manually verified on hardware — Bambu Lab P2S + AMS 2 Pro (printer fw 01.02.00.00), integration in LAN/developer mode:
- Before: stop_filament_drying / start_filament_drying published the command (confirmed in debug log) but the AMS did not react.
- After: both start and stop drying work; the AMS reacts immediately. Empty filament is accepted by the firmware.
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed

Additional Notes

The two added fields mirror Bambu Studio. Studio also populates filament with the tray's filament type on start, but an empty string is accepted by the firmware, so this minimal template change is enough to restore functionality. Regression appeared with firmware 01.02.00.00 and is reported across models (P2S, P1S, A1, H2, X2D with AMS 2 Pro / AMS HT) in #1997.