### PR TITLE
fix: cap TLS at 1.2 — P2S firmware 01.02.00.00 never answers a TLS 1.3 ClientHello

### DIFF
--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -842,6 +842,9 @@ def create_local_ssl_context():
     context.verify_flags &= ~ssl.VERIFY_X509_STRICT
     # Workaround because some users get this error despite SNI: "certificate verify failed: IP address mismatch"
     context.check_hostname = False
+    # P2S firmware 01.02.00.00 never responds to a TLS 1.3 ClientHello, hanging the
+    # handshake until timeout. TLS 1.2 is answered immediately, so cap it there.
+    context.maximum_version = ssl.TLSVersion.TLSv1_2
     return context
 
 @functools.lru_cache(maxsize=1)
@@ -849,4 +852,7 @@ def create_insecure_ssl_context():
     context = ssl.SSLContext(ssl.PROTOCOL_TLS)
     context.check_hostname = False
     context.verify_mode = ssl.CERT_NONE
+    # P2S firmware 01.02.00.00 never responds to a TLS 1.3 ClientHello, hanging the
+    # handshake until timeout. TLS 1.2 is answered immediately, so cap it there.
+    context.maximum_version = ssl.TLSVersion.TLSv1_2
     return context


### PR DESCRIPTION
## Summary

Fixes #2072.

The P2S (firmware 01.02.00.00, model code N7) MQTT broker on port 8883 does not respond to a TLS 1.3 ClientHello at all — the handshake hangs until it times out, so Lan Mode setup fails with `ssl.SSLError: The handshake operation timed out (_ssl.c:1064)`. A TLS 1.2 ClientHello is answered immediately:

```
# Hangs indefinitely (TLS 1.3 offered):
openssl s_client -connect PRINTER_IP:8883

# Connects immediately:
openssl s_client -connect PRINTER_IP:8883 -tls1_2
```

Python's `ssl.create_default_context()` offers TLS 1.3 by default, so both SSL context factories hit this. This PR caps `maximum_version` at TLS 1.2 in `create_local_ssl_context()` and `create_insecure_ssl_context()`.

## Testing

Verified on my own P2S (firmware 01.02.00.00) with HA 2026.7.4 and integration v2.2.22: with this change the Lan Mode config flow connection test succeeds and normal operation works; without it the handshake times out every time.

## Notes

I could only test on a P2S. The cap means every model negotiates TLS 1.2 instead of 1.3 — connections stay encrypted and certificate validation is unchanged. If you'd rather not cap globally, I'm happy to rework this as a retry-with-TLS-1.2 fallback on handshake timeout instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
