### PR TITLE
fix(ams): fall back to filament metadata when firmware omits per-tray state

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -3381,6 +3381,7 @@ class AMSTray:
         self._client = client
         self.empty = True
         self.state = 8
+        self._state_reported = False
         self.idx = ""
         self.name = ""
         self.type = ""
@@ -3457,6 +3458,9 @@ class AMSTray:
 
         metadata_only = ('id' in data) and set(data.keys()).issubset({'id', 'state'})
 
+        if 'state' in data:
+            self._state_reported = True
+
         if metadata_only:
             self.state = int(data['state']) if 'state' in data else 0
         else:
@@ -3483,9 +3487,29 @@ class AMSTray:
 
         return (old_data != f"{self.__dict__}")
 
+    def _has_filament_metadata(self) -> bool:
+        """True when tray metadata indicates a spool is present.
+
+        Fallback for firmware that never reports a per-tray ``state`` field:
+        presence of a filament profile id or a real material type means a
+        spool is loaded.
+        """
+        if self.idx:
+            return True
+        return bool(self.type) and self.type not in ("", "Empty")
+
     def _resolve_loaded_state(self, metadata_only: bool) -> None:
-        """Determine empty/loaded status based on AMS tray state field."""
-        if ams_tray_spool_loaded(self.state):
+        """Determine empty/loaded status.
+
+        Prefer the per-tray ``state`` bitfield when the printer reports one;
+        otherwise fall back to filament metadata so printers whose firmware
+        omits ``state`` still surface loaded spools instead of showing empty.
+        """
+        if self._state_reported:
+            loaded = ams_tray_spool_loaded(self.state)
+        else:
+            loaded = self._has_filament_metadata()
+        if loaded:
             self.empty = False
             name = self._resolve_tray_name(self.idx, self.type)
             self.name = name

--- a/tests/pybambu/test_ams_tray_state.py
+++ b/tests/pybambu/test_ams_tray_state.py
@@ -160,5 +160,58 @@ class TestAMSTrayState(unittest.TestCase):
         self.assertEqual(self.tray.state, 0)
 
 
+class TestAMSTrayNoStateFirmware(unittest.TestCase):
+    """Firmware that never reports a per-tray 'state' field.
+
+    The full tray payload carries filament metadata but no 'state', so
+    loaded/empty must be inferred from that metadata instead of the (never
+    updated) default state.
+    """
+
+    def setUp(self):
+        self.client = MagicMock()
+        self.client.slicer_settings.custom_filaments = {}
+        self.tray = AMSTray(self.client)
+
+    def test_full_payload_without_state_is_loaded(self):
+        self.tray.print_update({
+            "id": "0",
+            "remain": 43,
+            "tag_uid": "0000000000000000",
+            "tray_info_idx": "GFA01",
+            "tray_type": "PLA",
+            "tray_sub_brands": "PLA Matte",
+            "tray_color": "FFFFFFFF",
+        })
+        self.assertFalse(self.tray.empty)
+        self.assertEqual(self.tray.type, "PLA")
+
+    def test_empty_slot_without_state_is_empty(self):
+        self.tray.print_update({
+            "id": "1",
+            "tray_info_idx": "",
+            "tray_type": "",
+            "tray_color": "00000000",
+        })
+        self.assertTrue(self.tray.empty)
+
+    def test_type_only_without_state_is_loaded(self):
+        self.tray.print_update({
+            "id": "0",
+            "tray_info_idx": "",
+            "tray_type": "PETG",
+        })
+        self.assertFalse(self.tray.empty)
+        self.assertEqual(self.tray.name, "PETG")
+
+    def test_state_takes_over_once_reported(self):
+        # Loaded via metadata fallback first...
+        self.tray.print_update({"id": "0", "tray_type": "PLA", "tray_info_idx": "GFA01"})
+        self.assertFalse(self.tray.empty)
+        # ...then firmware starts reporting state: an empty state must win.
+        self.tray.print_update({"id": "0", "state": 8})
+        self.assertTrue(self.tray.empty)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

AMS trays show as empty on printers whose firmware sends a full tray
payload without a per-tray `state` field, even though the payload has
complete filament data.

`AMSTray` initializes `self.state = 8`, and `_resolve_loaded_state()`
decides empty/loaded only from `ams_tray_spool_loaded(self.state)`. When a
tray arrives with no `state` key, `print_update()` leaves `self.state` at
the default `8` (`STEADY` set, `SPOOL` clear), so `ams_tray_spool_loaded(8)`
is `False` and the slot is reset to empty. The filament data that did
arrive (tray_info_idx, tray_type, remain, colour) is discarded.

Example tray from such a payload, currently forced empty:

```json
{"id":"0","remain":43,"tag_uid":"0000000000000000","tray_info_idx":"GFA01",
 "tray_type":"PLA","tray_sub_brands":"PLA Matte","tray_color":"FFFFFFFF"}
```

Fix: track whether the printer has ever reported a `state` field. When it
has, behaviour is unchanged and the `state` bitfield stays the source of
truth. When it never does, fall back to filament metadata presence.

- `_state_reported` flag, set in `print_update()` when `'state' in data`
- `_has_filament_metadata()` helper
- `_resolve_loaded_state()` selects the state path or the metadata fallback

Firmware that reports `state` is unaffected.

## Type of Change

- [x] Bug fix

### Link to Issue

<!-- none -->

## Documentation

- [x] No documentation updates were necessary for this change

## Testing

Adds `TestAMSTrayNoStateFirmware` to `tests/pybambu/test_ams_tray_state.py`
for the no-`state` path: loaded full payload, empty slot, type-only, and
the transition where `state` starts being reported and takes over. Existing
tests still pass (`python -m pytest tests/pybambu`, 90 passed).

- [x] I have added/updated tests that prove my fix is effective
- [x] All new and existing tests passed

## Additional Notes

Seen on a P1S with a single AMS, running firmware 01.07.00.00. That
firmware is kept on purpose, since newer releases restrict the local
access this integration depends on. It sends full tray metadata but no
per-tray `state`, so the fallback only applies when `state` is never
present and does not relax empty detection for firmware that reports it.
