### PR TITLE
ci: warn (don't fail) on translation-file parity drift

### DIFF
--- a/.github/workflows/translation-parity.yml
+++ b/.github/workflows/translation-parity.yml
@@ -1,0 +1,26 @@
+name: Translation parity
+
+# Informational only, by design - reports translation locales that are out
+# of sync with en.json (missing keys, or stale keys no longer in English),
+# but never fails the job. A PR that only changes English strings shouldn't
+# be blocked on every locale catching up before it can merge.
+
+on:
+  push:
+    paths:
+      - "custom_components/bambu_lab/translations/**"
+  pull_request:
+    paths:
+      - "custom_components/bambu_lab/translations/**"
+
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - run: python3 scripts/check_translation_parity.py

--- a/.github/workflows/translation-parity.yml
+++ b/.github/workflows/translation-parity.yml
@@ -13,6 +13,11 @@ on:
     paths:
       - "custom_components/bambu_lab/translations/**"
 
+permissions:
+  # PR comments are served by the Issues API under the hood, so this - not
+  # pull-requests: write - is the scope that actually grants comment access.
+  issues: write
+
 jobs:
   parity:
     runs-on: ubuntu-latest
@@ -23,4 +28,34 @@ jobs:
         with:
           python-version: "3.13"
 
-      - run: python3 scripts/check_translation_parity.py
+      - id: check
+        run: python3 scripts/check_translation_parity.py
+
+      # Comments are only meaningful in a PR context (push events - e.g. a
+      # merge to main - have no PR to comment on).
+      - if: github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require("fs");
+            const marker = "<!-- translation-parity-check -->";
+            const body = fs.readFileSync("translation_parity_comment.md", "utf8");
+            const drift = "${{ steps.check.outputs.drift }}" === "true";
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.data.find((c) => c.body.startsWith(marker));
+
+            if (!drift && !existing) {
+              // Common case: no drift, and we've never had anything to say. Stay silent.
+              return;
+            }
+            if (existing) {
+              // Update our previous comment in place, whether that's new drift
+              // details or flipping it over to "resolved".
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+# Scratch output from scripts/check_translation_parity.py
+translation_parity_comment.md

--- a/scripts/check_translation_parity.py
+++ b/scripts/check_translation_parity.py
@@ -1,0 +1,88 @@
+"""Report translation keys that are missing or stale relative to en.json.
+
+Non-blocking by design: prints GitHub Actions ::warning:: annotations and a
+step-summary table, but always exits 0. The intent is visibility for
+reviewers/maintainers, not a merge gate - a PR that only touches English
+strings shouldn't be blocked on translations catching up.
+"""
+import glob
+import json
+import os
+import sys
+
+TRANSLATIONS_DIR = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..",
+                 "custom_components", "bambu_lab", "translations")
+)
+
+
+def flatten(d, prefix=""):
+    """Flatten a nested translation dict to {"a.b.c": "value"}."""
+    out = {}
+    for key, value in d.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            out.update(flatten(value, path))
+        else:
+            out[path] = value
+    return out
+
+
+def main():
+    en_path = os.path.join(TRANSLATIONS_DIR, "en.json")
+    with open(en_path, encoding="utf-8") as f:
+        en_keys = set(flatten(json.load(f)).keys())
+
+    summary_rows = []
+    any_drift = False
+
+    for filepath in sorted(glob.glob(os.path.join(TRANSLATIONS_DIR, "*.json"))):
+        filename = os.path.basename(filepath)
+        if filename == "en.json":
+            continue
+
+        with open(filepath, encoding="utf-8") as f:
+            other_keys = set(flatten(json.load(f)).keys())
+
+        missing = sorted(en_keys - other_keys)  # in en.json, not in this locale
+        extra = sorted(other_keys - en_keys)    # in this locale, not in en.json (stale)
+
+        if not missing and not extra:
+            continue
+
+        any_drift = True
+        summary_rows.append((filename, missing, extra))
+
+        if missing:
+            print(f"::warning file={os.path.relpath(filepath)}::"
+                  f"{filename} is missing {len(missing)} key(s) present in en.json: "
+                  f"{', '.join(missing[:5])}{', ...' if len(missing) > 5 else ''}")
+        if extra:
+            print(f"::warning file={os.path.relpath(filepath)}::"
+                  f"{filename} has {len(extra)} stale key(s) no longer in en.json: "
+                  f"{', '.join(extra[:5])}{', ...' if len(extra) > 5 else ''}")
+
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a", encoding="utf-8") as f:
+            if not any_drift:
+                f.write("## Translation parity\n\nAll locales match `en.json`. :white_check_mark:\n")
+            else:
+                f.write("## Translation parity\n\n"
+                        "This is informational only and does not block merging.\n\n"
+                        "| Locale | Missing keys | Stale keys |\n"
+                        "| --- | --- | --- |\n")
+                for filename, missing, extra in summary_rows:
+                    f.write(f"| `{filename}` | {len(missing)} | {len(extra)} |\n")
+                f.write("\nRun `python3 scripts/auto_translate.py` to fill in missing keys "
+                        "(requires network access to Google Translate).\n")
+
+    if not any_drift:
+        print("All locales match en.json.")
+
+    # Always succeed - this check is informational, not a merge gate.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_translation_parity.py
+++ b/scripts/check_translation_parity.py
@@ -1,9 +1,11 @@
 """Report translation keys that are missing or stale relative to en.json.
 
-Non-blocking by design: prints GitHub Actions ::warning:: annotations and a
-step-summary table, but always exits 0. The intent is visibility for
-reviewers/maintainers, not a merge gate - a PR that only touches English
-strings shouldn't be blocked on translations catching up.
+Non-blocking by design: prints GitHub Actions ::warning:: annotations, writes
+a step-summary table, and writes a PR-comment body to
+COMMENT_OUTPUT_PATH - but always exits 0. The intent is visibility for
+reviewers/maintainers (and the PR submitter), not a merge gate - a PR that
+only touches English strings shouldn't be blocked on translations catching
+up.
 """
 import glob
 import json
