### PR TITLE
ci: auto-label issues by device from the bug/feature-request form

### DIFF
--- a/.github/workflows/label-device.yml
+++ b/.github/workflows/label-device.yml
@@ -1,0 +1,59 @@
+name: Label issue by device
+
+# Applies a "device: <model>" label based on the answer to the "What device
+# are you using?" dropdown in the bug report / feature request issue forms.
+# Lets contributors who own a specific printer/AMS filter to issues that
+# affect their hardware, without requiring reporters to do anything extra -
+# the device field is already a required part of both templates.
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  label-device:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            // Keep in sync with the `device` dropdown options in
+            // .github/ISSUE_TEMPLATE/bug_report.yml and feature_request.yml.
+            const DEVICES = [
+              "A1 Mini", "A1", "H2C", "H2D", "H2S", "P1P", "P1S", "P2S",
+              "X1E", "X1C", "X1", "AMS 2 Pro", "AMS HT", "AMS Lite", "AMS",
+            ]; // longest-name-first so "A1 Mini" matches before "A1", etc.
+
+            const body = context.payload.issue.body || "";
+            const match = body.match(/###\s*What device are you using\?\s*\n+\s*([^\n]+)/i);
+            if (!match) {
+              return;
+            }
+            const answer = match[1].trim();
+            const device = DEVICES.find((d) => d.toLowerCase() === answer.toLowerCase());
+            if (!device) {
+              core.info(`Device field found ("${answer}") but it doesn't match a known dropdown option - skipping.`);
+              return;
+            }
+
+            const label = `device: ${device}`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.issue.number;
+
+            const current = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number });
+            const alreadyLabeled = current.data.some((l) => l.name === label);
+            // Also drop any other stale "device: X" label if the issue was edited
+            // to change the device answer.
+            const staleDeviceLabels = current.data
+              .map((l) => l.name)
+              .filter((n) => n.startsWith("device: ") && n !== label);
+
+            for (const stale of staleDeviceLabels) {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number, name: stale }).catch(() => {});
+            }
+            if (!alreadyLabeled) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] });
+            }


### PR DESCRIPTION
## Description

Both issue templates already require a "What device are you using?" dropdown, and it's reliably filled in — sampled real issue bodies and 57 of the 87 currently-open issues have a clean, parseable answer. The problem is that answer just sits as text in the issue body: there's no way to filter "show me the open P1S issues" or watch for new reports against a specific printer/AMS. That matters here specifically because you don't own every model Bambu ships, and community members who do own a given model are the ones best placed to help triage reports against it — but only if they can find them.

**Changes:**

- 15 new `device: <model>` labels, one per dropdown option in [bug_report.yml](../blob/main/.github/ISSUE_TEMPLATE/bug_report.yml) / [feature_request.yml](../blob/main/.github/ISSUE_TEMPLATE/feature_request.yml).
- `.github/workflows/label-device.yml`: on `issues: opened/edited`, parses the dropdown answer out of the issue body and applies the matching label automatically. No behavior change required from reporters — the data's already being collected on every new issue.
- One-time backfill onto the 57 existing open issues that already had a matching answer, so this is useful immediately instead of only for issues filed from today onward. Distribution, for reference:

  ```
  19  P1S          2  H2C
  11  X1C          2  H2D
   9  A1           1  AMS HT
   7  P2S          1  AMS
   4  A1 Mini      1  P1P
  ```

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): Issue-triage tooling, no code/runtime changes

### Link to Issue

None — came out of a repo-process review, not a filed issue.

## Documentation

- [x] No documentation updates were necessary for this change

## Testing

- [x] All new and existing tests passed

Not applicable in the usual sense (this doesn't touch the integration), but verified before merging:
- The parsing regex was checked against real sampled issue bodies (not synthetic ones) and matched cleanly for all 57 backfilled issues, zero ambiguous/unmatched cases.
- Confirmed `gh issue list --label "device: P1S"` returns the expected 19 issues post-backfill.

## Additional Notes

Scoped intentionally narrow: this only adds labels, it doesn't touch the stale-bot behavior (`days-before-close: -1` currently disables auto-close) or issue-template structure — flagging that as a separate, deliberately out-of-scope item in case it's worth a follow-up later.
