### PR TITLE
docs: add MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 ha-bambulab contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Static Badge](https://img.shields.io/badge/HACS-Custom-41BDF5?style=for-the-badge&logo=homeassistantcommunitystore&logoColor=white)](https://github.com/hacs/integration) 
 ![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/greghesp/ha-bambulab/total?style=for-the-badge)
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/greghesp/ha-bambulab?style=for-the-badge) [![Discord](https://img.shields.io/discord/1337028866643857429?style=for-the-badge&logo=discord&logoColor=white&label=Discord&color=7289da)](https://discord.gg/rsUHAW3DKz)
+[![License: MIT](https://img.shields.io/github/license/greghesp/ha-bambulab?style=for-the-badge)](LICENSE)
 
 
 
@@ -33,4 +34,8 @@ If you feel this integration was valuable and want to support it in other ways, 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=greghesp&repository=ha-bambulab&category=Integration)
 
 For more information on setting up and configuring ha-bambulab, [please read our full documentation](https://docs.page/greghesp/ha-bambulab/installation)
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).
 


### PR DESCRIPTION
## Description

`validate-hacs` has been failing on `main` every night for several days: "The repository has no license." HACS's check just needs a recognized license file present (GitHub's own license auto-detection) - it doesn't mandate a specific one.

Added the standard MIT License, the common choice for HACS/custom_components integrations - short, permissive, no unusual clauses. Copyright attributed to "ha-bambulab contributors" rather than a single name, since the project has multiple codeowners and accepts community PRs. Also added a License section + badge to the README pointing at it.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

### Link to Issue

None - `validate-hacs` failures on the scheduled nightly run are the trigger.

## Documentation

- [x] I have updated the relevant documentation to reflect these changes

## Testing

- [x] All new and existing tests passed

Not applicable to a license file in the usual sense, but this should turn the nightly `validate-hacs` check green again.

## Additional Notes

None.
