### PR TITLE
Fix Bambu camera stream URL handling for X2D

### DIFF
--- a/custom_components/bambu_lab/camera.py
+++ b/custom_components/bambu_lab/camera.py
@@ -117,8 +117,15 @@ class BambuLabRtspCamera(BambuLabEntity, Camera):
         return self._stream_source()
 
     def _stream_source(self) -> str | None:
+        reported_url = self.coordinator.get_model().camera.rtsp_url
+        if isinstance(reported_url, bytes):
+            try:
+                reported_url = reported_url.decode()
+            except UnicodeDecodeError:
+                return None
+
         return get_authenticated_rtsp_url(
-            self.coordinator.get_model().camera.rtsp_url,
+            reported_url,
             self._host,
             self._access_code,
         )

--- a/custom_components/bambu_lab/camera.py
+++ b/custom_components/bambu_lab/camera.py
@@ -91,7 +91,6 @@ class BambuLabRtspCamera(BambuLabEntity, Camera):
 
         self._attr_unique_id = f"{config_entry.data['serial']}_camera"
         self._access_code = config_entry.options.get("access_code", "")
-        self._host = config_entry.options.get("host", "")
 
         super().__init__(coordinator=coordinator)
         Camera.__init__(self)
@@ -117,7 +116,9 @@ class BambuLabRtspCamera(BambuLabEntity, Camera):
         return self._stream_source()
 
     def _stream_source(self) -> str | None:
-        reported_url = self.coordinator.get_model().camera.rtsp_url
+        model = self.coordinator.get_model()
+        ip_address = model.info.ip_address
+        reported_url = model.camera.rtsp_url
         if isinstance(reported_url, bytes):
             try:
                 reported_url = reported_url.decode()
@@ -126,7 +127,7 @@ class BambuLabRtspCamera(BambuLabEntity, Camera):
 
         return get_authenticated_rtsp_url(
             reported_url,
-            self._host,
+            ip_address,
             self._access_code,
         )
 

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -34,7 +34,7 @@ The serial number is in the form `a1b2c3d4e5f6a1b2`, not the `3DP-000-000` ident
 
 Additional setup may be needed for specific entities to work:
 
-- Camera feeds for H2D / H2S - you must enable the "LAN Only Liveview" option in the LAN mode settings. It is not necessary to enable LAN mode generally to enable the "LAN Only Liveview" option. This simply enables the RTSP stream to be available locally. The camera feed will also continue to work via Bambu Studio / Bamby Handy remotely.
+- Camera feeds for H2D / H2S / X2D - you must enable the "LAN Only Liveview" option in the LAN mode settings. It is not necessary to enable LAN mode generally to enable the "LAN Only Liveview" option. This simply enables the RTSP stream to be available locally. The camera feed will also continue to work via Bambu Studio / Bamby Handy remotely.
 - Cover image, Print weight, Print Bed Type - with newer firmware/printers (e.g. H2D 01.03.00.00, H2S 01.02.00.00, P2S), you must enable "Store Sent Files on External Storage" in the printer's "Print Options" settings, and use a USB drive/SD card (depending on the printer). These entities need to get the print file from the printer, but the internal storage doesn't seem to be exposed.
 
 #### Advanced options


### PR DESCRIPTION
## Description

Fixes Bambu Lab RTSP camera source handling for the X2D. The X2D reports its stream URL as bytes. The camera entity now decodes byte URLs at its boundary, substitutes the printer's current runtime IP address, and documents the X2D LAN LiveView requirement.

## Type of Change

<!-- Mark the appropriate option(s) with an 'x' -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

<!-- Provide a link to the Github issue if applicable -->

## Documentation

<!-- Mark the following checklist with an 'x' to confirm -->

- [X] I have updated the relevant documentation to reflect these changes
- [ ] No documentation updates were necessary for this change

## Testing

<!-- Describe the testing you have performed -->

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed

## Additional Notes

- Normalizes UTF-8 byte stream URLs before authentication and parsing.
- Returns no stream source for invalid UTF-8 instead of failing camera entity setup.
- Uses the printer model's current IP address rather than the potentially stale configured host.
- Adds X2D to the printers requiring LAN Only LiveView.

```
Logger: homeassistant.components.camera
Source: helpers/entity\_platform.py:725
Integration: Camera (documentation, issues)
First occurred: 6:03:32 PM (2 occurrences)
Last logged: 6:33:52 PM
Error adding entity camera.x2d\_camera for domain camera with platform bambu\_lab
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/helpers/entity\_platform.py", line 725, in \_async\_add\_entities
await self.\_async\_add\_entity(
entity, False, entity\_registry, config\_subentry\_id
)
File "/usr/src/homeassistant/homeassistant/helpers/entity\_platform.py", line 1104, in \_async\_add\_entity
await entity.add\_to\_platform\_finish()
File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1443, in add\_to\_platform\_finish
await self.async\_internal\_added\_to\_hass()
File "/usr/src/homeassistant/homeassistant/components/camera/**init**.py", line 705, in async\_internal\_added\_to\_hass
await self.async\_refresh\_providers(write\_state=False)
File "/usr/src/homeassistant/homeassistant/components/camera/**init**.py", line 731, in async\_refresh\_providers
new\_provider = await self.\_async\_get\_supported\_webrtc\_provider(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
async\_get\_supported\_provider
^^^^^^^^^^^^^^^^^^^^^^^^^^^^
)
^
File "/usr/src/homeassistant/homeassistant/components/camera/**init**.py", line 764, in \_async\_get\_supported\_webrtc\_provider
return await fn(self.hass, self)
^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/src/homeassistant/homeassistant/components/camera/webrtc.py", line 365, in async\_get\_supported\_provider
if not providers or not (stream\_source := await camera.stream\_source()):
^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/config/custom\_components/bambu\_lab/camera.py", line 115, in stream\_source
split\_host = parsed\_url.netloc.split(':')
TypeError: a bytes-like object is required, not 'str'
```
