### PR TITLE
Fix AMS entities disappearing after incomplete version data

### DIFF
--- a/custom_components/bambu_lab/binary_sensor.py
+++ b/custom_components/bambu_lab/binary_sensor.py
@@ -40,9 +40,11 @@ async def async_setup_entry(
 
     for sensor in AMS_BINARY_SENSORS:
         for index in coordinator.get_model().ams.data.keys():
-            if coordinator.get_model().ams.data[index] is not None:
-                if sensor.exists_fn(coordinator, index):
-                    async_add_entities([BambuLabAMSBinarySensor(coordinator, sensor, index)])
+            ams_instance = coordinator.get_model().ams.data[index]
+            if ams_instance is None or not ams_instance.serial:
+                continue
+            if sensor.exists_fn(coordinator, index):
+                async_add_entities([BambuLabAMSBinarySensor(coordinator, sensor, index)])
 
     for sensor in VIRTUAL_TRAY_BINARY_SENSORS:    
         if sensor.exists_fn(coordinator):

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -875,10 +875,18 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         for device in dev_reg.devices.values():
             if config_entry_id in device.config_entries:
                 # This device is associated with this printer.
-                if device.model == 'AMS' or device.model == 'AMS Lite' or device.model == 'AMS 2 Pro' or device.model == 'AMS HT':
-                    # And it's an AMS device
+                is_known_ams = device.model in ('AMS', 'AMS Lite', 'AMS 2 Pro', 'AMS HT')
+                is_placeholder_ams = (
+                    device.model == 'Unknown'
+                    and (DOMAIN, "") in device.identifiers
+                    and (device.name or "").startswith(f"{self.config_entry.data['device_type']}_{self.config_entry.data['serial']}_AMS_")
+                )
+                if is_known_ams or is_placeholder_ams:
+                    # push_status can create an AMS placeholder before version metadata is
+                    # available. Older versions registered that placeholder with an empty
+                    # identifier; always discard it so the real serial can own the device.
                     ams_serial = list(device.identifiers)[0][1]
-                    if ams_serial not in existing_ams_devices:
+                    if is_placeholder_ams or ams_serial not in existing_ams_devices:
                         LOGGER.debug(f"Found stale attached AMS with serial {ams_serial}")
                         ams_devices_to_remove.append(device.id)
 

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -155,9 +155,10 @@ class Device:
         return (self.push_all_data != None) and (self.get_version_data != None)
 
     def info_update(self, data):
+        had_full_printer_data = self.has_full_printer_data
         self.info.info_update(data = data)
         self.home_flag.info_update(data = data)
-        self.ams.info_update(data = data)
+        ams_info_changed = self.ams.info_update(data = data)
 
         if data.get("command") == "get_version":
             send_ready_event = self.get_version_data is None and self.push_all_data is not None
@@ -165,6 +166,11 @@ class Device:
                 LOGGER.debug("Reached first push of version data.")
             self.get_version_data = data
             if send_ready_event:
+                self._client.callback("event_printer_ready")
+            elif had_full_printer_data and ams_info_changed:
+                # A later get_version response can fill in AMS identity metadata that was
+                # missing during initial startup. Re-run entity setup so placeholder AMS
+                # entries are replaced with entities using the real serial/model.
                 self._client.callback("event_printer_ready")
 
 
@@ -3132,7 +3138,7 @@ class AMSList:
         else:
             return self.data[self.active_ams_index].tray[self.active_tray_index]
 
-    def info_update(self, data):
+    def info_update(self, data) -> bool:
         old_data = f"{self.__dict__}"
 
         # First determine if this the version info data or the json payload data. We use the version info to determine
@@ -3204,6 +3210,7 @@ class AMSList:
                 data_changed = True
 
         data_changed = data_changed or (old_data != f"{self.__dict__}")
+        return data_changed
 
     def print_update(self, data) -> bool:
         old_data = f"{self.__dict__}"

--- a/custom_components/bambu_lab/sensor.py
+++ b/custom_components/bambu_lab/sensor.py
@@ -45,6 +45,13 @@ async def async_setup_entry(
 
     for sensor in AMS_SENSORS:
         for index in coordinator.get_model().ams.data.keys():
+            ams_instance = coordinator.get_model().ams.data[index]
+            # push_status can arrive before complete get_version metadata and create
+            # a placeholder AMS with no serial. Device/entity identity depends on the
+            # real AMS serial, so wait for version metadata instead of registering a
+            # transient placeholder that HA cannot later reconcile cleanly.
+            if ams_instance is None or not ams_instance.serial:
+                continue
             if sensor.exists_fn(coordinator, index):
                 async_add_entities([BambuLabAMSSensor(coordinator, sensor, index)])
 

--- a/tests/pybambu/test_models.py
+++ b/tests/pybambu/test_models.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from pybambu.models import (
     AMSList,
     Camera,
+    Device,
     Extruder,
     Fans,
     HMSList,
@@ -282,6 +283,47 @@ class TestAMSList(unittest.TestCase):
         self.ams_list.info_update(data)
         self.assertIn(0, self.ams_list.data)
         self.assertEqual(self.ams_list.data[0].sw_version, "00.00.06.49")
+
+    def test_ams_info_update_reports_identity_changes(self):
+        data = self.test_data['get_version']
+
+        self.assertTrue(self.ams_list.info_update(data))
+        self.assertFalse(self.ams_list.info_update(data))
+
+    def test_late_ams_version_metadata_retriggers_ready(self):
+        """Complete AMS identity arriving after startup must rebuild HA entities."""
+        client = MagicMock()
+        device = Device(client)
+        client._device = device
+
+        # A full status push can arrive before version metadata and creates an AMS
+        # placeholder with no serial/model identity.
+        device.print_update(self.test_data['push_all'])
+        self.assertIn(0, device.ams.data)
+        self.assertEqual(device.ams.data[0].serial, "")
+        self.assertEqual(device.ams.data[0].model, "Unknown")
+
+        # Simulate the first get_version response being incomplete (printer module
+        # present, AMS module omitted). Startup still becomes ready at this point.
+        incomplete_version = json.loads(json.dumps(self.test_data['get_version']))
+        incomplete_version['module'] = [
+            module for module in incomplete_version.get('module', [])
+            if not module.get('name', '').startswith(('ams/', 'ams_f1/', 'n3f/', 'n3s/'))
+        ]
+        device.info_update(incomplete_version)
+        self.assertTrue(device.has_full_printer_data)
+        client.callback.assert_any_call("event_printer_ready")
+        ready_count = client.callback.call_args_list.count(call("event_printer_ready"))
+
+        # A later complete version response fills in the real AMS identity. This
+        # must fire ready again so the coordinator reruns entity registration.
+        device.info_update(self.test_data['get_version'])
+        self.assertNotEqual(device.ams.data[0].serial, "")
+        self.assertNotEqual(device.ams.data[0].model, "Unknown")
+        self.assertEqual(
+            client.callback.call_args_list.count(call("event_printer_ready")),
+            ready_count + 1,
+        )
 
     def test_ams_print_update(self):
         # Test AMS print update


### PR DESCRIPTION
## Summary

Fixes a startup race where AMS entities can disappear while the printer itself remains online.

## Root cause

A `push_status` payload can arrive before complete `get_version` metadata. In that order, pybambu creates a placeholder AMS with model `Unknown` and an empty serial. Home Assistant can then initialize against that placeholder before the real AMS identity arrives.

If a later `get_version` response fills in the AMS serial/model, the integration previously did not rerun entity setup. This can leave an AMS device registered with no entities until the integration is manually reloaded.

## Changes

- Do not register AMS sensor/binary-sensor entities until the AMS has a real serial.
- Make `AMSList.info_update()` report AMS identity changes.
- Retrigger the existing printer-ready reinitialization path when late version metadata fills in AMS identity after startup.
- Remove stale placeholder AMS devices created with an empty identifier by older behavior.
- Add regression coverage for `push_status` arriving before incomplete then complete `get_version` data.

## Tests

- `python -m pytest -q` — 95 passed
- `git diff --check upstream/main...HEAD` — clean
