### PR TITLE
fix: MQTT hot-path bugs — disconnect stall, blocking cloud fetch, shared command templates

### DIFF
--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import functools
 import os
 import re
@@ -15,6 +16,7 @@ from homeassistant.helpers import (
     device_registry,
     entity_registry
 )
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.core import Event, HomeAssistant, callback
@@ -148,12 +150,21 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
                     data=self.config_entry.data,
                     options=options)
 
+        # Image updates are dispatched directly to the affected image entity instead of
+        # refreshing the full entity set - chamber images arrive at up to a couple of
+        # frames per second and a full refresh per frame is needlessly expensive.
         elif event == "event_printer_chamber_image_update":
             if self.get_option_enabled(Options.IMAGECAMERA):
-                self._update_data()
+                async_dispatcher_send(self._hass, self.image_update_signal("chamber"))
 
         elif event == "event_printer_cover_image_update":
-            self._update_data()
+            async_dispatcher_send(self._hass, self.image_update_signal("cover"))
+
+        elif event == "event_printer_pick_image_update":
+            async_dispatcher_send(self._hass, self.image_update_signal("pick"))
+
+        elif event == "event_printer_missing_sdcard":
+            self.PublishDeviceTriggerEvent(event)
 
         elif event == "event_printer_error":
             self._update_printer_error()
@@ -303,7 +314,9 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         future.set_result(result)
         
     def _service_call_skip_objects(self, data: dict):
-        command = SKIP_OBJECTS_TEMPLATE
+        # All command templates are deep-copied before mutation - filling in the shared
+        # global corrupts concurrent service calls and later reuses of the template.
+        command = copy.deepcopy(SKIP_OBJECTS_TEMPLATE)
         objects = data.get("objects")
 
         # normalize to list[int]
@@ -333,7 +346,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         self.client.publish(command)
 
     def _service_call_send_gcode(self, data: dict):
-        command = SEND_GCODE_TEMPLATE
+        command = copy.deepcopy(SEND_GCODE_TEMPLATE)
         command['print']['param'] = f"{data.get('command')}\n"
         self.client.publish(command)
 
@@ -345,7 +358,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
             LOGGER.error(f"Invalid axis '{axis}' or distance out of range '{distance}'")
             return False
         
-        command = SEND_GCODE_TEMPLATE
+        command = copy.deepcopy(SEND_GCODE_TEMPLATE)
         gcode = HOME_GCODE if axis == 'HOME' else MOVE_AXIS_GCODE
         speed = 900 if axis == 'Z' else 3000
         if axis != 'HOME':
@@ -372,7 +385,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
             return { "Success": False,
                      "Error": f"Nozzle temperature too low to perform extrusion: {nozzle_temp}ºC" }
 
-        command = SEND_GCODE_TEMPLATE
+        command = copy.deepcopy(SEND_GCODE_TEMPLATE)
         gcode = EXTRUDER_GCODE
         distance = (1 if move == 'EXTRUDE' else -1) * 10
 
@@ -460,7 +473,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
             return False
         
         ams_index = self._get_ams_index_from_device(ams_device)
-        command = AMS_FILAMENT_DRYING_TEMPLATE
+        command = copy.deepcopy(AMS_FILAMENT_DRYING_TEMPLATE)
         command['print']['ams_id'] = ams_index
         
         start_command = data['service'] == 'start_filament_drying'
@@ -504,11 +517,11 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
             return
         
         if self.get_model().supports_feature(Features.AMS_READ_RFID_COMMAND):
-            command = AMS_READ_RFID_TEMPLATE
+            command = copy.deepcopy(AMS_READ_RFID_TEMPLATE)
             command['print']['ams_id'] = ams_index
             command['print']['slot_id'] = tray_index
         else:
-            command = SEND_GCODE_TEMPLATE
+            command = copy.deepcopy(SEND_GCODE_TEMPLATE)
             gcode = AMS_READ_RFID_GCODE
             gcode = gcode.format(global_tray_index = (ams_index*4) + tray_index)
             command['print']['param'] = gcode
@@ -557,7 +570,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         # String must be upper case
         tray_color = tray_color.upper()
 
