### PR TITLE
Fix stale local print cover images

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -939,6 +939,9 @@ class PrintJob:
     gcode_file: str
     gcode_file_downloaded: str
     _subtask_name: str
+    model_id: str
+    task_id: str
+    plate_idx: int
     start_time: datetime
     end_time: datetime
     remaining_time: int
@@ -966,6 +969,9 @@ class PrintJob:
         self.gcode_file = ""
         self.gcode_file_downloaded = ""
         self._subtask_name = ""
+        self.model_id = ""
+        self.task_id = ""
+        self.plate_idx = 0
         self.start_time = None
         self.end_time = None
         self.remaining_time = 0
@@ -1080,6 +1086,10 @@ class PrintJob:
         self._subtask_name = data.get("subtask_name", self._subtask_name)
         if old_subtask_name != self._subtask_name:
             LOGGER.debug(f"SUBTASK_NAME: {self._subtask_name}")
+
+        self.model_id = data.get("model_id", self.model_id)
+        self.task_id = data.get("task_id", self.task_id)
+        self.plate_idx = data.get("plate_idx", self.plate_idx)
 
         # Printer-initiated prints and reprints can reach RUNNING before the
         # printer reports a subtask name. In that case model data is initially
@@ -2207,16 +2217,20 @@ class PrintJob:
                         plate_number = metadata.get('value')
                         LOGGER.debug(f"Plate: {plate_number}")
                         
-                        # Now we have the plate number, extract the cover image from the archive
-                        self._client._device.cover_image.set_image(archive.read(f"Metadata/plate_{plate_number}.png"))
-                        LOGGER.debug(f"Cover image: Metadata/plate_{plate_number}.png")
+                        # MQTT is authoritative for the plate that is actively printing.
+                        # A printer can retain/reuse a 3mf whose slice_info points at a
+                        # different plate, which otherwise makes the cover image stale.
+                        active_plate_number = str(self.plate_idx) if self.plate_idx else plate_number
+                        cover_entry_name = f"Metadata/plate_{active_plate_number}.png"
+                        self._client._device.cover_image.set_image(archive.read(cover_entry_name))
+                        LOGGER.debug(f"Cover image: {cover_entry_name}")
 
                         # Save the cover image to the cache
                         try:
                             # Save the cover image directly to the cache
                             cover_filename = os.path.splitext(os.path.basename(model_file_path))[0] + '.png'
                             cover_path = os.path.join(model_dir, cover_filename)
-                            with archive.open(f"Metadata/plate_{plate_number}.png") as cover_entry, open(cover_path, "wb") as target_path:
+                            with archive.open(cover_entry_name) as cover_entry, open(cover_path, "wb") as target_path:
                                 shutil.copyfileobj(cover_entry, target_path)
                             LOGGER.debug(f"Cover image saved to: {cover_path}")
                         except Exception as e:
@@ -2381,8 +2395,12 @@ class PrintJob:
             self.end_time = None
         else:
             LOGGER.debug("Updating bambu cloud task data found for printer.")
+            # For local prints with FTP available, the printer's 3mf is the
+            # authoritative image source. Bambu Cloud's "latest task" can lag
+            # behind the active print and return a stale cover.
+            use_cloud_cover = not (self._print_type == "local" and self._client.ftp_enabled)
             url = self._task_data.get('cover', '')
-            if url != "":
+            if use_cloud_cover and url != "":
                 data = self._client.bambu_cloud.download(url)
                 self._client._device.cover_image.set_image(data)
 

--- a/tests/pybambu/test_models.py
+++ b/tests/pybambu/test_models.py
@@ -6,6 +6,7 @@ import os
 import json
 import tempfile
 import time
+from zipfile import ZipFile
 
 from pathlib import Path
 
@@ -127,6 +128,65 @@ class TestPrintJob(unittest.TestCase):
 
         self.print_job._clear_model_data.assert_not_called()
         self.print_job._update_task_data.assert_not_called()
+
+    def test_print_update_tracks_active_print_identity(self):
+        """MQTT job identifiers are retained for model-data validation."""
+        self.print_job.gcode_state = "RUNNING"
+
+        self.print_job.print_update({
+            "model_id": "US-current-model",
+            "task_id": "8291",
+            "plate_idx": 2,
+        })
+
+        self.assertEqual(self.print_job.model_id, "US-current-model")
+        self.assertEqual(self.print_job.task_id, "8291")
+        self.assertEqual(self.print_job.plate_idx, 2)
+
+    def test_local_print_does_not_apply_cloud_cover_when_ftp_available(self):
+        """A stale cloud task must not overwrite a local print's FTP cover."""
+        self.client.ftp_enabled = True
+        self.client.bambu_cloud.auth_token = "token"
+        self.client.bambu_cloud.get_latest_task_for_printer.return_value = {
+            "cover": "https://example.invalid/stale.png",
+            "status": 2,
+        }
+        self.print_job._print_type = "local"
+
+        self.print_job._download_task_data_from_cloud()
+
+        self.client.bambu_cloud.download.assert_not_called()
+        self.client._device.cover_image.set_image.assert_not_called()
+
+    def test_ftp_cover_uses_active_mqtt_plate(self):
+        """The active MQTT plate wins when archive metadata points elsewhere."""
+        self.client.ftp_enabled = True
+        self.client._device.supports_feature.return_value = False
+        self.print_job.plate_idx = 2
+        self.print_job.ams_mapping = []
+        self.print_job.prune_print_history_files = MagicMock()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_path = os.path.join(temp_dir, "current.3mf")
+            with ZipFile(model_path, "w") as archive:
+                archive.writestr(
+                    "Metadata/slice_info.config",
+                    '<config><plate><metadata key="index" value="4" /></plate></config>',
+                )
+                archive.writestr("Metadata/plate_2.png", b"active-plate-cover")
+                archive.writestr("Metadata/plate_4.png", b"stale-plate-cover")
+                archive.writestr("Metadata/plate_4.gcode", b"gcode")
+                archive.writestr("Metadata/plate_4.json", '{"bed_type": "textured_plate"}')
+
+            sources = [MagicMock()]
+            self.print_job._remote_media_sources = MagicMock(return_value=sources)
+            self.print_job._attempt_remote_model_download = MagicMock(return_value=model_path)
+            self.print_job._close_remote_media_sources = MagicMock()
+
+            result = self.print_job._async_download_task_data_from_printer_worker()
+
+        self.assertTrue(result)
+        self.client._device.cover_image.set_image.assert_called_once_with(b"active-plate-cover")
 
     def test_prune_cleans_stale_part_files_even_when_pruning_disabled(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

Fix stale or incorrect cover images for local prints when Bambu Cloud task data or archived plate metadata does not match the active printer job.

## Root cause

The integration could use the latest Bambu Cloud task cover without proving that task was the currently running local print. It could also extract the cover image using the plate index stored in the downloaded 3MF metadata even when MQTT reported a different active plate.

This can leave Home Assistant showing the correct task name while displaying a cover from an older print or another plate.

## Changes

- Retain `model_id`, `task_id`, and `plate_idx` from the active MQTT print state.
- For local prints with printer media access available, do not let the Bambu Cloud latest-task cover overwrite the printer-derived cover.
- Use the active MQTT `plate_idx` when extracting the cover image from the 3MF archive.
- Preserve the existing delayed-subtask-name refresh behavior.
- Add regression tests for active print identity, stale cloud covers, and mismatched archive/MQTT plate indices.

## Validation

- `python -m pytest tests/pybambu` — 96 passed
- `git diff --check`
