### PR TITLE
fix: guard against explicit null values in print_update dict chains

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -453,10 +453,10 @@ class Camera:
         #   "tutk_server": "disable"
         # }
 
-        self.timelapse = data.get("ipcam", {}).get("timelapse", self.timelapse)
-        self.recording = data.get("ipcam", {}).get("ipcam_record", self.recording)
-        self.resolution = data.get("ipcam", {}).get("resolution", self.resolution)
-        self.rtsp_url = data.get("ipcam", {}).get("rtsp_url", self.rtsp_url)
+        self.timelapse = (data.get("ipcam") or {}).get("timelapse", self.timelapse)
+        self.recording = (data.get("ipcam") or {}).get("ipcam_record", self.recording)
+        self.resolution = (data.get("ipcam") or {}).get("resolution", self.resolution)
+        self.rtsp_url = (data.get("ipcam") or {}).get("rtsp_url", self.rtsp_url)
         if self._client._enable_camera:
             if self.rtsp_url == "disable":
                 if not self._fired_camera_disabled_event:
@@ -2204,7 +2204,7 @@ class Info:
         #   },
 
         if not self._force_ip:
-            info = data.get('net', {}).get('info', [])
+            info = (data.get('net') or {}).get('info', [])
             for net in info:
                 ip_int = net.get("ip", 0)
                 if ip_int != 0:
@@ -2266,7 +2266,7 @@ class Info:
         # and new versions provided for each component. While the X1 lists only the new version
         # in separate string properties.
 
-        self.new_version_state = data.get("upgrade_state",{}).get("new_version_state", self.new_version_state)
+        self.new_version_state = (data.get("upgrade_state") or {}).get("new_version_state", self.new_version_state)
 
         # Nozzle data is provided differently for dual-nozzle printers (at least)
         # New (H2D):
@@ -3213,7 +3213,7 @@ class StageAction:
             self._print_type = "unknown"
 
         # New way it is presented
-        self._id = int(data.get("stage", {}).get("_id", self._id))
+        self._id = int((data.get("stage") or {}).get("_id", self._id))
         # Old way it's presented
         self._id = int(data.get("stg_cur", self._id))
         if (self._print_type == "idle") and (self._id == 0):

--- a/custom_components/bambu_lab/pybambu/tests/test_models.py
+++ b/custom_components/bambu_lab/pybambu/tests/test_models.py
@@ -9,7 +9,7 @@ import json
 # Add the parent directory to the Python path to find pybambu
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
-from pybambu.models import PrintJob, Info, AMSList, Extruder, Fans, HMSList, PrintError, Temperature
+from pybambu.models import PrintJob, Info, AMSList, Extruder, Fans, HMSList, PrintError, Temperature, Camera, StageAction
 from pybambu.const import FansEnum, Printers
 
 class TestPrintJob(unittest.TestCase):
@@ -61,6 +61,58 @@ class TestInfo(unittest.TestCase):
 
         self.assertEqual(self.info.active_nozzle_diameter, 0.4)
         self.assertEqual(self.info.active_nozzle_type, "hardened_steel")
