### PR TITLE
ci: add A2L, X2D, and R1 to device dropdowns and labeler

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -52,15 +52,18 @@ body:
       options:
         - A1
         - A1 Mini
+        - A2L
         - H2C
         - H2D
         - H2S
         - P1P
         - P1S
         - P2S
+        - R1
         - X1
         - X1C
         - X1E
+        - X2D
         - AMS
         - AMS 2 Pro
         - AMS HT

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -18,15 +18,18 @@ body:
       options:
         - A1
         - A1 Mini
+        - A2L
         - H2C
         - H2D
         - H2S
         - P1P
         - P1S
         - P2S
+        - R1
         - X1
         - X1C
         - X1E
+        - X2D
         - AMS
         - AMS 2 Pro
         - AMS HT

--- a/.github/workflows/label-device.yml
+++ b/.github/workflows/label-device.yml
@@ -23,8 +23,8 @@ jobs:
             // Keep in sync with the `device` dropdown options in
             // .github/ISSUE_TEMPLATE/bug_report.yml and feature_request.yml.
             const DEVICES = [
-              "A1 Mini", "A1", "H2C", "H2D", "H2S", "P1P", "P1S", "P2S",
-              "X1E", "X1C", "X1", "AMS 2 Pro", "AMS HT", "AMS Lite", "AMS",
+              "A1 Mini", "A1", "A2L", "H2C", "H2D", "H2S", "P1P", "P1S", "P2S",
+              "R1", "X1E", "X1C", "X1", "X2D", "AMS 2 Pro", "AMS HT", "AMS Lite", "AMS",
             ]; // longest-name-first so "A1 Mini" matches before "A1", etc.
 
             const body = context.payload.issue.body || "";


### PR DESCRIPTION
## What

Adds `A2L`, `X2D`, and `R1` as selectable options in the "What device are you using?" dropdown on both issue templates, and keeps `label-device.yml`'s `DEVICES` list in sync per its own comment.

## Why

- `A2L` and `X2D` are already real printer models in pybambu's `Printers` enum, but weren't selectable when filing an issue/feature request against them.
- `R1` is an upcoming device with no integration support yet - adding it now so requests/reports for it land pre-labeled (`device: R1`) instead of unlabeled or misfiled, since it's a safe bet someone opens a feature request for it as soon as it's out.

## Labels

The existing `device: *` labels are pre-created manually rather than auto-created by the workflow (`addLabels` 404s against a label that doesn't exist), so I've already created the three matching labels on the repo with the same style as the rest: `device: A2L`, `device: X2D`, `device: R1` (`#1D76DB`, "Reported against a <device>").