### PR TITLE
Fix device registry deprecation warnings on HA 2026.9

### DIFF
--- a/custom_components/bambu_lab/__init__.py
+++ b/custom_components/bambu_lab/__init__.py
@@ -18,7 +18,6 @@ from homeassistant.helpers import entity_platform
 from homeassistant.components.http import HomeAssistantView
 from aiohttp import web
 import aiofiles
-from homeassistant.helpers import device_registry
 
 from .const import (
     DOMAIN,
@@ -69,8 +68,7 @@ class PrintHistoryAPIView(HomeAssistantView):
                     files = await coordinator.get_cached_files(file_type='prints')
                     
                     # Get the device ID from the device registry
-                    dev_reg = device_registry.async_get(self.hass)
-                    hadevice = dev_reg.async_get_device(identifiers={(DOMAIN, printer_info.serial)})
+                    hadevice = coordinator.get_ha_printer_device()
                     device_id = hadevice.id if hadevice else None
                     
                     # Get printer name from device registry or use device_type as fallback
@@ -155,8 +153,7 @@ class VideoAPIView(HomeAssistantView):
                     files = await coordinator.get_cached_files(file_type='timelapse')
                     
                     # Get the device ID from the device registry
-                    dev_reg = device_registry.async_get(self.hass)
-                    hadevice = dev_reg.async_get_device(identifiers={(DOMAIN, printer_info.serial)})
+                    hadevice = coordinator.get_ha_printer_device()
                     device_id = hadevice.id if hadevice else None
                     
                     # Get printer name from device registry or use device_type as fallback

--- a/custom_components/bambu_lab/config_flow.py
+++ b/custom_components/bambu_lab/config_flow.py
@@ -55,6 +55,18 @@ REGION_SELECTOR = SelectSelector(
 )
 
 
+def _async_get_printer_device(hass, serial: str):
+    """Find a registered printer's device entry by serial across all config
+    entries. async_get_device lookups by identifier are deprecated as of HA
+    2026.9 because identifiers are no longer unique across config entries."""
+    dev_reg = device_registry.async_get(hass)
+    for config_entry in hass.config_entries.async_entries(DOMAIN):
+        for device in device_registry.async_entries_for_config_entry(dev_reg, config_entry.entry_id):
+            if (DOMAIN, serial) in device.identifiers:
+                return device
+    return None
+
+
 class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = CONFIG_VERSION
     _bambu_cloud: None
@@ -278,8 +290,7 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         printer_list = []
         for device in device_list:
-            dev_reg = device_registry.async_get(self.hass)
-            hadevice = dev_reg.async_get_device(identifiers={(DOMAIN, device['dev_id'])})
+            hadevice = _async_get_printer_device(self.hass, device['dev_id'])
             if hadevice is None:
                 LOGGER.debug(f"Printer {device['dev_id']} found.")
                 printer_list.append(SelectOptionDict(value = device['dev_id'], label = f"{device['name']}: {device['dev_id']}"))
@@ -391,8 +402,7 @@ class BambuLabFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 if result == 0:
                     if self._show_existing:
                         # Check to see if this device is already registered and delete it if so.
-                        dev_reg = device_registry.async_get(self.hass)
-                        hadevice = dev_reg.async_get_device(identifiers={(DOMAIN, device['dev_id'])})
+                        hadevice = _async_get_printer_device(self.hass, device['dev_id'])
                         if hadevice is not None:
                             for config_entry in hadevice.config_entries:
                                 LOGGER.debug(f"Removing existing config_entry: {config_entry}")

--- a/custom_components/bambu_lab/coordinator.py
+++ b/custom_components/bambu_lab/coordinator.py
@@ -212,7 +212,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
 
     def _is_service_call_for_me(self, data: dict):
         dev_reg = device_registry.async_get(self._hass)
-        hadevice = dev_reg.async_get_device(identifiers={(DOMAIN, self.get_model().info.serial)})
+        hadevice = self.get_ha_printer_device()
 
         device_id = data.get('device_id')
         entity_id = data.get('entity_id')
@@ -460,8 +460,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         ams_parent_device_id = ams_device.via_device_id
 
         # Get my device id
-        dr = device_registry.async_get(self._hass)
-        hadevice = dr.async_get_device(identifiers={(DOMAIN, self.get_model().info.serial)})
+        hadevice = self.get_ha_printer_device()
 
         if ams_parent_device_id != hadevice.id:
             return None
@@ -754,8 +753,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
             LOGGER.error(f"Exception data: {e}")
 
     def _update_printer_error(self):
-        dev_reg = device_registry.async_get(self._hass)
-        hadevice = dev_reg.async_get_device(identifiers={(DOMAIN, self.get_model().info.serial)})
+        hadevice = self.get_ha_printer_device()
         if hadevice is None:
             # Device not in the registry yet (HMS error can arrive during the initial
             # connect, before the device entry exists). Skip this cycle to avoid
@@ -784,8 +782,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
             self._hass.bus.async_fire(f"{DOMAIN}_event", event_data)
 
     def _update_print_error(self):
-        dev_reg = device_registry.async_get(self._hass)
-        hadevice = dev_reg.async_get_device(identifiers={(DOMAIN, self.get_model().info.serial)})
+        hadevice = self.get_ha_printer_device()
         if hadevice is None:
             LOGGER.debug("_update_print_error: device not registered yet, skipping")
             return
@@ -817,7 +814,7 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
             LOGGER.debug(f"'{new_sw_ver}' '{new_hw_ver}'")
             if (new_sw_ver != "unknown"):
                 dev_reg = device_registry.async_get(self._hass)
-                hadevice = dev_reg.async_get_device(identifiers={(DOMAIN, self.get_model().info.serial)})
+                hadevice = self.get_ha_printer_device()
                 dev_reg.async_update_device(hadevice.id, sw_version=new_sw_ver, hw_version=new_hw_ver, serial_number=self.config_entry.data["serial"])
                 self._updatedDevice = True
 
@@ -872,23 +869,22 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         config_entry_id=self.config_entry.entry_id
         dev_reg = device_registry.async_get(self._hass)
         ams_devices_to_remove = []
-        for device in dev_reg.devices.values():
-            if config_entry_id in device.config_entries:
-                # This device is associated with this printer.
-                is_known_ams = device.model in ('AMS', 'AMS Lite', 'AMS 2 Pro', 'AMS HT')
-                is_placeholder_ams = (
-                    device.model == 'Unknown'
-                    and (DOMAIN, "") in device.identifiers
-                    and (device.name or "").startswith(f"{self.config_entry.data['device_type']}_{self.config_entry.data['serial']}_AMS_")
-                )
-                if is_known_ams or is_placeholder_ams:
-                    # push_status can create an AMS placeholder before version metadata is
-                    # available. Older versions registered that placeholder with an empty
-                    # identifier; always discard it so the real serial can own the device.
-                    ams_serial = list(device.identifiers)[0][1]
-                    if is_placeholder_ams or ams_serial not in existing_ams_devices:
-                        LOGGER.debug(f"Found stale attached AMS with serial {ams_serial}")
-                        ams_devices_to_remove.append(device.id)
+        for device in device_registry.async_entries_for_config_entry(dev_reg, config_entry_id):
+            # This device is associated with this printer.
+            is_known_ams = device.model in ('AMS', 'AMS Lite', 'AMS 2 Pro', 'AMS HT')
+            is_placeholder_ams = (
+                device.model == 'Unknown'
+                and (DOMAIN, "") in device.identifiers
+                and (device.name or "").startswith(f"{self.config_entry.data['device_type']}_{self.config_entry.data['serial']}_AMS_")
+            )
+            if is_known_ams or is_placeholder_ams:
+                # push_status can create an AMS placeholder before version metadata is
+                # available. Older versions registered that placeholder with an empty
+                # identifier; always discard it so the real serial can own the device.
+                ams_serial = list(device.identifiers)[0][1]
+                if is_placeholder_ams or ams_serial not in existing_ams_devices:
+                    LOGGER.debug(f"Found stale attached AMS with serial {ams_serial}")
+                    ams_devices_to_remove.append(device.id)
 
         for device in ams_devices_to_remove:
             LOGGER.debug("Removing stale AMS.")
@@ -896,18 +892,16 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
 
         # Clean up orphaned Hotend Rack device if printer no longer has one.
         if not self.get_model().supports_feature(Features.HOTEND_RACK):
-            for device in dev_reg.devices.values():
-                if config_entry_id in device.config_entries:
-                    if device.model == 'Hotend Rack':
-                        LOGGER.debug("Removing stale Hotend Rack device.")
-                        dev_reg.async_remove_device(device.id)
+            for device in device_registry.async_entries_for_config_entry(dev_reg, config_entry_id):
+                if device.model == 'Hotend Rack':
+                    LOGGER.debug("Removing stale Hotend Rack device.")
+                    dev_reg.async_remove_device(device.id)
 
         # And now we can reinitialize the sensors, which will trigger device creation as necessary.
         self.hass.async_create_task(self._reinitialize_sensors())
 
     def PublishDeviceTriggerEvent(self, event: str):
-        dev_reg = device_registry.async_get(self._hass)
-        hadevice = dev_reg.async_get_device(identifiers={(DOMAIN, self.get_model().info.serial)})
+        hadevice = self.get_ha_printer_device()
         if hadevice is None:
             # Events can arrive during initial connect, before the device entry exists.
             LOGGER.debug(f"PublishDeviceTriggerEvent: device not registered yet, skipping {event}")
@@ -927,6 +921,31 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
 
     def get_model(self):
         return self.client.get_device()
+
+    def get_ha_printer_device(self):
+        """Find the printer's device registry entry.
+
+        async_get_device lookups by identifier are deprecated as of HA 2026.9
+        because identifiers are no longer unique across config entries, so scan
+        just this config entry's devices instead."""
+        dev_reg = device_registry.async_get(self._hass)
+        printer_identifier = (DOMAIN, self.get_model().info.serial)
+        for device in device_registry.async_entries_for_config_entry(dev_reg, self.config_entry.entry_id):
+            if printer_identifier in device.identifiers:
+                return device
+        return None
+
+    def _set_via_device(self, device_info: DeviceInfo):
+        """Link a device to its parent printer.
+
+        HA 2026.8 deprecated the via_device identifier tuple in favor of
+        via_device_id; older versions don't accept via_device_id at all."""
+        if "via_device_id" in DeviceInfo.__optional_keys__:
+            printer_device = self.get_ha_printer_device()
+            if printer_device is not None:
+                device_info["via_device_id"] = printer_device.id
+        else:
+            device_info["via_device"] = (DOMAIN, self.config_entry.data["serial"])
 
     def get_printer_device(self):
         printer_serial = self.config_entry.data["serial"]
@@ -952,45 +971,48 @@ class BambuDataUpdateCoordinator(DataUpdateCoordinator):
         ams_serial = self.get_model().ams.data[index].serial
         model = self.get_model().ams.data[index].model
 
-        return DeviceInfo(
+        device_info = DeviceInfo(
             identifiers={(DOMAIN, ams_serial)},
-            via_device=(DOMAIN, printer_serial),
             name=device_name,
             model=model,
             manufacturer=BRAND,
             hw_version=self.get_model().ams.data[index].hw_version,
             sw_version=self.get_model().ams.data[index].sw_version
         )
+        self._set_via_device(device_info)
+        return device_info
 
     def get_virtual_tray_device(self, suffix: str):
         printer_serial = self.config_entry.data["serial"]
         device_type = self.config_entry.data["device_type"]
         device_name=f"{device_type}_{printer_serial}_ExternalSpool{suffix}"
 
-        return DeviceInfo(
+        device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{printer_serial}_ExternalSpool{suffix}")},
-            via_device=(DOMAIN, printer_serial),
             name=device_name,
             model="External Spool",
             manufacturer=BRAND,
             hw_version="",
             sw_version=""
         )
+        self._set_via_device(device_info)
+        return device_info
 
     def get_hotend_rack_device(self):
         printer_serial = self.config_entry.data["serial"]
         device_type = self.config_entry.data["device_type"]
         device_name = f"{device_type}_{printer_serial}_HotendRack"
 
-        return DeviceInfo(
+        device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{printer_serial}_HotendRack")},
-            via_device=(DOMAIN, printer_serial),
             name=device_name,
             model="Hotend Rack",
             manufacturer=BRAND,
             hw_version="",
             sw_version=""
         )
+        self._set_via_device(device_info)
+        return device_info
 
     def get_option_enabled(self, option: Options):
         options = dict(self.config_entry.options)


### PR DESCRIPTION
## Description

HA 2026.9 started warning about three device registry patterns in this integration (the log in #2104 lists all of them, #2116 covers the last two):

- `via_device=(DOMAIN, printer_serial)` in the AMS, external spool and hotend rack `DeviceInfo` builders in `coordinator.py`. HA 2026.8 added `via_device_id` to `DeviceInfo` and deprecated the identifier tuple, removal is 2027.8.
- `dev_reg.async_get_device(identifiers=...)` for the printer's own device, six places in `coordinator.py` plus the two API views in `__init__.py` and two spots in `config_flow.py`. Removal 2027.8.
- `dev_reg.devices.values()` scans in `_printer_ready`. Removal 2027.9.

What changed:

- New `BambuDataUpdateCoordinator.get_ha_printer_device()` finds the printer's entry by walking `async_entries_for_config_entry` for this config entry. All the coordinator and API view lookups go through it. `config_flow.py` gets a small module level equivalent that walks every bambu_lab config entry, since the flow has no coordinator yet.
- The three `DeviceInfo` builders call `_set_via_device()`, which sets `via_device_id` to the printer's registry id when the installed `DeviceInfo` has that key, and falls back to the old `via_device` tuple otherwise. hacs.json still allows HA 2025.1.1, so the fallback keeps those installs working. If the printer isn't registered yet the link is skipped, which is what HA did with an unresolvable `via_device` before, and `_printer_ready` re-adds the entities afterwards anyway.
- `_printer_ready` iterates `async_entries_for_config_entry(dev_reg, config_entry_id)` instead of the whole registry, so the manual `config_entry_id in device.config_entries` check goes away. The loop body is unchanged, most of that hunk is a one level dedent.

I went with `async_entries_for_config_entry` rather than the `async_get_device_by_identifier` the warning suggests because that method only exists from HA 2026.8.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

Fixes #2104
Fixes #2116

## Documentation

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

## Testing

- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

`pytest tests/pybambu`: 108 passed. I also drove the changed coordinator methods against a real device registry (pytest-homeassistant-custom-component) on HA 2026.9.1 and on HA 2026.2.3: no `homeassistant.helpers.frame` warnings on either, the AMS device ends up with `via_device_id` pointing at the printer on 2026.9.1 and with the old `via_device` link on 2026.2.3, and the stale AMS / hotend rack cleanup in `_printer_ready` still only touches this entry's devices. Not tested on a live printer.

## Additional Notes

`git diff -w` makes the `_printer_ready` hunk easier to read. If you'd rather bump the minimum HA to 2026.8 and drop the `via_device` fallback, I can trim `_set_via_device` down to the `via_device_id` line.