### PR TITLE
fix(camera): register camera entity even when printer is offline at HA startup

### DIFF
--- a/custom_components/bambu_lab/camera.py
+++ b/custom_components/bambu_lab/camera.py
@@ -30,20 +30,48 @@ async def async_setup_entry(
         entry: ConfigEntry,
         async_add_entities: AddEntitiesCallback
 ) -> None:
-    
+
     coordinator: BambuDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-    if not coordinator.get_model().has_full_printer_data:
-        return
 
     LOGGER.debug(f"CAMERA::async_setup_entry")
 
-    if coordinator.get_model().supports_feature(Features.CAMERA_RTSP) and coordinator.get_option_enabled(Options.CAMERA):
-        url = coordinator.get_model().camera.rtsp_url
-        if url != None and url != "disable":
-            async_add_entities([BambuLabRtspCamera(coordinator, entry)])
+    # NOTE: We intentionally do NOT gate on has_full_printer_data here.
+    #
+    # When HA restarts while the printer is offline, has_full_printer_data is False
+    # at setup time, causing camera entities to never be registered. When the printer
+    # later comes online, _reinitialize_sensors() unloads and reloads all platforms —
+    # but if async_setup_entry bails out early again, the camera entity is permanently
+    # lost from the registry until the integration is manually reloaded.
+    #
+    # The correct HA pattern is to always register entities and let them sit as
+    # `unavailable` until the device is reachable. The coordinator's
+    # _reinitialize_sensors() call (triggered by event_printer_ready) then causes
+    # async_setup_entry to run again with full data, at which point the entity
+    # transitions to a live state.
+    #
+    # For the RTSP camera we check the option flags (always available from config
+    # entry options) and register unconditionally; stream_source() handles the
+    # unavailable state gracefully by returning None.
+    #
+    # For the image-based camera, exists_fn still guards against printers that
+    # genuinely don't support the feature — but only once full data is available.
+    # Before that, we skip it rather than crashing; it will be registered on the
+    # next _reinitialize_sensors() pass after event_printer_ready fires.
 
-    if CHAMBER_CAMERA_SENSOR.exists_fn(coordinator):
-        async_add_entities([BambuLabImageCamera(coordinator, entry)])
+    if coordinator.get_option_enabled(Options.CAMERA):
+        if coordinator.get_model().supports_feature(Features.CAMERA_RTSP):
+            # Printer supports RTSP and camera option is enabled.
+            # Register the entity now; stream_source() will return None (gracefully)
+            # until the printer is online and rtsp_url is populated.
+            async_add_entities([BambuLabRtspCamera(coordinator, entry)])
+        elif coordinator.get_model().has_full_printer_data:
+            # Full printer data is available: we can reliably evaluate CAMERA_IMAGE
+            # support and the IMAGECAMERA option. Only register if the feature is
+            # actually present (some printers don't have a chamber camera at all).
+            if CHAMBER_CAMERA_SENSOR.exists_fn(coordinator):
+                async_add_entities([BambuLabImageCamera(coordinator, entry)])
+        # If neither branch matches (no full data yet, non-RTSP printer), the entity
+        # will be registered on the next _reinitialize_sensors() pass.
 
 
 class BambuLabRtspCamera(BambuLabEntity, Camera):


### PR DESCRIPTION
Camera entities were lost from the HA registry when HA restarted while the printer was offline. Removes the has_full_printer_data gate from async_setup_entry so the entity is always registered. Fixes #2032

## Description

When HA restarts while the printer is powered off, `async_setup_entry` in `camera.py` returned early because `has_full_printer_data` was `False`. This prevented the camera entity from ever being registered in the HA 
entity registry. When the printer later came online and `_reinitialize_sensors()` triggered a new setup pass, the same early return fired again — leaving the entity permanently absent until a manual integration reload.

The fix removes the `has_full_printer_data` gate from `async_setup_entry`:
- RTSP cameras are now registered whenever the camera option is enabled and the printer type supports RTSP (both are always available from config entry options). `stream_source()` already returns `None` gracefully when the printer is unreachable.
- Image cameras retain their `exists_fn` guard since feature detection requires live printer data, but will be correctly registered on the next `_reinitialize_sensors()` pass after `event_printer_ready` fires.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

Fixes #2032

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [ ] I have updated the relevant documentation to reflect these changes
- [X] No documentation updates were necessary for this change

## Testing

Tested manually on an H2S with integration v2.22-beta4 / HA 2026.6.4:

1. Printer online → camera entity present and streaming
2. Power off printer → restart HA → camera entity remains in registry as `unavailable` (previously: entity was removed from the registry entirely)
3. Power printer back on → entity automatically transitions to `streaming` without requiring a manual integration reload

Reproduction of the original bug was also confirmed via HA system logs: 
HomeKit Bridge logged "entity not available" for the camera entity immediately after HA startup with the printer offline, confirming the entity had never been registered.

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed

## Additional Notes

The `_reinitialize_sensors()` flow in `coordinator.py` (unload + reload of all platforms, triggered by event_printer_ready`) is correct and requires no changes. The bug was exclusively in `camera.py` returning before registering any entity.