@@ -14,6 +16,11 @@ TRANSLATIONS_DIR = os.path.normpath(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "..",
                  "custom_components", "bambu_lab", "translations")
 )
+
+# Marker so the workflow's comment step can find-and-update its own previous
+# comment on later pushes, instead of piling up a new one each time.
+COMMENT_MARKER = "<!-- translation-parity-check -->"
+COMMENT_OUTPUT_PATH = os.environ.get("COMMENT_OUTPUT_PATH", "translation_parity_comment.md")
 
 
 def flatten(d, prefix=""):
@@ -26,6 +33,28 @@ def flatten(d, prefix=""):
         else:
             out[path] = value
     return out
+
+
+def build_markdown(summary_rows, any_drift):
+    if not any_drift:
+        return "## Translation parity\n\nAll locales match `en.json`. :white_check_mark:\n"
+
+    lines = [
+        "## Translation parity",
+        "",
+        "This is informational only and does not block merging.",
+        "",
+        "| Locale | Missing keys | Stale keys |",
+        "| --- | --- | --- |",
+    ]
+    for filename, missing, extra in summary_rows:
+        lines.append(f"| `{filename}` | {len(missing)} | {len(extra)} |")
+    lines += [
+        "",
+        "Run `python3 scripts/auto_translate.py` to fill in missing keys "
+        "(requires network access to Google Translate).",
+    ]
+    return "\n".join(lines) + "\n"
 
 
 def main():
@@ -62,20 +91,23 @@ def main():
                   f"{filename} has {len(extra)} stale key(s) no longer in en.json: "
                   f"{', '.join(extra[:5])}{', ...' if len(extra) > 5 else ''}")
 
+    markdown = build_markdown(summary_rows, any_drift)
+
     step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
     if step_summary:
         with open(step_summary, "a", encoding="utf-8") as f:
-            if not any_drift:
-                f.write("## Translation parity\n\nAll locales match `en.json`. :white_check_mark:\n")
-            else:
-                f.write("## Translation parity\n\n"
-                        "This is informational only and does not block merging.\n\n"
-                        "| Locale | Missing keys | Stale keys |\n"
-                        "| --- | --- | --- |\n")
-                for filename, missing, extra in summary_rows:
-                    f.write(f"| `{filename}` | {len(missing)} | {len(extra)} |\n")
-                f.write("\nRun `python3 scripts/auto_translate.py` to fill in missing keys "
-                        "(requires network access to Google Translate).\n")
+            f.write(markdown)
+
+    # Written every run (whether drift was found or not) so the workflow's
+    # comment step can also use it to update a previous "drift found"
+    # comment to a "resolved" state once a later push fixes it.
+    with open(COMMENT_OUTPUT_PATH, "w", encoding="utf-8") as f:
+        f.write(f"{COMMENT_MARKER}\n{markdown}")
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as f:
+            f.write(f"drift={'true' if any_drift else 'false'}\n")
 
     if not any_drift:
         print("All locales match en.json.")


### PR DESCRIPTION
## Description

Right now translation drift between `en.json` and the 17 locale files is invisible until someone happens to notice - there's no CI signal at all. This adds one: a workflow that reports (via `::warning::` annotations + a step-summary table) any locale missing keys that exist in `en.json`, or carrying stale keys that no longer exist in `en.json`.

**Deliberately non-blocking.** It always exits 0. A PR that only changes English strings shouldn't be held up waiting for every locale to catch up - this is visibility for the PR submitter and reviewers, not a merge gate.

Originally this only surfaced as check-annotation warnings, but those are easy to miss (a reviewer sees a green check and has no reason to click in), so it now also posts a PR comment - directly visible in the conversation to whoever opened the PR:
- New drift found -> comment posted.
- Drift changes on a later push -> the same comment is updated in place (hidden marker), not duplicated.
- Drift gets fixed by a later push -> the comment updates to an all-clear state instead of sitting there stale.
- No drift and nothing was ever flagged (the common case) -> stays silent, no unprompted bot comment.

Only runs when `custom_components/bambu_lab/translations/**` changes (push + PR), since that's the only thing that can introduce this kind of drift.

**This isn't theoretical** - right now, all 17 locales are missing the same 3 keys from two recent English-only changes (`tpu_high_flow` nozzle type, `tfa_csrf_fallback` error strings). The path filter means this PR's own CI run won't actually trigger it (it only touches the workflow/script files, not translations/), but it's been verified locally against the real translation files - see Testing below - and will run on the next PR that does touch translations/.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): CI tooling, informational only, no runtime/integration changes

### Link to Issue

None - came out of a repo-process review.

## Documentation

- [x] No documentation updates were necessary for this change

## Testing

- [x] All new and existing tests passed

Verified locally against the real (currently drifted) translation files: exits 0, correctly reports the 3-key drift as warnings. Also tested the "stale key" branch (a locale carrying a key no longer in `en.json`) against a throwaway copy of the translations directory, since the current real data only exercises the "missing key" path.

## Additional Notes

Scoped narrowly on purpose: this only reports drift. It doesn't run `scripts/auto_translate.py` automatically - that's a separate, more involved decision (machine-translation quality trust, when to trigger it, commit-vs-PR) that's being considered separately.