-        command = AMS_FILAMENT_SETTING_TEMPLATE
+        command = copy.deepcopy(AMS_FILAMENT_SETTING_TEMPLATE)
         command['print']['ams_id'] = ams_index
         command['print']['tray_info_idx'] = data.get('tray_info_idx', '')
         command['print']['tray_id'] = tray_index
@@ -653,7 +666,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
             LOGGER.error(f"An AMS tray or external spool is required")
             return False
 
-        command = SWITCH_AMS_TEMPLATE
+        command = copy.deepcopy(SWITCH_AMS_TEMPLATE)
         command['print']['ams_id'] = ams_index
         command['print']['slot_id'] = tray
         command['print']['target'] = target
@@ -678,14 +691,14 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
             LOGGER.error(f"Loading filament is not available for this printer's firmware version, please update it")
             return False
 
-        command = SWITCH_AMS_TEMPLATE
+        command = copy.deepcopy(SWITCH_AMS_TEMPLATE)
         command['print']['ams_id'] = ams_index
         command['print']['slot_id'] = 255
         command['print']['target'] = 255
         self.client.publish(command)
 
     def _service_call_print_project_file(self, data: dict):
-        command = PRINT_PROJECT_FILE_TEMPLATE
+        command = copy.deepcopy(PRINT_PROJECT_FILE_TEMPLATE)
         filepath = data.get("filepath")
         plate = data.get("plate", 1)
         timelapse = data.get("timelapse", False)
@@ -878,6 +891,10 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
     def PublishDeviceTriggerEvent(self, event: str):
         dev_reg = device_registry.async_get(self._hass)
         hadevice = dev_reg.async_get_device(identifiers={(DOMAIN, self.get_model().info.serial)})
+        if hadevice is None:
+            # Events can arrive during initial connect, before the device entry exists.
+            LOGGER.debug(f"PublishDeviceTriggerEvent: device not registered yet, skipping {event}")
+            return
 
         event_data = {
             "device_id": hadevice.id,
@@ -886,6 +903,10 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         }
         LOGGER.debug(f"BUS EVENT: {event}: {event_data}")
         self._hass.bus.async_fire(f"{DOMAIN}_event", event_data)
+
+    def image_update_signal(self, image_type: str) -> str:
+        """Dispatcher signal for targeted image entity updates."""
+        return f"{DOMAIN}_{self.config_entry.data['serial']}_{image_type}_image_update"
 
     def get_model(self):
         return self.client.get_device()

--- a/custom_components/bambu_lab/device_trigger.py
+++ b/custom_components/bambu_lab/device_trigger.py
@@ -28,6 +28,7 @@ TRIGGER_TYPES = {
     "event_print_error_cleared",
     "event_printer_error",
     "event_printer_error_cleared",
+    "event_printer_missing_sdcard",
 }
 
 TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(

--- a/custom_components/bambu_lab/image.py
+++ b/custom_components/bambu_lab/image.py
@@ -5,7 +5,8 @@ from datetime import datetime
 
 from homeassistant.components.image import ImageEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, LOGGER, Options
@@ -58,8 +59,33 @@ async def async_setup_entry(
         async_add_entities([chamber_image])
 
 
-class CoverImage(ImageEntity, BambuLabEntity):
+class DispatchedImageEntity:
+    """Mixin that refreshes the entity from a targeted dispatcher signal.
+
+    Image updates are pushed per-entity by the coordinator instead of through a full
+    coordinator refresh (see coordinator.image_update_signal)."""
+
+    IMAGE_SIGNAL_TYPE: str
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self.coordinator.image_update_signal(self.IMAGE_SIGNAL_TYPE),
+                self._handle_image_update,
+            )
+        )
+
+    @callback
+    def _handle_image_update(self) -> None:
+        self.async_write_ha_state()
+
+
+class CoverImage(DispatchedImageEntity, ImageEntity, BambuLabEntity):
     """Representation of an image entity."""
