### PR TITLE
Fix fan percentages and failed-publish state overrides

### DIFF
--- a/custom_components/bambu_lab/fan.py
+++ b/custom_components/bambu_lab/fan.py
@@ -8,6 +8,7 @@ from homeassistant.components.fan import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, LOGGER
@@ -108,14 +109,14 @@ class BambuLabFan(BambuLabEntity, FanEntity):
 
     def _set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
-        if self.entity_description.key == "cooling_fan":
-            self.coordinator.get_model().fans.set_fan_speed(FansEnum.PART_COOLING, percentage)
-        elif self.entity_description.key == "aux_fan":
-            self.coordinator.get_model().fans.set_fan_speed(FansEnum.AUXILIARY, percentage)
-        elif self.entity_description.key == "chamber_fan":
-            self.coordinator.get_model().fans.set_fan_speed(FansEnum.CHAMBER, percentage)
-        elif self.entity_description.key == "secondary_aux_fan":
-            self.coordinator.get_model().fans.set_fan_speed(FansEnum.SECONDARY_AUXILIARY, percentage)
+        fan = {
+            "cooling_fan": FansEnum.PART_COOLING,
+            "aux_fan": FansEnum.AUXILIARY,
+            "chamber_fan": FansEnum.CHAMBER,
+            "secondary_aux_fan": FansEnum.SECONDARY_AUXILIARY,
+        }[self.entity_description.key]
+        if not self.coordinator.get_model().fans.set_fan_speed(fan, percentage):
+            raise HomeAssistantError("Fan command could not be published")
 
     def set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
@@ -123,7 +124,7 @@ class BambuLabFan(BambuLabEntity, FanEntity):
 
     def turn_on(self, speed: str = None, percentage: int = None, preset_mode: str = None, **kwargs: any) -> None:
         """Turn the fan on."""
-        self._set_percentage(100)
+        self._set_percentage(100 if percentage is None else percentage)
 
     def turn_off(self, **kwargs) -> None:
         """Turn the fan off."""

--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -692,13 +692,17 @@ class Fans:
 
         return (old_data != f"{self.__dict__}")
 
-    def set_fan_speed(self, fan: FansEnum, percentage: int):
+    def set_fan_speed(self, fan: FansEnum, percentage: int) -> bool:
         """Set fan speed"""
         percentage = round(percentage / 10) * 10
         command = fan_percentage_to_gcode(fan, percentage)
 
+        # Do not report a local override when the broker rejected the publish.
+        if not self._client.publish(command):
+            return False
+
         if fan == FansEnum.PART_COOLING:
-            self._cooling_fan_speed = percentage
+            self._cooling_fan_speed_override = percentage
             self._cooling_fan_speed_override_time = datetime.now()
         elif fan == FansEnum.AUXILIARY:
             self._aux_fan_speed_override = percentage
@@ -710,10 +714,8 @@ class Fans:
             self._secondary_aux_fan_speed_override = percentage
             self._secondary_aux_fan_speed_override_time = datetime.now()
 
-        LOGGER.debug(command)
-        self._client.publish(command)
-
         self._client.callback("event_printer_data_update")
+        return True
 
     def get_fan_speed(self, fan: FansEnum) -> int:
         if fan == FansEnum.PART_COOLING:

--- a/tests/pybambu/test_fans.py
+++ b/tests/pybambu/test_fans.py
@@ -1,0 +1,55 @@
+"""Fan overrides must reflect commands actually accepted for publication."""
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from pybambu.const import FansEnum
+from pybambu.models import Fans
+
+
+CONTROLLABLE = (
+    FansEnum.PART_COOLING,
+    FansEnum.AUXILIARY,
+    FansEnum.CHAMBER,
+    FansEnum.SECONDARY_AUXILIARY,
+)
+
+
+@pytest.mark.parametrize("fan", CONTROLLABLE)
+def test_successful_publish_sets_override(fan):
+    client = MagicMock()
+    client.publish.return_value = True
+    fans = Fans(client)
+
+    assert fans.set_fan_speed(fan, 20) is True
+    assert fans.get_fan_speed(fan) == 20
+    client.publish.assert_called_once()
+    client.callback.assert_called_once_with("event_printer_data_update")
+
+
+@pytest.mark.parametrize("fan", CONTROLLABLE)
+def test_failed_publish_preserves_previous_override(fan):
+    client = MagicMock()
+    client.publish.return_value = True
+    fans = Fans(client)
+    fans.set_fan_speed(fan, 20)
+    client.reset_mock()
+    client.publish.return_value = False
+
+    assert fans.set_fan_speed(fan, 80) is False
+    assert fans.get_fan_speed(fan) == 20
+    client.callback.assert_not_called()
+
+
+def test_part_cooling_returns_to_printer_telemetry_after_override_expires():
+    client = MagicMock()
+    client.publish.return_value = True
+    fans = Fans(client)
+    fans.print_update({"cooling_fan_speed": "0"})
+    fans.set_fan_speed(FansEnum.PART_COOLING, 20)
+    assert fans.get_fan_speed(FansEnum.PART_COOLING) == 20
+
+    fans._cooling_fan_speed_override_time = datetime.now() - timedelta(seconds=6)
+    fans.print_update({"cooling_fan_speed": "0"})
+    assert fans.get_fan_speed(FansEnum.PART_COOLING) == 0

