### PR TITLE
Document resource URL for YAML-mode dashboards

### DIFF
--- a/docs/frontend/index.mdx
+++ b/docs/frontend/index.mdx
@@ -18,6 +18,21 @@ All the cards can be configured using Dashboard UI editor.
   <Step>Find one of the _Custom: Bambu_ card in the list.</Step>
 </Steps>
 
+<Note>
+  The integration registers the card resource automatically only when your
+  Lovelace dashboards are in **storage** (UI managed) mode. If you run Lovelace
+  in **YAML** mode, the cards will not show up until you add the resource URL
+  yourself:
+
+  ```yaml
+  lovelace:
+    mode: yaml
+    resources:
+      - url: /bambu_lab/ha-bambulab-cards.js
+        type: module
+  ```
+</Note>
+
 ## Pre-made Dashboard
 
 You can find an amazing web configurator to easily create a Dashboard for your Bambu printer like the one below


### PR DESCRIPTION
## Description

Fixes #1074. The card resource only gets registered automatically when Lovelace is in storage (UI) mode, so YAML-mode users have no idea why the cards never show up. Added a note in the frontend docs with the resource URL to add manually:

```yaml
lovelace:
  mode: yaml
  resources:
    - url: /bambu_lab/ha-bambulab-cards.js
      type: module
```

The URL matches the one registered in `const.py`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

### Link to Issue

https://github.com/greghesp/ha-bambulab/issues/1074

## Documentation

- [x] I have updated the relevant documentation to reflect these changes

## Testing

Docs-only change. Confirmed the documented URL matches the resource path in `const.py`.