### PR TITLE
fix(tfa): adding missing CSRF endpoint to obtain real CSRF data 

### DIFF
--- a/custom_components/bambu_lab/pybambu/bambu_cloud.py
+++ b/custom_components/bambu_lab/pybambu/bambu_cloud.py
@@ -78,6 +78,12 @@ class CsrfError(Exception):
         super().__init__("Blocked by CSRF cookie requirement")
         self.error_code = 403
 
+class CsrfObtainError(Exception):
+    def __init__(self):
+        super().__init__("Not able to obtain CSRF cookie")
+        self.error_code = 403
+
+
 @dataclass
 class BambuCloud:
   
@@ -291,7 +297,17 @@ class BambuCloud:
             "tfaCode": code
         }
 
-        response = self._post(BambuUrl.TFA_LOGIN, json=data)
+        csrf_response = self._get(BambuUrl.CSRF)
+
+        if csrf_response.status_code != 204 or csrf_response.cookies.get('bbl_csrf_token') is None:
+            LOGGER.error(f"Failed to retrieve CSRF token: {csrf_response.status_code}")
+            raise CsrfObtainError
+
+        headers = self._get_headers()
+        headers['x-bbl-csrf-token'] = csrf_response.cookies.get('bbl_csrf_token')
+        headers['Cookie'] = f"bbl_csrf_token={csrf_response.cookies.get('bbl_csrf_token')}"
+
+        response = self._post(BambuUrl.TFA_LOGIN, headers=headers, json=data)
 
         LOGGER.debug(f"Response: {response.status_code}")
         if response.status_code == 200:

--- a/custom_components/bambu_lab/pybambu/const.py
+++ b/custom_components/bambu_lab/pybambu/const.py
@@ -300,6 +300,7 @@ class BambuUrl(IntEnum):
     PROJECTS = 8,
     USERDETAIL = 9,
     PREFERENCE = 10,
+    CSRF = 11,
 
 BAMBU_URL = {
     BambuUrl.LOGIN: 'https://api.bambulab.com/v1/user-service/user/login',
@@ -311,6 +312,7 @@ BAMBU_URL = {
     BambuUrl.TASKS: 'https://api.bambulab.com/v1/user-service/my/tasks',
     BambuUrl.PROJECTS: 'https://api.bambulab.com/v1/iot-service/api/user/project',
     BambuUrl.PREFERENCE: 'https://api.bambulab.com/v1/design-user-service/my/preference',
+    BambuUrl.CSRF: 'https://bambulab.com/api/sign-in/csrf',
 }
 
 # AMS tray `state` — see docs/merge-request-ams-tray-state.md


### PR DESCRIPTION
re-enabling usage of TFA instead of avoiding it

## Description

mainly I wanted to fix #1970 but than I also found #2058. Testing the new release re-enabled using login but as also mention in the PR not fixing the TFA / missing cookie problem.

I decided to recheck the whole login flow again and found an additional endpoint providing the CSRF info.

So this PR is meant to really fix TFA. Sadly it isn't as sophisticated, refined as #2058 but hopefully still exceptable

## Type of Change


- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

#1970 

## Documentation

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