--- a/tests/test_fan_entity.py
+++ b/tests/test_fan_entity.py
@@ -1,0 +1,45 @@
+"""Optional entity checks: run in a Home Assistant Python environment.
+
+The lightweight pybambu CI suite does not install Home Assistant. These tests
+skip when it is absent and make no service call or MQTT connection.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("homeassistant")
+
+from homeassistant.exceptions import HomeAssistantError
+from custom_components.bambu_lab.fan import BambuLabFan, FANS
+from custom_components.bambu_lab.pybambu.const import FansEnum
+
+
+@pytest.fixture
+def fan():
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.get_model().fans.set_fan_speed.return_value = True
+    return BambuLabFan(coordinator, FANS[2], SimpleNamespace(data={"serial": "TESTSERIAL"}))
+
+
+@pytest.mark.parametrize("percentage", [0, 20, 100])
+def test_turn_on_preserves_percentage(fan, percentage):
+    fan.turn_on(percentage=percentage)
+    fan.coordinator.get_model().fans.set_fan_speed.assert_called_once_with(FansEnum.CHAMBER, percentage)
+
+
+def test_turn_on_without_percentage_defaults_to_full_speed(fan):
+    fan.turn_on()
+    fan.coordinator.get_model().fans.set_fan_speed.assert_called_once_with(FansEnum.CHAMBER, 100)
+
+
+def test_failed_publish_raises_service_error(fan):
+    fan.coordinator.get_model().fans.set_fan_speed.return_value = False
+    with pytest.raises(HomeAssistantError, match="could not be published"):
+        fan.set_percentage(20)
+
+
+def test_turn_off_requests_zero(fan):
+    fan.turn_off()
+    fan.coordinator.get_model().fans.set_fan_speed.assert_called_once_with(FansEnum.CHAMBER, 0)


### PR DESCRIPTION
## Description

Fix three related fan-action correctness bugs, independently of any signed-MQTT support:

- `fan.turn_on(percentage=20)` currently sends 100%. Preserve an explicit percentage, including zero; retain the existing 100% default when omitted.
- Part cooling writes `_cooling_fan_speed` while `get_fan_speed()` reads `_cooling_fan_speed_override` during the override period. Set the actual override field.
- If MQTT publication fails, do not change the local override or issue a successful state-update callback. Return the result and raise `HomeAssistantError` at the entity boundary so automations can detect failure.

The existing five-second optimistic behavior after **successful** publication is unchanged. Broker acceptance is not a claim that the printer executed the command. Signature-required entity gating, connection modes, dependencies, camera handling and licenses are unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

Discovered while validating the separate signed-cloud fan prototype in [#2119](https://github.com/greghesp/ha-bambulab/issues/2119). This PR stands on its own and does not implement or close that feature proposal.

## Documentation

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

- `python3.11 -m pytest tests/pybambu -q`: **102 passed**.
- `python -m pytest tests/test_fan_entity.py -q` in an isolated temporary copy inside HA 2026.9.1's runtime: **6 passed**. No live component import via config entry, MQTT connection, service call or printer action.
- New regression coverage: all four controllable fan enum values, failed-publish state preservation, part-cooling override expiry, explicit/default percentages, off and service errors.
- The optional entity tests skip without Home Assistant; the existing lightweight CI dependency set is preserved.
- `git diff --check` and secret scanning passed.

## Additional Notes

Prepared with AI assistance and reviewed against the current `main` implementation. Tests use synthetic identities and mocked clients; no operator configuration or credentials are included. The signed implementation and its licensing/lifecycle questions are deliberately separate.
