### PR TITLE
Fix/translation placeholder parity

### DIFF
--- a/.github/workflows/translation-parity.yml
+++ b/.github/workflows/translation-parity.yml
@@ -1,7 +1,7 @@
 name: Translation parity
 
-# Missing/stale keys remain informational. Placeholder errors fail the job,
-# including missing translations for English strings containing placeholders.
+# Missing/stale keys and placeholder errors remain informational warnings.
+# Translation findings do not block merging while locales catch up.
 
 on:
   push:
@@ -35,7 +35,7 @@ jobs:
 
       # Comments are only meaningful in a PR context (push events - e.g. a
       # merge to main - have no PR to comment on).
-      - if: always() && github.event_name == 'pull_request' && steps.check.outputs.drift != ''
+      - if: github.event_name == 'pull_request'
         uses: actions/github-script@v9
         with:
           script: |

--- a/.github/workflows/translation-parity.yml
+++ b/.github/workflows/translation-parity.yml
@@ -1,17 +1,19 @@
 name: Translation parity
 
-# Informational only, by design - reports translation locales that are out
-# of sync with en.json (missing keys, or stale keys no longer in English),
-# but never fails the job. A PR that only changes English strings shouldn't
-# be blocked on every locale catching up before it can merge.
+# Missing/stale keys remain informational. Placeholder errors fail the job,
+# including missing translations for English strings containing placeholders.
 
 on:
   push:
     paths:
       - "custom_components/bambu_lab/translations/**"
+      - "scripts/check_translation_parity.py"
+      - ".github/workflows/translation-parity.yml"
   pull_request:
     paths:
       - "custom_components/bambu_lab/translations/**"
+      - "scripts/check_translation_parity.py"
+      - ".github/workflows/translation-parity.yml"
 
 permissions:
   # PR comments are served by the Issues API under the hood, so this - not
@@ -33,15 +35,14 @@ jobs:
 
       # Comments are only meaningful in a PR context (push events - e.g. a
       # merge to main - have no PR to comment on).
-      - if: github.event_name == 'pull_request'
+      - if: always() && github.event_name == 'pull_request' && steps.check.outputs.drift != ''
         uses: actions/github-script@v9
         with:
           script: |
             // GitHub forces a read-only GITHUB_TOKEN for pull_request runs
             // triggered from a fork, regardless of the `permissions:` block
             // above - so createComment/updateComment always 403s here. Skip
-            // rather than let that throw and fail this "informational only,
-            // never fails the job" check for every external contributor.
+            // rather than let reporting fail for every external contributor.
             const isFork = context.payload.pull_request.head.repo.full_name !==
                             context.payload.pull_request.base.repo.full_name;
             if (isFork) {

--- a/custom_components/bambu_lab/translations/ca.json
+++ b/custom_components/bambu_lab/translations/ca.json
@@ -938,7 +938,7 @@
     },
     "access_code_rejected": {
       "title": "Codi d'accés rebutjat",
-      "description": "La impressora ha rebutjat el codi d'accés configurat per a {dispositiu}. Això normalment significa que el codi s'ha regenerat, per exemple mitjançant un restabliment de fàbrica. Llegiu el nou codi d'accés des de la pantalla de configuració de xarxa de la impressora i torneu a configurar la integració amb ell."
+      "description": "La impressora ha rebutjat el codi d'accés configurat per a {device}. Això normalment significa que el codi s'ha regenerat, per exemple mitjançant un restabliment de fàbrica. Llegiu el nou codi d'accés des de la pantalla de configuració de xarxa de la impressora i torneu a configurar la integració amb ell."
     }
   }
 }

--- a/custom_components/bambu_lab/translations/cs.json
+++ b/custom_components/bambu_lab/translations/cs.json
@@ -938,7 +938,7 @@
     },
     "access_code_rejected": {
       "title": "Přístupový kód zamítnut",
-      "description": "Tiskárna odmítla nakonfigurovaný přístupový kód pro {zařízení}. To obvykle znamená, že kód byl znovu vygenerován, například obnovením továrního nastavení. Přečtěte si nový přístupový kód z obrazovky nastavení sítě tiskárny a překonfigurujte s ním integraci."
+      "description": "Tiskárna odmítla nakonfigurovaný přístupový kód pro {device}. To obvykle znamená, že kód byl znovu vygenerován, například obnovením továrního nastavení. Přečtěte si nový přístupový kód z obrazovky nastavení sítě tiskárny a překonfigurujte s ním integraci."
     }
   }
 }

