### PR TITLE
Recover automatically when the printer rejects the access code

### DIFF
--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -40,6 +40,7 @@ from .const import (
 )
 
 from .pybambu import BambuClient
+from .pybambu.bambu_cloud import BambuCloud
 from .pybambu.const import (
     AMS_MODELS,
     AMS_DRYING_MODELS,
@@ -82,6 +83,9 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
             
         self._updatedDevice = False
         self._shutdown = False
+        # Guards the access denied recovery so one failure episode triggers at most one
+        # cloud lookup. Reset once the printer connects successfully again.
+        self._access_denied_handled = False
         self.data = self.get_model()
         self._eventloop = asyncio.get_running_loop()
         # Pass LOGGERFORHA logger into HA as otherwise it generates a debug output line every single time we tell it we have an update
@@ -116,7 +120,10 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         
         if event == "event_printer_bambu_authentication_failed":
             self._report_authentication_issue()
-        
+
+        elif event == "event_printer_access_denied":
+            self._hass.async_create_task(self._async_handle_access_denied())
+
         elif event == "event_printer_no_external_storage":
             self._report_no_external_storage_issue()
 
@@ -127,6 +134,8 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
             self._report_encryption_enabled_issue()
 
         elif event == "event_printer_ready":
+            # A successful connection ends any access denied episode.
+            self._access_denied_handled = False
             self._printer_ready()
 
         elif event == "event_light_update":
@@ -1065,6 +1074,53 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
             translation_key=issue,
             translation_placeholders = {"device": f"'{self.config_entry.options.get('name', '')}'"},
         )
+
+    async def _async_handle_access_denied(self):
+        # The printer refused the MQTT connection with CONNACK code 5. The usual cause is a
+        # rotated LAN access code - a factory reset regenerates it - and retrying can never
+        # recover from that, so the client has already stopped. For cloud-linked printers
+        # Bambu Cloud already knows the new code (it's how Bambu Studio and Handy reconnect
+        # after a reset), so try to refresh it silently before asking the user for anything.
+        #
+        # Note code 5 is also seen when the printer is powered off (#1863), so the stored
+        # code is only replaced when the cloud reports a genuinely different one.
+        if self._access_denied_handled:
+            return
+        self._access_denied_handled = True
+
+        options = self.config_entry.options
+        auth_token = options.get('auth_token', '')
+        serial = self.config_entry.data['serial']
+        if auth_token != '':
+            bambu_cloud = BambuCloud(
+                options.get('region', ''),
+                options.get('email', ''),
+                options.get('username', ''),
+                auth_token)
+            devices = await self._hass.async_add_executor_job(bambu_cloud.get_device_list)
+            device = next((device for device in devices or [] if device.get('dev_id') == serial), None)
+            new_access_code = '' if device is None else device.get('dev_access_code', '')
+            if new_access_code != '' and new_access_code != options.get('access_code', ''):
+                LOGGER.info("Printer rejected the access code but Bambu Cloud reports a new one. Updating the config entry and reloading.")
+                new_options = dict(options)
+                new_options['access_code'] = new_access_code
+                self._hass.config_entries.async_update_entry(
+                    entry=self.config_entry,
+                    data=self.config_entry.data,
+                    options=new_options)
+                await self.hass.config_entries.async_reload(self.config_entry.entry_id)
+                return
+            if new_access_code != '' and new_access_code == options.get('access_code', ''):
+                # The stored code still matches the cloud - the rejection has another cause,
+                # such as the printer being powered off or mid-boot. Nothing to repair here.
+                LOGGER.debug("Printer rejected the access code but it matches Bambu Cloud. Not an access code problem.")
+                return
+        # LAN-only setup, or the cloud lookup failed - the user has to read the new code off
+        # the printer's screen, so tell them with a visible repair issue instead of a log line.
+        self._report_access_code_rejected_issue()
+
+    def _report_access_code_rejected_issue(self):
+        self._report_generic_issue("access_code_rejected", True)
 
     def _report_authentication_issue(self):
         # issue_id's are permanent - once ignored they will never show again so we need a unique id 

--- a/custom_components/bambu_lab/pybambu/bambu_client.py
+++ b/custom_components/bambu_lab/pybambu/bambu_client.py
@@ -598,6 +598,10 @@ class BambuClient:
             if self._last_error_code != result_code:
                 if result_code == 5:
                     LOGGER.error(f"On Disconnect: Printer disconnected with Access Denied error. Check serial, access code and IP address.")
+                    # Tell the integration layer the printer rejected the access code. The usual cause is a
+                    # rotated code (a factory reset regenerates it), which the coordinator can recover from
+                    # Bambu Cloud for cloud-linked printers - or surface as a repair issue for LAN setups.
+                    self.callback("event_printer_access_denied")
                 else:
                     LOGGER.debug(f"On Disconnect: Printer disconnected with error code: {result_code}")
             else:

--- a/custom_components/bambu_lab/translations/en.json
+++ b/custom_components/bambu_lab/translations/en.json
@@ -904,6 +904,10 @@
       "title": "Authentication Failed",
       "description": "Attempting to connect to Bambu Lab failed for {device}. Please reconfigure the integration and provide fresh credentials."
     },
