### PR TITLE
Rename right nozzle labels in Simplified Chinese

### DIFF
--- a/custom_components/bambu_lab/translations/zh-Hans.json
+++ b/custom_components/bambu_lab/translations/zh-Hans.json
@@ -753,10 +753,10 @@
         }
       },
       "right_nozzle_diameter": {
-        "name": "正确的喷嘴大小"
+        "name": "右喷嘴大小"
       },
       "right_nozzle_type": {
-        "name": "正确的喷嘴类型",
+        "name": "右喷嘴类型",
         "state": {
           "hardened_steel": "硬化钢",
           "stainless_steel": "不锈钢",


### PR DESCRIPTION
## Summary

- Rename the Simplified Chinese right nozzle diameter label from `正确的喷嘴大小` to `右喷嘴大小`.
- Rename the Simplified Chinese right nozzle type label from `正确的喷嘴类型` to `右喷嘴类型`.

## Why

The existing translation uses `正确的` (correct) where `右` (right) is intended, so the right nozzle settings are mislabeled for Simplified Chinese users.

## Impact

The affected settings now clearly identify the right nozzle size and type.

## Validation

- Parsed `custom_components/bambu_lab/translations/zh-Hans.json` with `JSON.parse`.
- Ran `git diff --check`.