+
+    def test_info_update_upgrade_state_none(self):
+        # Regression test for https://github.com/greghesp/ha-bambulab/issues/2057
+        # The printer can send "upgrade_state": null (rather than omitting the key)
+        # which must not raise AttributeError: 'NoneType' object has no attribute 'get'.
+        data = dict(self.test_data['push_all'])
+        data['upgrade_state'] = None
+
+        # Should not raise.
+        self.info.print_update(data)
+
+        # With upgrade_state explicitly null, new_version_state should be left unchanged
+        # (falls back to its previous value, same as if the key were absent).
+        self.assertEqual(self.info.new_version_state, 0)
+
+    def test_info_update_net_none(self):
+        # Same explicit-null issue can occur for the "net" key used for IP address discovery.
+        # Force the code path that reads "net" (it's skipped when force_ip is enabled).
+        self.info._force_ip = False
+        data = dict(self.test_data['push_all'])
+        data['net'] = None
+
+        # Should not raise.
+        self.info.print_update(data)
+
+class TestCamera(unittest.TestCase):
+    def setUp(self):
+        self.client = MagicMock()
+        self.camera = Camera(self.client)
+        self.client._enable_camera = False
+
+        # Load test data from P1P.json
+        with open(os.path.join(os.path.dirname(__file__), 'P1P.json'), 'r') as f:
+            self.test_data = json.load(f)
+
+    def test_camera_update_ipcam_none(self):
+        # Same explicit-null issue can occur for the "ipcam" key.
+        data = dict(self.test_data['push_all'])
+        data['ipcam'] = None
+
+        # Should not raise.
+        result = self.camera.print_update(data)
+        self.assertFalse(result)
+
+class TestStageAction(unittest.TestCase):
+    def test_stage_update_stage_none(self):
+        # Same explicit-null issue can occur for the "stage" key.
+        stage_action = StageAction()
+        data = {"print_type": "idle", "stage": None}
+
+        # Should not raise.
+        stage_action.print_update(data)
 
 class TestAMSList(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Symptom

Fixes #2057 — `AttributeError: 'NoneType' object has no attribute 'get'` raised from `Info.print_update` when the printer sends `"upgrade_state": null` explicitly in the MQTT status message (rather than omitting the key).

```
File ".../pybambu/models.py", line 2269, in print_update
    self.new_version_state = data.get("upgrade_state",{}).get("new_version_state", self.new_version_state)
AttributeError: 'NoneType' object has no attribute 'get'
```

## Root cause

`custom_components/bambu_lab/pybambu/models.py:2269`

`dict.get(key, default)` only applies the default when the key is **absent**, not when its value is explicitly `None`. When `upgrade_state` is sent as `null`, the first `.get()` returns `None`, and chaining `.get("new_version_state", ...)` onto `None` raises.

This is clearly an oversight rather than intentional: the same `upgrade_state` key is already handled correctly elsewhere in the same file, in the `Upgrade` class (`models.py` ~line 849):

```python
state = data.get("upgrade_state", None)
if state is not None:
    ...
```

## What changed

- `models.py:2269` (`Info.print_update`) — the reported fix, using the pattern suggested in the issue: `(data.get("upgrade_state") or {}).get("new_version_state", self.new_version_state)`.
- While searching for the same `data.get(x, {}).get(...)` pattern elsewhere in the file, I found three more single-level occurrences that are structurally identical and equally trivial to guard, so I included them:
  - `Camera.print_update` — `"ipcam"` (4 lines: timelapse, recording, resolution, rtsp_url)
  - `Info.print_update` — `"net"` (IP address discovery)
  - `StageAction.print_update` — `"stage"`

I deliberately left the multi-level chains alone (e.g. `data.get("device", {}).get("bed", {}).get("info", {}).get("temp", None)` at lines ~525, 542, 567, 660, 2290, 2318, 2514, 2553, 2779, 3702) as an observation rather than a change — hardening those would require guarding every level of the chain, which is a larger and less obviously "trivial" edit, and I have no evidence any of those specific sub-keys (`device`, `bed`, `ctc`, `nozzle`, `extruder`, `airduct`, `holder`) are ever sent as explicit `null`. Happy to take a follow-up pass at those if wanted.

## Tests

Added regression tests to `custom_components/bambu_lab/pybambu/pybambu/tests/test_models.py` (actual path: `custom_components/bambu_lab/pybambu/tests/test_models.py`) that feed each affected key as `None` and assert `print_update` no longer raises:
- `TestInfo.test_info_update_upgrade_state_none`
- `TestInfo.test_info_update_net_none`
- `TestCamera.test_camera_update_ipcam_none`
- `TestStageAction.test_stage_update_stage_none`

## What I validated

- Ran the full `pybambu/tests` suite locally (`run_tests.sh`'s inline logic, plus the two test files it doesn't currently wire in — `test_ams_tray_state.py` and `test_bambu_cloud_csrf.py`) before and after the change:
  - **Before** (on unmodified `main`): 39/39 pre-existing tests pass, no failures.
  - **New tests added, fix not yet applied**: all 4 new tests fail with the exact reported `AttributeError`, confirming they reproduce the bug.
  - **After** (fix + tests applied): all 43 (and all 67 including the two unwired files) tests pass.
- I do **not** have a physical printer, and no CI workflow in this repo runs the `pybambu` test suite — I could not validate this against a live/real MQTT payload beyond the unit tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)