--- a/custom_components/bambu_lab/translations/de.json
+++ b/custom_components/bambu_lab/translations/de.json
@@ -938,7 +938,7 @@
     },
     "access_code_rejected": {
       "title": "Zugangscode abgelehnt",
-      "description": "Der Drucker hat den konfigurierten Zugriffscode für {Gerät} abgelehnt. Dies bedeutet normalerweise, dass der Code neu generiert wurde, beispielsweise durch einen Werksreset. Lesen Sie den neuen Zugangscode auf dem Bildschirm mit den Netzwerkeinstellungen des Druckers ab und konfigurieren Sie die Integration damit neu."
+      "description": "Der Drucker hat den konfigurierten Zugriffscode für {device} abgelehnt. Dies bedeutet normalerweise, dass der Code neu generiert wurde, beispielsweise durch einen Werksreset. Lesen Sie den neuen Zugangscode auf dem Bildschirm mit den Netzwerkeinstellungen des Druckers ab und konfigurieren Sie die Integration damit neu."
     }
   }
 }

--- a/custom_components/bambu_lab/translations/it.json
+++ b/custom_components/bambu_lab/translations/it.json
@@ -938,7 +938,7 @@
     },
     "access_code_rejected": {
       "title": "Codice di accesso rifiutato",
-      "description": "La stampante ha rifiutato il codice di accesso configurato per {dispositivo}. Questo di solito significa che il codice è stato rigenerato, ad esempio mediante un ripristino delle impostazioni di fabbrica. Leggere il nuovo codice di accesso dalla schermata delle impostazioni di rete della stampante e riconfigurare l'integrazione con esso."
+      "description": "La stampante ha rifiutato il codice di accesso configurato per {device}. Questo di solito significa che il codice è stato rigenerato, ad esempio mediante un ripristino delle impostazioni di fabbrica. Leggere il nuovo codice di accesso dalla schermata delle impostazioni di rete della stampante e riconfigurare l'integrazione con esso."
     }
   }
 }

--- a/custom_components/bambu_lab/translations/pl.json
+++ b/custom_components/bambu_lab/translations/pl.json
@@ -938,7 +938,7 @@
     },
     "access_code_rejected": {
       "title": "Kod dostępu odrzucony",
-      "description": "Drukarka odrzuciła skonfigurowany kod dostępu dla {urządzenia}. Zwykle oznacza to, że kod został zregenerowany, na przykład poprzez przywrócenie ustawień fabrycznych. Przeczytaj nowy kod dostępu z ekranu ustawień sieciowych drukarki i ponownie skonfiguruj z nim integrację."
+      "description": "Drukarka odrzuciła skonfigurowany kod dostępu dla {device}. Zwykle oznacza to, że kod został zregenerowany, na przykład poprzez przywrócenie ustawień fabrycznych. Przeczytaj nowy kod dostępu z ekranu ustawień sieciowych drukarki i ponownie skonfiguruj z nim integrację."
     }
   }
 }

--- a/scripts/check_translation_parity.py
+++ b/scripts/check_translation_parity.py
@@ -1,8 +1,8 @@
 """Check translation keys and placeholders against en.json without editing them.
 
-Ordinary missing/stale keys remain informational. Missing translations of
-placeholder-bearing strings, mismatched placeholder names and invalid format
-strings fail the check. Reports are deterministic and overwritten on each run.
+Translation findings, including missing/stale keys and placeholder errors, are
+informational warnings and do not block merging. Reports are deterministic and
+overwritten on each run. Source translations are never modified.
 """
 import glob
 import json
