### PR TITLE
Add timeout to Bambu Cloud POST requests

### DIFF
--- a/custom_components/bambu_lab/pybambu/bambu_cloud.py
+++ b/custom_components/bambu_lab/pybambu/bambu_cloud.py
@@ -175,16 +175,16 @@ class BambuCloud:
             if not curl_available:
                 LOGGER.debug(f"Curl library is unavailable.")
                 raise CurlUnavailableError()
-            response = curl_requests.post(url, headers=headers, json=json, impersonate=IMPERSONATE_BROWSER)
+            response = curl_requests.post(url, headers=headers, json=json, timeout=10, impersonate=IMPERSONATE_BROWSER)
         elif CONNECTION_MECHANISM == ConnectionMechanismEnum.CLOUDSCRAPER:
             if len(headers) == 0:
                 headers = self._get_headers()
             scraper = cloudscraper.create_scraper()
-            response = scraper.post(url, headers=headers, json=json)
+            response = scraper.post(url, headers=headers, json=json, timeout=10)
         elif CONNECTION_MECHANISM == ConnectionMechanismEnum.REQUESTS:
             if len(headers) == 0:
                 headers = self._get_headers()
-            response = requests.post(url, headers=headers, json=json)
+            response = requests.post(url, headers=headers, json=json, timeout=10)
         else:
             raise NotImplementedError()
 


### PR DESCRIPTION
## Summary
- `_post()` in `pybambu/bambu_cloud.py` issues `curl_cffi` / `cloudscraper` / `requests` POST calls without a `timeout`, unlike `_get()` which already sets `timeout=10` on all three connection mechanisms.
- When Bambu Cloud is slow to respond during login (`_get_authentication_token`) or the email/SMS verification-code request, this leaves the config flow hanging indefinitely instead of failing fast — since the call runs via `hass.async_add_executor_job` with no outer timeout either, the UI just appears stuck with no error and no next step, which is especially confusing during the interactive verification-code step (it can look like the "enter code" field never appears).
- Brings `_post()` in line with the existing `_get()` behavior by adding `timeout=10` to all three POST call paths.

## Test plan
- [x] Reproduced the hang locally: `_get_authentication_token` logged `Getting accessToken from Bambu Cloud` and then nothing for several minutes on a slow/flaky connection attempt.
- [x] Applied the fix and confirmed the same call now fails fast with a normal `requests`/`curl_cffi` timeout exception, which the config flow's existing `except Exception` handler already surfaces as `cannot_connect`, letting the user retry immediately instead of waiting minutes.
- [ ] Would appreciate a maintainer/CI check on `curl_cffi`'s `timeout` kwarg name for the `impersonate` code path, since I could only verify behavior end-to-end on the plain `requests` path in my environment.