### PR TITLE
fix: fall back to code login when the 2FA endpoint is CSRF-blocked

### DIFF
--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -30,6 +30,7 @@ from .pybambu.bambu_cloud import (
     CodeRequiredError,
     CodeExpiredError,
     CodeIncorrectError,
+    CsrfError,
     TfaCodeRequiredError
 )
 
@@ -219,6 +220,21 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             except TfaCodeRequiredError:
                 self.authentication_type = 'tfaCode'
                 errors['base'] = 'tfaCode'
+                # Fall through to form generation to ask for verification code
+            except CsrfError:
+                # The 2FA endpoint lives on the website host (bambulab.com), which now
+                # requires a CSRF cookie that the API host never issues, so the code is
+                # rejected before it is ever evaluated. The API host still accepts code
+                # login, so request a code and fall back to that flow.
+                LOGGER.warning("2FA endpoint blocked by CSRF. Falling back to code login.")
+                try:
+                    await self.hass.async_add_executor_job(
+                        self._bambu_cloud.request_new_code)
+                    self.authentication_type = 'verifyCode'
+                    errors['base'] = 'tfa_csrf_fallback'
+                except Exception as e:
+                    LOGGER.error(f"Fallback code request failed with error code {e.args}")
+                    errors['base'] = "cannot_connect"
                 # Fall through to form generation to ask for verification code
             except Exception as e:
                 LOGGER.error(f"Failed to connect with error code {e.args}")
@@ -708,6 +724,21 @@ class BambuOptionsFlowHandler(config_entries.OptionsFlow):
             except TfaCodeRequiredError:
                 self.authentication_type = 'tfaCode'
                 errors['base'] = 'tfaCode'
+                # Fall through to form generation to ask for verification code
+            except CsrfError:
+                # The 2FA endpoint lives on the website host (bambulab.com), which now
+                # requires a CSRF cookie that the API host never issues, so the code is
+                # rejected before it is ever evaluated. The API host still accepts code
+                # login, so request a code and fall back to that flow.
+                LOGGER.warning("2FA endpoint blocked by CSRF. Falling back to code login.")
+                try:
+                    await self.hass.async_add_executor_job(
+                        self._bambu_cloud.request_new_code)
+                    self.authentication_type = 'verifyCode'
+                    errors['base'] = 'tfa_csrf_fallback'
+                except Exception as e:
+                    LOGGER.error(f"Fallback code request failed with error code {e.args}")
+                    errors['base'] = "cannot_connect"
                 # Fall through to form generation to ask for verification code
             except Exception as e:
                 LOGGER.error(f"Failed to connect with error code {e.args}")

--- a/custom_components/bambu_lab/pybambu/bambu_cloud.py
+++ b/custom_components/bambu_lab/pybambu/bambu_cloud.py
@@ -73,6 +73,11 @@ class CurlUnavailableError(Exception):
         super().__init__("curl library unavailable")
         self.error_code = 400
 
+class CsrfError(Exception):
+    def __init__(self):
+        super().__init__("Blocked by CSRF cookie requirement")
+        self.error_code = 403
+
 @dataclass
 class BambuCloud:
   
@@ -116,6 +121,11 @@ class BambuCloud:
         if response.status_code == 403 and 'cloudflare' in response.text:
             LOGGER.error("BLOCKED BY CLOUDFLARE")
             raise CloudflareError()
+        elif response.status_code == 403 and 'missing_cookie' in response.text:
+            # bambulab.com (the website host) requires a CSRF cookie that the API host
+            # never issues. Callers can recover by falling back to code login.
+            LOGGER.error("BLOCKED BY CSRF COOKIE REQUIREMENT")
+            raise CsrfError()
         elif response.status_code == 429 and 'cloudflare' in response.text:
             LOGGER.error("TEMPORARY 429 BLOCK BY CLOUDFLARE")
             raise CloudflareError(response.status_code, response.text)