+    "access_code_rejected": {
+      "title": "Access Code Rejected",
+      "description": "The printer rejected the configured access code for {device}. This usually means the code was regenerated, for example by a factory reset. Read the new access code from the printer's network settings screen and reconfigure the integration with it."
+    },
     "no_external_storage": {
       "title": "No USB or SD Card Detected",
       "description": "{device} does not have an USB or SD card connected. This is needed for all features that depend on ftp to the printer such as the cover image, skipping objects and print history."

--- a/custom_components/bambu_lab/translations/es.json
+++ b/custom_components/bambu_lab/translations/es.json
@@ -920,6 +920,10 @@
       "title": "Error de autenticación",
       "description": "El intento de conectarse a Bambu Lab falló para {device}. Vuelva a configurar la integración y proporcione credenciales nuevas."
     },
+    "access_code_rejected": {
+      "title": "Código de acceso rechazado",
+      "description": "La impresora rechazó el código de acceso configurado para {device}. Esto suele significar que el código se regeneró, por ejemplo tras un restablecimiento de fábrica. Consulte el nuevo código de acceso en la pantalla de ajustes de red de la impresora y vuelva a configurar la integración con él."
+    },
     "no_external_storage": {
       "title": "No se detecta ninguna tarjeta USB o SD",
       "description": "{device} no tiene una tarjeta USB o SD conectada. Esto es necesario para todas las funciones que dependen de ftp para la impresora, como la imagen de portada, la omisión de objetos y el historial de impresión."

--- a/tests/pybambu/test_bambu_client_disconnect.py
+++ b/tests/pybambu/test_bambu_client_disconnect.py
@@ -1,0 +1,37 @@
+import unittest
+from unittest.mock import MagicMock
+
+from pybambu.bambu_client import BambuClient
+
+
+class TestAccessDeniedDisconnect(unittest.TestCase):
+    """CONNACK code 5 means the printer rejected the access code - typically because a
+    factory reset regenerated it. The client already stops retrying in that case; these
+    pin the event that lets the integration layer react (refresh the code from Bambu
+    Cloud, or raise a repair issue)."""
+
+    def setUp(self):
+        self.client = BambuClient({
+            'host': '192.0.2.10',
+            'serial': 'TESTSERIAL123',
+            'enable_camera': False,
+        })
+        self.events = []
+        self.client._callback = self.events.append
+        self.client.client = MagicMock()
+
+    def test_access_denied_fires_the_event(self):
+        self.client.on_disconnect(client_=None, userdata=None, result_code=5)
+
+        self.assertIn("event_printer_access_denied", self.events)
+
+    def test_other_error_codes_do_not_fire_it(self):
+        self.client.on_disconnect(client_=None, userdata=None, result_code=16)
+
+        self.assertNotIn("event_printer_access_denied", self.events)
+
+    def test_a_repeated_access_denied_fires_the_event_once(self):
+        self.client.on_disconnect(client_=None, userdata=None, result_code=5)
+        self.client.on_disconnect(client_=None, userdata=None, result_code=5)
+
+        self.assertEqual(self.events.count("event_printer_access_denied"), 1)


### PR DESCRIPTION
## Description

When a printer rejects the MQTT connection with CONNACK code 5 (Access Denied), the integration currently logs one error and stops the client (`bambu_client.py`, `on_disconnect`) — and that is the end of it: no repair issue, no reauth path, no recovery. The entities go `unavailable` and the only explanation lives in a debug log.

The usual real-world cause is a **rotated LAN access code**: a factory reset regenerates it (other causes: the user regenerating it manually). After the reset, the user re-binds the printer to their Bambu account — Bambu's own required step — and from that moment **Bambu Cloud already knows the new access code**, which is how Bambu Studio and Handy reconnect without asking for anything. The integration holds the same cloud session and the same API (`get_device_list()` returns `dev_access_code`), but never uses it for this.

This PR closes that gap:

- `pybambu/bambu_client.py`: on the first CONNACK 5 of an episode, emit a new `event_printer_access_denied` callback (additive; existing behaviour unchanged).
- `coordinator.py`: handle the event once per failure episode (reset on `event_printer_ready`):
  - **Cloud-linked printers**: fetch the device list from Bambu Cloud (in an executor) and compare `dev_access_code` with the configured one. If it differs, update the config entry and reload — the integration heals itself with zero user action, matching the behaviour of Bambu's own apps.
  - If the cloud reports the **same** code, do nothing: code 5 is also seen when the printer is powered off (#1863), and replacing a correct code or nagging the user would be wrong there.
  - **LAN-only setups** (or a failed cloud lookup): raise a visible repair issue (`access_code_rejected`) telling the user to read the new code off the printer's screen — instead of today's silent dead integration.

Translations: `access_code_rejected` issue strings added to `en.json` and `es.json` (other locales left to the informational parity flow).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

No exact open issue; related context: #2065 (authentication dead-end), #1863 (code 5 while the printer is powered off — the reason the fix compares codes instead of reacting blindly).

## Documentation

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

`python -m pytest tests/pybambu`: **89 passed** (86 existing + 3 new in `tests/pybambu/test_bambu_client_disconnect.py` pinning that CONNACK 5 fires the event once per episode and other codes do not). Both translation files validate as JSON; touched modules compile clean.

Field validation: the cloud-recovery path reproduces a real incident — after a factory reset, an integration configured via cloud login sat in an Access Denied loop; fetching `dev_access_code` via the stored session and updating the entry's `access_code`, then reloading, restored the connection immediately (CONNACK 0). This PR automates exactly that manual repair.

## Additional Notes

- The recovery runs at most once per failure episode (`_access_denied_handled`, reset on a successful connect), so a printer that stays denied does not hammer the Bambu API.
- The stored code is only ever **replaced** when the cloud reports a genuinely different one — never cleared, never guessed.
- Scope deliberately excludes the reconnect/backoff behaviour for other disconnect codes.