@@ -78,7 +78,7 @@ def build_markdown(summary_rows, any_drift):
     lines = [
         "## Translation parity",
         "",
-        "Missing/stale keys are informational; placeholder errors fail the check.",
+        "Missing/stale keys and placeholder errors are informational and do not block merging.",
         "",
         "| Locale | Missing keys | Stale keys | Placeholder errors |",
         "| --- | --- | --- | --- |",
@@ -105,7 +105,6 @@ def main():
 
     summary_rows = []
     any_drift = False
-    has_placeholder_errors = False
 
     for filepath in sorted(glob.glob(os.path.join(TRANSLATIONS_DIR, "*.json"))):
         filename = os.path.basename(filepath)
@@ -119,7 +118,6 @@ def main():
         missing = sorted(en_keys - other_keys)  # in en.json, not in this locale
         extra = sorted(other_keys - en_keys)    # in this locale, not in en.json (stale)
         errors = placeholder_errors(english, translated)
-        has_placeholder_errors = has_placeholder_errors or bool(errors)
 
         if not missing and not extra and not errors:
             continue
@@ -136,7 +134,7 @@ def main():
                   f"{filename} has {len(extra)} stale key(s) no longer in en.json: "
                   f"{', '.join(extra[:5])}{', ...' if len(extra) > 5 else ''}")
         for key, message in errors.items():
