### PR TITLE
Refresh model when delayed task name arrives

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -1030,6 +1030,21 @@ class PrintJob:
         self._subtask_name = data.get("subtask_name", self._subtask_name)
         if old_subtask_name != self._subtask_name:
             LOGGER.debug(f"SUBTASK_NAME: {self._subtask_name}")
+
+        # Printer-initiated prints and reprints can reach RUNNING before the
+        # printer reports a subtask name. In that case model data is initially
+        # loaded using the newest 3mf on the printer as a fallback, which may
+        # belong to an older print. Resolve the model again once the real task
+        # name arrives so the cover image and metadata match the active print.
+        if (
+            old_subtask_name == ""
+            and self._subtask_name != ""
+            and self._loaded_model_data
+            and self.gcode_state not in ("IDLE", "FAILED", "FINISH", "unknown")
+        ):
+            LOGGER.debug("SUBTASK_NAME ARRIVED AFTER MODEL DATA; RELOADING MODEL")
+            self._clear_model_data()
+            self._update_task_data()
         self.file_type_icon = "mdi:file" if self._print_type != "cloud" else "mdi:cloud-outline"
         self.current_layer = data.get("layer_num", self.current_layer)
         self.total_layers = data.get("total_layer_num", self.total_layers)

--- a/custom_components/bambu_lab/pybambu/tests/test_models.py
+++ b/custom_components/bambu_lab/pybambu/tests/test_models.py
@@ -32,6 +32,43 @@ class TestPrintJob(unittest.TestCase):
         self.assertEqual(self.print_job.current_layer, 1)
         self.assertEqual(self.print_job.total_layers, 70)
 
+    def test_late_subtask_name_reloads_model_data(self):
+        """Model data loaded by fallback is refreshed when the task name arrives."""
+        self.print_job.gcode_state = "RUNNING"
+        self.print_job._loaded_model_data = True
+        self.print_job._clear_model_data = MagicMock()
+        self.print_job._update_task_data = MagicMock()
+
+        self.print_job.print_update({"subtask_name": "Current print"})
+
+        self.print_job._clear_model_data.assert_called_once_with()
+        self.print_job._update_task_data.assert_called_once_with()
+
+    def test_known_subtask_name_does_not_reload_model_data(self):
+        """Repeated task-name updates do not restart model downloads."""
+        self.print_job.gcode_state = "RUNNING"
+        self.print_job._subtask_name = "Current print"
+        self.print_job._loaded_model_data = True
+        self.print_job._clear_model_data = MagicMock()
+        self.print_job._update_task_data = MagicMock()
+
+        self.print_job.print_update({"subtask_name": "Current print"})
+
+        self.print_job._clear_model_data.assert_not_called()
+        self.print_job._update_task_data.assert_not_called()
+
+    def test_late_subtask_name_does_not_reload_finished_print(self):
+        """Late idle-state updates do not fetch model data for an old print."""
+        self.print_job.gcode_state = "FINISH"
+        self.print_job._loaded_model_data = True
+        self.print_job._clear_model_data = MagicMock()
+        self.print_job._update_task_data = MagicMock()
+
+        self.print_job.print_update({"subtask_name": "Finished print"})
+
+        self.print_job._clear_model_data.assert_not_called()
+        self.print_job._update_task_data.assert_not_called()
+
 class TestInfo(unittest.TestCase):
     def setUp(self):
         self.client = MagicMock()


### PR DESCRIPTION
## What changed

- Re-resolve print model data when a printer-initiated print or reprint reports its `subtask_name` after model data was already loaded.
- Limit the refresh to active prints and the first empty-to-named transition.
- Add regression tests for delayed task names, repeated task-name updates, and finished prints.

## Root cause

Some printer-initiated prints reach `RUNNING` before MQTT supplies `subtask_name`. The integration then falls back to the newest `.3mf` on the printer, which can be a previous slicer upload. Because model data is marked loaded, the later correct task name did not trigger another lookup, leaving a stale cover image and metadata.

## Impact

When the delayed task name arrives, the integration now clears the fallback model data and resolves the named `.3mf`, allowing the cover image and metadata to match the active print.

Fixes #1804

## Validation

- `python test_models.py TestPrintJob -v` — 4 passed
- Broader direct discovery — 58 tests passed; 2 unrelated modules were not discoverable because they use package-relative imports under script-style discovery
- `python -m compileall -q ..`
- `git diff --check`