--- a/custom_components/bambu_lab/pybambu/tests/test_bambu_cloud_csrf.py
+++ b/custom_components/bambu_lab/pybambu/tests/test_bambu_cloud_csrf.py
@@ -1,0 +1,54 @@
+import unittest
+from unittest.mock import MagicMock
+
+from ..bambu_cloud import (
+    BambuCloud,
+    CloudflareError,
+    CsrfError,
+)
+
+
+def _response(status_code, text):
+    """Minimal stand-in for a requests/cloudscraper response."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = text
+    return response
+
+
+class TestCsrfDetection(unittest.TestCase):
+    """Regression tests for the 2FA CSRF failure (#2056).
+
+    The 2FA leg of the cloud login posts to bambulab.com, which now requires
+    a CSRF cookie that api.bambulab.com never issues. That rejection is a
+    structured JSON 403 rather than a Cloudflare challenge page, so it has to
+    be told apart from both the Cloudflare block and a generic permission
+    failure - the config flow recovers from it specifically, by falling back
+    to code login.
+    """
+
+    def setUp(self):
+        self.cloud = BambuCloud("", "", "", "")
+
+    def test_csrf_403_raises_csrf_error(self):
+        body = '{"error":"CSRF error: missing_cookie","reason":"missing_cookie"}'
+        with self.assertRaises(CsrfError):
+            self.cloud._test_response(_response(403, body))
+
+    def test_cloudflare_403_still_raises_cloudflare_error(self):
+        # The pre-existing Cloudflare branch must keep winning for challenge
+        # pages, which are HTML and mention cloudflare rather than a cookie.
+        body = '<!DOCTYPE html><title>Just a moment...</title>cloudflare'
+        with self.assertRaises(CloudflareError):
+            self.cloud._test_response(_response(403, body))
+
+    def test_unrelated_403_still_raises_permission_error(self):
+        with self.assertRaises(PermissionError):
+            self.cloud._test_response(_response(403, '{"error":"forbidden"}'))
+
+    def test_success_response_does_not_raise(self):
+        self.cloud._test_response(_response(200, '{"accessToken":"token"}'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -37,7 +37,8 @@
       "verifyCode": "Verification code is required. Check your email or phone.",
       "code_expired": "Verification code expired. New code requested. Check your email or phone.",
       "code_incorrect": "Verification code was incorrect. Please re-enter.",
-      "tfaCode": "2FA code is required. Please enter it now."
+      "tfaCode": "2FA code is required. Please enter it now.",
+      "tfa_csrf_fallback": "Bambu Lab's two factor authentication endpoint is currently rejecting requests. A verification code has been sent to your email or phone instead - please enter it below."
     },
     "step": {
       "user": {
@@ -135,7 +136,8 @@
       "verifyCode": "Verification code is required. Check your email or phone.",
       "code_expired": "Verification code expired. New code requested. Check your email or phone.",
       "code_incorrect": "Verification code was incorrect. Please re-enter.",
-      "tfaCode": "2FA code is required. Please enter it now."
+      "tfaCode": "2FA code is required. Please enter it now.",
+      "tfa_csrf_fallback": "Bambu Lab's two factor authentication endpoint is currently rejecting requests. A verification code has been sent to your email or phone instead - please enter it below."
     },
     "step": {
       "init": {

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -10,7 +10,9 @@ nextTitle: Features
 For configuration, you'll ideally use your Bambu Credentials for the simplest setup and the most features as some sensors are supported by data from your Bambu cloud account print history.
 You can also, optionally, provide the printer's local IP address to enable the more efficient and reliable direct to printer connection for the printer sensor data and to enable the P1/A1 chamber image support.
 
-However, the Bambu cloud connection doesn't support 2FA and passwordless social media accounts at this time. And it obviously does not support printers explicitly set to Lan Only Mode.
+However, the Bambu cloud connection doesn't support passwordless social media accounts at this time. And it obviously does not support printers explicitly set to Lan Only Mode.
+
+Accounts with two factor authentication are supported. Bambu's 2FA endpoint is currently rejecting requests from the integration, so if your authenticator code is refused a verification code is sent to your email or phone instead - enter that when prompted.
 
 ### Configuring a Printer
 


### PR DESCRIPTION
## Description

Cloud login currently fails for any account with 2FA enabled. Every 2FA submission returns:

```
403 {"error":"CSRF error: missing_cookie","reason":"missing_cookie"}
```

**Root cause:** the two login legs use different hosts.

```python
BambuUrl.LOGIN:     'https://api.bambulab.com/v1/user-service/user/login'   # const.py:304
BambuUrl.TFA_LOGIN: 'https://bambulab.com/api/sign-in/tfa'                  # const.py:305
```

Leg 1 authenticates against the **API** host. Leg 2 redeems the resulting `tfaKey` against the
**website** host, which now requires a CSRF cookie. Nothing in the API flow issues one, and the
client has never contacted `bambulab.com` at that point, so the cookie cannot exist. The code is
rejected before it is ever evaluated — which is why a fresh emailed code fails identically to a
TOTP code, and why the credentials appear to be at fault when they are not.

This is reproducible with dummy credentials, no account required:

```python
import cloudscraper
H = {'User-Agent': 'bambu_network_agent/01.09.05.01', 'accept': 'application/json',
     'Content-Type': 'application/json'}

s = cloudscraper.create_scraper()
print(s.post('https://api.bambulab.com/v1/user-service/user/login', headers=H,
      json={"account": "x@example.invalid", "password": "x", "apiError": ""}).status_code)
# 400 - ordinary application error, no CSRF gate on this host

s = cloudscraper.create_scraper()
r = s.post('https://bambulab.com/api/sign-in/tfa', headers=H,
           json={"tfaKey": "0"*16, "tfaCode": "000000"})
print(r.status_code, r.text)
# 403 {"error":"CSRF error: missing_cookie","reason":"missing_cookie"}
```

The whole `bambulab.com/api/sign-in/*` namespace is gated — `/api/sign-in/form` behaves the same.
Note that simply persisting a session or cookie jar does **not** fix this: a preflight
`GET https://bambulab.com/en/sign-in` returns 200 but sets only `__cf_bm`, and carrying that jar
into the TFA POST still yields `missing_cookie`.

**Fix:** the API host still accepts code login, so this detects that specific 403 as a new
`CsrfError` and falls back to the existing verification-code flow, which runs entirely on
`api.bambulab.com` and is unaffected.

2FA is still attempted first, so if the website endpoint starts working again the original
behaviour resumes automatically with no further change. The password step is untouched — this
substitutes the *second factor* (an emailed/SMS code instead of TOTP), it does not remove one.

- `pybambu/bambu_cloud.py` — new `CsrfError`; `_test_response` distinguishes the CSRF 403 from
  the Cloudflare block and from a generic `PermissionError`
- `config_flow.py` — handle `CsrfError` by requesting a code and switching to the existing
  `verifyCode` step. Applied in both `BambuConfigFlow` and `BambuOptionsFlowHandler`, which carry
  near-identical copies of this logic
- `translations/en.json` — one new error string explaining the fallback, in both the `config` and
  `options` error blocks
- `docs/setup.mdx` — corrected; it stated the cloud connection does not support 2FA

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

### Link to Issue

Fixes #2056

## Documentation

- [x] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

Verified end-to-end in Home Assistant 2026.7.2 against a real 2FA-enabled account (P1S, Europe
region) by running the config flow through the UI. Entering the TOTP produced the fallback:

```
BLOCKED BY CSRF COOKIE REQUIREMENT
2FA endpoint blocked by CSRF. Falling back to code login.
```

A verification code arrived by email, and redeeming it completed authentication and reached
device selection with the account's printer listed. No `Failed to connect with error code
(403...)` was logged.

Added `pybambu/tests/test_bambu_cloud_csrf.py` covering the new branch in `_test_response`, plus
regression cover that the pre-existing Cloudflare and generic-permission branches are unchanged.

- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

## Additional Notes

**Not tested:** a non-2FA account, the SMS/China code path, and reauth. The options flow shares
the identical code path as the config flow but was not separately exercised through the UI. I only
have one account available to test against.

**On running the test suite:** `pytest` cannot collect from the repo root without `homeassistant`
installed, because collection imports `custom_components/bambu_lab/__init__.py`. Running from
`custom_components/bambu_lab/` instead fails differently, as `select.py` shadows the stdlib
`select` module. I ran the suite against an isolated copy of `pybambu/` (63 passed, including the
4 new tests). Not something this PR changes, but it may be worth a `conftest.py` or CI job.

**Two adjacent findings**, deliberately left out to keep this focused — happy to raise separately:

1. `CONNECTION_MECHANISM` is only ever assigned `CLOUDSCRAPER` or `REQUESTS`
   (`bambu_cloud.py:29-32`), so the `CURL_CFFI` branches at `:107`, `:137` and `:164` are
   unreachable and installing `curl_cffi` currently has no effect.
2. `cloudscraper.create_scraper()` is called fresh inside every `_get`/`_post`, so each
   `cf_clearance` cookie is discarded and the Cloudflare challenge is re-solved on every request.