-            print(f"::error file={os.path.relpath(filepath)}::"
+            print(f"::warning file={os.path.relpath(filepath)}::"
                   f"{filename}:{key}: {message}")
 
     markdown = build_markdown(summary_rows, any_drift)
@@ -160,7 +158,8 @@ def main():
     if not any_drift:
         print("All locales match en.json.")
 
-    return 1 if has_placeholder_errors else 0
+    # Translation findings are informational, not a merge gate.
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/check_translation_parity.py
+++ b/scripts/check_translation_parity.py
@@ -1,16 +1,14 @@
-"""Report translation keys that are missing or stale relative to en.json.
+"""Check translation keys and placeholders against en.json without editing them.
 
-Non-blocking by design: prints GitHub Actions ::warning:: annotations, writes
-a step-summary table, and writes a PR-comment body to
-COMMENT_OUTPUT_PATH - but always exits 0. The intent is visibility for
-reviewers/maintainers (and the PR submitter), not a merge gate - a PR that
-only touches English strings shouldn't be blocked on translations catching
-up.
+Ordinary missing/stale keys remain informational. Missing translations of
+placeholder-bearing strings, mismatched placeholder names and invalid format
+strings fail the check. Reports are deterministic and overwritten on each run.
 """
 import glob
 import json
 import os
 import sys
+from string import Formatter
 
 TRANSLATIONS_DIR = os.path.normpath(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "..",
@@ -35,6 +33,44 @@ def flatten(d, prefix=""):
     return out
 
 
+def placeholder_names(text):
+    """Respect escaped braces and placeholders in nested format specs."""
+    names = set()
+    for _, field, format_spec, _ in Formatter().parse(text):
+        if field is not None:
+            names.add(field)
+            names.update(placeholder_names(format_spec))
+    return names
+
+
+def placeholder_errors(english, translated):
+    """Compare flattened strings; include missing placeholder-bearing keys."""
+    errors = {}
+    for key, value in sorted(english.items()):
+        if not isinstance(value, str):
+            continue
+        try:
+            expected = placeholder_names(value)
+        except ValueError as error:
+            errors[key] = f"invalid English format string: {error}"
+            continue
+        if key not in translated:
+            if expected:
+                errors[key] = f"missing translation with placeholders {sorted(expected)}"
+            continue
+        if not isinstance(translated[key], str):
+            errors[key] = "translation must be a string"
+            continue
+        try:
+            actual = placeholder_names(translated[key])
+        except ValueError as error:
+            errors[key] = f"invalid translated format string: {error}"
+            continue
+        if actual != expected:
+            errors[key] = f"expected {sorted(expected)}, got {sorted(actual)}"
+    return errors
+
+
 def build_markdown(summary_rows, any_drift):
     if not any_drift:
         return "## Translation parity\n\nAll locales match `en.json`. :white_check_mark:\n"
@@ -42,17 +78,21 @@ def build_markdown(summary_rows, any_drift):
     lines = [
         "## Translation parity",
         "",
-        "This is informational only and does not block merging.",
+        "Missing/stale keys are informational; placeholder errors fail the check.",
         "",
-        "| Locale | Missing keys | Stale keys |",
-        "| --- | --- | --- |",
+        "| Locale | Missing keys | Stale keys | Placeholder errors |",
+        "| --- | --- | --- | --- |",
     ]
-    for filename, missing, extra in summary_rows:
-        lines.append(f"| `{filename}` | {len(missing)} | {len(extra)} |")
+    for filename, missing, extra, errors in summary_rows:
+        lines.append(f"| `{filename}` | {len(missing)} | {len(extra)} | {len(errors)} |")
+    for filename, _, _, errors in summary_rows:
+        for key, message in errors.items():
+            lines.append(f"\n- `{filename}:{key}`: {message}")
     lines += [
         "",
         "Run `python3 scripts/auto_translate.py` to fill in missing keys "
-        "(requires network access to Google Translate).",
+        "(requires network access to Google Translate). Preserve placeholder names "
+        "exactly as in English and rerun this check afterwards.",
     ]
     return "\n".join(lines) + "\n"
 
@@ -60,10 +100,12 @@ def build_markdown(summary_rows, any_drift):
 def main():
     en_path = os.path.join(TRANSLATIONS_DIR, "en.json")
     with open(en_path, encoding="utf-8") as f:
-        en_keys = set(flatten(json.load(f)).keys())
+        english = flatten(json.load(f))
+    en_keys = set(english)
 
     summary_rows = []
     any_drift = False
+    has_placeholder_errors = False
 
     for filepath in sorted(glob.glob(os.path.join(TRANSLATIONS_DIR, "*.json"))):
         filename = os.path.basename(filepath)
@@ -71,16 +113,19 @@ def main():
             continue
 
         with open(filepath, encoding="utf-8") as f:
-            other_keys = set(flatten(json.load(f)).keys())
+            translated = flatten(json.load(f))
+        other_keys = set(translated)
 
         missing = sorted(en_keys - other_keys)  # in en.json, not in this locale
         extra = sorted(other_keys - en_keys)    # in this locale, not in en.json (stale)
+        errors = placeholder_errors(english, translated)
+        has_placeholder_errors = has_placeholder_errors or bool(errors)
 
-        if not missing and not extra:
+        if not missing and not extra and not errors:
             continue
 
         any_drift = True
-        summary_rows.append((filename, missing, extra))
+        summary_rows.append((filename, missing, extra, errors))
 
         if missing:
             print(f"::warning file={os.path.relpath(filepath)}::"
@@ -90,12 +135,15 @@ def main():
             print(f"::warning file={os.path.relpath(filepath)}::"
                   f"{filename} has {len(extra)} stale key(s) no longer in en.json: "
                   f"{', '.join(extra[:5])}{', ...' if len(extra) > 5 else ''}")
+        for key, message in errors.items():
+            print(f"::error file={os.path.relpath(filepath)}::"
+                  f"{filename}:{key}: {message}")
 
     markdown = build_markdown(summary_rows, any_drift)
 
     step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
     if step_summary:
-        with open(step_summary, "a", encoding="utf-8") as f:
+        with open(step_summary, "w", encoding="utf-8") as f:
             f.write(markdown)
 
     # Written every run (whether drift was found or not) so the workflow's
@@ -112,8 +160,7 @@ def main():
     if not any_drift:
         print("All locales match en.json.")
 
-    # Always succeed - this check is informational, not a merge gate.
-    return 0
+    return 1 if has_placeholder_errors else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Fix translated placeholder names in the access-code repair description and
extend the existing translation-parity check to detect this class of error
across all languages.

Home Assistant reports a translation validation warning for
`component.bambu_lab.issues.access_code_rejected.description` in Czech because
the localized string contains `{zařízení}`, while English and the integration
provide `{device}`. Checking the other locales reveals the same problem in
Catalan (`{dispositiu}`), German (`{Gerät}`), Italian (`{dispositivo}`) and Polish
(`{urządzenia}`). These are substitution keys, not words to translate.

This PR:

- Restores `{device}` in those five descriptions, preserving the translated
  prose. The JSON files also gain a final newline.
- Extends `scripts/check_translation_parity.py`; no separate validator or test
  file is introduced. It automatically compares all non-English translation
  JSON files against `en.json`, including nested keys.
- Checks that every English placeholder-bearing key exists in every locale
  with exactly the same set of placeholder names. Missing, renamed and extra
  placeholders are reported, including placeholders added where English has none.
  Ordering and repetition do not matter. Escaped braces and nested format
  specifications are handled; malformed format strings are reported.
- Reports the locale, full key and mismatch in Actions annotations and Markdown.
  Placeholder errors produce warnings and return exit code 0, just like ordinary
  missing/stale keys. The existing non-blocking policy is preserved: an English
  string change does not require all translations to catch up before merging.
- Runs the existing parity workflow for checker/workflow changes as well as
  translation changes. Existing PR comment handling and the restriction on
  comments from fork PRs are preserved.

The checker does not rewrite or auto-translate source files. Repeated runs over
the same input produce identical results and replace the generated Markdown
reports. `GITHUB_OUTPUT` retains GitHub's append-based output protocol.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

### Link to Issue

No separate issue has been filed for this translation warning.

## Documentation

- [ ] I have updated the relevant documentation to reflect these changes
- [x] No documentation updates were necessary for this change

No user-facing setup or printer behavior changes. The checker docstring,
workflow comments and generated report explain the non-blocking validation.

## Testing

- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

**Scope of the checked test-result item:** all tests selected by the existing
CI test workflow passed locally: **108 pybambu tests**. The updated parity check
also reports no findings across all 16 non-English locales. This does not claim
that every test file in the repository passes or that GitHub-hosted CI has run.

**Updated validation:** the existing automated translation-parity check and its
CI workflow now cover placeholder mismatches across all locales. No separate
pytest test file was added. Regression checks described below verified detection
of the original defects and the non-blocking warning behavior.

**Existing tests outside CI:** the three tests in `tests/test_auto_translate.py`
are not selected by the current CI workflow. Running them separately exposes
pre-existing defects in the test harness and assertions, unrelated to this PR.
We did not modify or fix these tests; details are recorded below.

Validated locally on Python 3.12:

```sh
python -m pytest tests/pybambu -q
python -m pytest tests/test_auto_translate.py -q
python scripts/check_translation_parity.py
git diff --check main...HEAD
```

- All **108 pybambu tests** selected by the existing test workflow pass.
- All **16 non-English locales** pass the updated parity check.
- An in-memory regression check detects each of the five original defects
  from the base commit. Fourteen additional cases cover renamed, missing and
  extra placeholders, missing required versus ordinary keys, reordered/repeated
  placeholders, escaped braces, nested format specifications, malformed strings
  and non-string translations. Nested-key flattening is also checked.
- Synthetic mismatches confirm that `main()` reports warnings, records drift
  and returns 0. Two repeated runs return 0 with identical stdout and generated
  reports; SHA-256 checks confirm
  all 17 translation files remain unchanged by validation.

Running the unchanged `tests/test_auto_translate.py` produces three pre-existing
`NameError` failures in its AST-based loader (`HTTP_SESSION` twice, `os` once).
The loader also omits `__file__`, and the Git-path test has a stale argument
assertion revealed after supplying the missing globals. These are defects in
the tests; fixing them is outside this PR's scope. The test file and
`scripts/auto_translate.py` are byte-unchanged from the base commit.
GitHub CI uses Python 3.13; that run, HACS validation and hassfest remain pending.

## Additional Notes

- Based on `main` at `129e8aa06b0ba7bb72fb40d96ad09b8f102dc834`.
- Only five translations, the existing checker and its workflow change.
- No dependency/version bump, authentication change, device-registry change,
  printer-control change or frontend build is involved.
- No credentials, device identifiers or household diagnostics are attached.
