### PR TITLE
Parse the 3MF print weight as a float

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -2259,7 +2259,11 @@ class PrintJob:
                         self.print_bed_type = json.loads(archive.read(f"Metadata/plate_{plate_number}.json")).get('bed_type')
                     elif (metadata.get('key') == 'weight'):
                         LOGGER.debug(f"Weight: {metadata.get('value')}")
-                        self.print_weight = metadata.get('value')
+                        try:
+                            # The XML attribute is a string; print_weight is a float everywhere else.
+                            self.print_weight = float(metadata.get('value'))
+                        except (TypeError, ValueError) as e:
+                            LOGGER.error(f"Failed to parse print weight: {e}")
                     elif (metadata.get('key') == 'prediction'):
                         # Estimated print length in seconds
                         LOGGER.debug(f"Print time: {metadata.get('value')}s")

--- a/tests/pybambu/test_models.py
+++ b/tests/pybambu/test_models.py
@@ -189,6 +189,36 @@ class TestPrintJob(unittest.TestCase):
         self.assertTrue(result)
         self.client._device.cover_image.set_image.assert_called_once_with(b"active-plate-cover")
 
+    def test_slice_info_weight_is_a_float(self):
+        """The 3MF stores the weight as text; print_weight is a float everywhere else."""
+        self.client.ftp_enabled = True
+        self.client._device.supports_feature.return_value = False
+        self.client._device.external_spool[0].active = True
+        self.print_job.plate_idx = 1
+        self.print_job.ams_mapping = []
+        self.print_job.prune_print_history_files = MagicMock()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_path = os.path.join(temp_dir, "current.3mf")
+            with ZipFile(model_path, "w") as archive:
+                archive.writestr(
+                    "Metadata/slice_info.config",
+                    '<config><plate><metadata key="index" value="1" />'
+                    '<metadata key="weight" value="49.59" /></plate></config>',
+                )
+                archive.writestr("Metadata/plate_1.png", b"cover")
+                archive.writestr("Metadata/plate_1.gcode", b"gcode")
+                archive.writestr("Metadata/plate_1.json", '{"bed_type": "textured_plate"}')
+
+            self.print_job._remote_media_sources = MagicMock(return_value=[MagicMock()])
+            self.print_job._attempt_remote_model_download = MagicMock(return_value=model_path)
+            self.print_job._close_remote_media_sources = MagicMock()
+
+            self.assertTrue(self.print_job._async_download_task_data_from_printer_worker())
+
+        self.assertEqual(self.print_job.print_weight, 49.59)
+        self.assertEqual(self.print_job.get_print_weights, {"External Spool": 49.59})
+
     def test_prune_cleans_stale_part_files_even_when_pruning_disabled(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             stale_part = Path(temp_dir) / "stale.3mf.part"


### PR DESCRIPTION
## Description

`PrintJob.print_weight` is declared as a float. It has two sources: the cloud task data assigns a number (`self._task_data.get('weight', ...)`), and the `slice_info.config` parse assigned the raw XML attribute, which is a string (`self.print_weight = metadata.get('value')`).

`get_print_weights` passes that field through as the `External Spool` / `External Spool 2` attribute of the print weight sensor. On a print fed from the external spool the attribute therefore reads `49.59` when the cloud data lands and `"49.59"` after the FTP parse, which is the last update the sensor gets for that print. Seen in the recorder on an A1 with 2.2.25: `External Spool: 49.59` at 08:45:41Z, `External Spool: "49.59"` at 08:45:50Z, nothing later. The AMS tray weights a few lines below were already cast with `float()`, so they are not affected.

The parse now casts the weight with the same `float()` and logs a parse failure instead of raising inside the loop.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

None filed.

## Documentation

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

`test_slice_info_weight_is_a_float` builds a 3MF whose `slice_info.config` carries `<metadata key="weight" value="49.59" />`, runs `_async_download_task_data_from_printer_worker` with the external spool active, and asserts `print_weight == 49.59` and `get_print_weights == {"External Spool": 49.59}`. On `main` it fails with `'49.59' != 49.59`. `pytest tests/pybambu`: 108 passed.

## Additional Notes

One line of behaviour change; the log line and the surrounding parse are untouched.
