### PR TITLE
ci: skip PR comment on fork PRs in translation parity check

### DIFF
--- a/.github/workflows/translation-parity.yml
+++ b/.github/workflows/translation-parity.yml
@@ -37,6 +37,18 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
+            // GitHub forces a read-only GITHUB_TOKEN for pull_request runs
+            // triggered from a fork, regardless of the `permissions:` block
+            // above - so createComment/updateComment always 403s here. Skip
+            // rather than let that throw and fail this "informational only,
+            // never fails the job" check for every external contributor.
+            const isFork = context.payload.pull_request.head.repo.full_name !==
+                            context.payload.pull_request.base.repo.full_name;
+            if (isFork) {
+              core.notice("Skipping PR comment: forked PRs get a read-only token, so this check can't comment here. See the step above for the parity results.");
+              return;
+            }
+
             const fs = require("fs");
             const marker = "<!-- translation-parity-check -->";
             const body = fs.readFileSync("translation_parity_comment.md", "utf8");


### PR DESCRIPTION
## Problem

Fork-triggered `pull_request` runs get a read-only `GITHUB_TOKEN` from GitHub regardless of the `permissions:` block declared in the workflow. That means `createComment`/`updateComment` in the translation-parity comment step always throws `Resource not accessible by integration` for external contributors' PRs, and since the error wasn't caught, it failed the whole job — even though this check is explicitly meant to be informational-only and never fail.

Seen failing on #2098.

## Fix

Detect a fork PR up front (comparing `head.repo.full_name` vs `base.repo.full_name`) and skip the comment attempt with a `core.notice()` instead of letting the API call throw. The parity findings still surface via the annotations from the prior `check_translation_parity.py` step, which don't need write access.

Non-fork PRs are unaffected - they still get the summary comment as before.

## Note

For fork PRs, the parity findings are visible via the Checks tab annotations rather than a PR comment (Checks tab, not inline on Files Changed, if the drifted locale files aren't part of the PR's own diff). A fuller fix (two-workflow `workflow_run` pattern to safely post a real comment for forks too) is possible but out of scope here - filing this as the low-effort fix for the immediate broken-job issue.