+
+    IMAGE_SIGNAL_TYPE = "cover"
 
     def __init__(
         self,
@@ -89,8 +115,11 @@ class CoverImage(ImageEntity, BambuLabEntity):
     def available(self) -> bool:
         return self.coordinator.get_model().cover_image.get_last_update_time() != None
     
-class ChamberImage(ImageEntity, BambuLabEntity):
+class ChamberImage(DispatchedImageEntity, ImageEntity, BambuLabEntity):
     """Representation of an image entity."""
+
+    IMAGE_SIGNAL_TYPE = "chamber"
+
     def __init__(
         self,
         hass: HomeAssistant,
@@ -116,8 +145,10 @@ class ChamberImage(ImageEntity, BambuLabEntity):
         return self.coordinator.get_model().chamber_image.get_last_update_time()
 
 
-class PickImage(ImageEntity, BambuLabEntity):
+class PickImage(DispatchedImageEntity, ImageEntity, BambuLabEntity):
     """Representation of an object pick image entity."""
+
+    IMAGE_SIGNAL_TYPE = "pick"
 
     def __init__(
         self,

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -240,7 +240,10 @@ class MqttThread(threading.Thread):
                     # so this avoids repetitive debug spew.
                     LOGGER.debug(f"Connect: Attempting Connection to {host}")
                 connectionSuccessful = False
-                self._client.client.connect(host, self._client._port, keepalive=5)
+                # Keepalive must comfortably exceed the worst-case time spent in the
+                # message callbacks - the broker drops us after 1.5x keepalive without a
+                # ping, and the watchdog already detects dead connections after 60s.
+                self._client.client.connect(host, self._client._port, keepalive=30)
                 connectionSuccessful = True
 
                 LOGGER.debug("Starting listen loop")
@@ -592,7 +595,14 @@ class BambuClient:
             if not self._loaded_slicer_settings:
                 # Only update slicer settings once per successful connection to the printer.
                 self._loaded_slicer_settings = True
-                self.slicer_settings.update()
+                # This does blocking cloud HTTP calls. Run it off the paho network thread
+                # so a slow cloud response cannot stall the keepalive ping and drop the
+                # MQTT connection.
+                threading.Thread(
+                    target=self.slicer_settings.update,
+                    name=f"{self._device.info.device_type}-SlicerSettings",
+                    daemon=True,
+                ).start()
 
             if self._refreshed:
                 # X1 mqtt payload is inconsistent. Adjust it for consistent logging.
@@ -665,35 +675,38 @@ class BambuClient:
     def disconnect(self):
         """Disconnect the Bambu Client from server"""
         LOGGER.debug("Disconnect: Client Disconnecting")
-        
+
+        # Break the paho network loop before joining the MQTT thread - loop_forever()
+        # only returns once disconnect() has been called, so joining first would always
+        # run into the full join timeout and stall the caller for that long.
+        if self._mqtt is not None:
+            self._mqtt.stop()
+        if self.client is not None:
+            try:
+                self.client.disconnect()
+                self.client.loop_stop()
+            except Exception as e:
+                LOGGER.debug(f"Error during MQTT disconnect: {e}")
+
         # Stop and wait for background threads
         if self._mqtt is not None:
             LOGGER.debug("Stopping MQTT thread")
-            self._mqtt.stop()
             self._mqtt.join(timeout=5)
             self._mqtt = None
-            
+
         if self._watchdog is not None:
             LOGGER.debug("Stopping watchdog thread")
             self._watchdog.stop()
             self._watchdog.join(timeout=5)
             self._watchdog = None
-            
+
         if self._camera is not None:
             LOGGER.debug("Stopping camera thread")
             self._camera.stop()
             self._camera.join(timeout=5)
             self._camera = None
-        
-        # Disconnect MQTT client
-        if self.client is not None:
-            try:
-                self.client.loop_stop()
-                self.client.disconnect()
-            except Exception as e:
-                LOGGER.debug(f"Error during MQTT disconnect: {e}")
-            finally:
-                self.client = None
+
+        self.client = None
 
 
     def ftp_connection(self) -> ImplicitFTP_TLS:

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import ftplib
 import json
 import math
@@ -130,7 +131,11 @@ class Device:
                 if send_ready_event:
                     self._client.callback("event_printer_ready")
 
-        self._client.callback("event_printer_data_update")
+        # Only notify Home Assistant when something actually changed. The printer pushes
+        # status roughly once a second; without this gate every push forces all entities
+        # to recompute and rewrite their state.
+        if send_event:
+            self._client.callback("event_printer_data_update")
 
     @property
     def has_full_printer_data(self):
@@ -1940,7 +1945,7 @@ class PrintJob:
                     if cloud_dt.tzinfo is None:
                         cloud_dt = cloud_dt.replace(tzinfo=tz.UTC)
                     # Convert everything to UTC-aware datetime
-                    self.start_time = cloud_dt.astimezone(tz.UTC)
+                    self.end_time = cloud_dt.astimezone(tz.UTC)
                     LOGGER.debug(f"CLOUD END TIME2: {self.end_time}")
 
     def _identify_objects_in_pick_image(self, image: Image) -> set:
@@ -3187,7 +3192,7 @@ class Speed:
             if option == speed:
                 self._id = id
                 self.name = speed
-                command = SPEED_PROFILE_TEMPLATE
+                command = copy.deepcopy(SPEED_PROFILE_TEMPLATE)
                 command['print']['param'] = f"{id}"
                 self._client.publish(command)
                 self._client.callback("event_speed_update")

--- a/custom_components/bambu_lab/pybambu/utils.py
+++ b/custom_components/bambu_lab/pybambu/utils.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 import gzip
 import json
@@ -68,7 +69,8 @@ def fan_percentage_to_gcode(fan: FansEnum, percentage: int):
 
     percentage = round(percentage / 10) * 10
     speed = math.ceil(255 * percentage / 100)
-    command = SEND_GCODE_TEMPLATE
+    # Deep copy the template - mutating the shared global corrupts concurrent callers.
+    command = copy.deepcopy(SEND_GCODE_TEMPLATE)
     command['print']['param'] = f"M106 {fanString} S{speed}\n"
     return command
 
@@ -80,7 +82,7 @@ def set_temperature_to_gcode(temp: TempEnum, temperature: int, device_type: Prin
     elif temp == TempEnum.HEATBED:
         tempCommand = "M140"
     elif temp == TempEnum.CHAMBER:
-        command = SEND_GCODE_TEMPLATE
+        command = copy.deepcopy(SEND_GCODE_TEMPLATE)
         if device_type == Printers.X1E:
             # X1E has no airduct; M141 alone controls the chamber heater.
             command['print']['param'] = f"M141 S{temperature}\n"
@@ -90,7 +92,7 @@ def set_temperature_to_gcode(temp: TempEnum, temperature: int, device_type: Prin
             command['print']['param'] = f"M141 S{temperature}\nM145 P0\n"
         return command
 
-    command = SEND_GCODE_TEMPLATE
+    command = copy.deepcopy(SEND_GCODE_TEMPLATE)
     command['print']['param'] = f"{tempCommand} S{temperature}\n"
     return command
 
@@ -417,13 +419,15 @@ def upgrade_template(url: str) -> dict:
         r"offline\/([\w-]+)\/([\d\.]+)\/([\w]+)\/"
         r"offline-([\w\-\.]+)\.zip"
     )
-    info = re.search(pattern, url).groups()
-    if not info:
+    match = re.search(pattern, url)
+    if match is None:
         LOGGER.warning(f"Could not parse firmware url: {url}")
         return None
-    
-    model, version, hash, stamp = info
-    template = UPGRADE_CONFIRM_TEMPLATE.copy()
+
+    model, version, hash, stamp = match.groups()
+    # Deep copy the template - a shallow copy shares the nested 'upgrade' dict, so the
+    # first call would bake its URL into the global and later calls would resend it.
+    template = copy.deepcopy(UPGRADE_CONFIRM_TEMPLATE)
     template["upgrade"]["url"] = template["upgrade"]["url"].format(
         model=model, version=version, hash=hash, stamp=stamp
     )

--- a/custom_components/bambu_lab/translations/de.json
+++ b/custom_components/bambu_lab/translations/de.json
@@ -8,7 +8,8 @@
       "event_print_error": "Druckfehler",
       "event_print_error_cleared": "Druckfehler behoben",
       "event_printer_error": "HMS-Fehler",
-      "event_printer_error_cleared": "HMS-Fehler behoben"
+      "event_printer_error_cleared": "HMS-Fehler behoben",
+      "event_printer_missing_sdcard": "SD-Karte fehlt"
     }
   },
   "config": {

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -8,7 +8,8 @@
       "event_print_error": "Print error",
       "event_print_error_cleared": "Print error cleared",
       "event_printer_error": "HMS error",
-      "event_printer_error_cleared": "HMS error cleared"
+      "event_printer_error_cleared": "HMS error cleared",
+      "event_printer_missing_sdcard": "Missing SD card"
     }
   },
   "config": {


### PR DESCRIPTION
## Description

Seven fixes in the MQTT/coordinator hot path and in `pybambu`. Each one is visible in the code rather than inferred from a benchmark, so they are listed with the mechanism.

**`disconnect()` blocked the event loop for a guaranteed 5 s.** The MQTT thread was joined with `join(timeout=5)` *before* the paho network loop was broken. `loop_forever()` only returns once `disconnect()` has been called, so the join could never succeed early — every reload and every shutdown paid the full timeout inside Home Assistant's event loop. The loop is now stopped first, then the thread is joined.

**Slicer settings were fetched over blocking cloud HTTP on the paho network thread.** `on_message` called `slicer_settings.update()` directly while `keepalive` was 5 s. A slow cloud response stalled the keepalive ping, the broker dropped the connection, and the client went into a reconnect loop. The fetch now runs on its own daemon thread, and `keepalive` is raised to 30 s — the watchdog still detects genuinely dead connections after 60 s.

**Command templates were mutated in place as shared module-level dicts** (gcode, speed profile, upgrade confirm, AMS commands, `print_project_file`, `skip_objects`). Two concurrent service calls could corrupt each other's payloads, and `upgrade_confirm` baked the first printer's firmware URL into the global and resent it for later upgrades. All are deep-copied before mutation now.

**`upgrade_template()` raised `AttributeError` on an unparseable firmware URL** instead of returning `None`.

**Cloud task `endTime` was written into `start_time`** instead of `end_time`, corrupting the start-time sensor and the usage-hours accounting.

**The change-detection result was computed and then discarded.** `print_update()` already returns whether a submodule reported a change, but `event_printer_data_update` fired unconditionally on every push — roughly once per second — so all entities recomputed and rewrote their state even when nothing had changed. The existing return value is now honoured. Behaviour on first connect is unchanged: the initial full push always reports changes, and `event_printer_ready` still fires separately.

**Two events were fired but never handled.** `event_printer_pick_image_update` meant the pick image entity never updated; `event_printer_missing_sdcard` is now exposed as a device trigger ("Missing SD card", en + de), and `PublishDeviceTriggerEvent` no longer raises when the device is not yet registered.

Camera frame updates (chamber/cover/pick) are also dispatched straight to the affected image entity instead of triggering a full coordinator refresh per frame.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): reduced per-message work in the coordinator

### Link to Issue

N/A — found while reading the hot path, not from a filed report.

## Documentation

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

The existing `pybambu` unit tests pass. Beyond that, tested on a **P2S with AMS 2 Pro in LAN-only mode**, running on Home Assistant on an ARM host: the integration loads cleanly, 69 entities, no errors in the log.

**On the CPU claim, I want to be straight with you: I could not measure it, and I am not asserting a number.** I ran paired 6-minute container-CPU samples with the printer idle-connected, old build vs new. The apparent gain (≈42.6 → ≈39.9 CPU-s) is real in the data but the same magnitude shows up *with the opposite sign* in the control condition where the printer is powered off and no status pushes exist at all — a difference cannot exist there by construction, so that control is not a control, and the measurement does not separate signal from noise. Instantaneous container CPU on this host swings ~8 points between samples; the effect being chased is under 1.

Counting `state_changed` events does not work as a proxy either: Home Assistant suppresses writes that do not change a value, so the redundant recomputation cost CPU without ever producing an event. Both builds sit at 0–5 Bambu events per minute.

So the gating change rests on the code, not on a benchmark: the change-detection result was already being computed and thrown away. If you want it benchmarked properly it would need a counter inside `_update_data()` rather than an inference from process CPU — happy to add one if you would rather see that before merging.

The bug fixes above are all reviewable by inspection. The ones I could not exercise on my hardware are `upgrade_template()` (no unparseable firmware URL to hand), the cloud `end_time` path (LAN-only setup), and the concurrent-template corruption (verified by reading, not by racing two service calls).

## Additional Notes

Happy to split this into separate PRs if you would prefer to take the `disconnect()` and slicer-settings threading fixes on their own — those two are the ones with user-visible impact.
